### PR TITLE
docs: add onboarding documentation and README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,52 @@
 # IUGA Website App
 
-## Scripts
-To run the full stack application in DEV mode, enter `npm run dev`.
+React frontend + Express backend for the **Informatics Undergraduate Association (IUGA)** at the University of Washington.
 
+## Quickstart
+
+```bash
+# Install everything and run in dev mode
+npm run dev
+```
+
+The app is served at **http://localhost:7777** — the frontend uses **mock data**, so no backend or database is needed for frontend development.
+
+See [Quickstart Guide](docs/QUICKSTART.md) for full setup instructions.
+
+## Documentation
+
+| Doc | What it covers |
+|---|---|
+| [Quickstart](docs/QUICKSTART.md) | Prerequisites, installation, env config, run, verify |
+| [Architecture](docs/ARCHITECTURE.md) | Project structure, stack decisions, data flow |
+| [Development](docs/DEVELOPMENT.md) | Setup, scripts, workflow, conventions |
+| [Frontend](docs/FRONTEND.md) | Frontend structure, pages, components, styling, auth |
+| [Backend](docs/BACKEND.md) | Backend structure, API routes, controllers, models, database |
+| [Deployment](docs/DEPLOYMENT.md) | Environments, CI/CD, Docker |
+| [Maintainers](docs/MAINTAINERS.md) | Monitoring, maintenance, incident response |
+| [Troubleshooting](docs/TROUBLESHOOTING.md) | Diagnosis guide for pipeline and runtime failures |
+
+## Project Structure
+
+```
+├── frontend/          # React SPA (Create React App, MSAL auth, SCSS)
+├── backend/           # Express.js API (MongoDB, express-session)
+│   ├── env/           # Environment files (gitignored except .env.example)
+│   └── schemas/       # Git submodule — shared Mongoose schemas
+├── docs/              # Project documentation (start here)
+├── Dockerfile         # Multi-stage production build
+├── dev.jenkinsfile    # CI/CD pipeline — development
+├── staging.jenkinsfile
+└── prod.jenkinsfile
+```
+
+## Scripts
+
+| Script | Action |
+|---|---|
+| `npm run dev` | Build frontend → start backend (dev env) |
+| `npm run debug` | Build frontend → start backend (debug env) |
+| `npm run frontend` | Start CRA dev server only (`:3000`, hot reload) |
+| `npm run backend` | Install + start backend (dev env) |
+| `npm run backend-dev` | Same as above |
+| `npm run backend-debug` | Install + start backend (debug env) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,157 @@
+# IUGA Website — Architecture Overview
+
+## Repository Boundary
+
+This repository (`iuga-web-app`) contains two deployable units plus shared infrastructure:
+
+```
+iuga-web-app/
+├── frontend/          → React SPA (Create React App)
+├── backend/           → Express.js API server
+├── backend/schemas/   → Git submodule: UW-IUGA/iuga-web-schemas (Mongoose schemas)
+├── Dockerfile         → Multi-stage build for production deployment
+├── dev.jenkinsfile    → Jenkins pipeline (dev environment)
+├── staging.jenkinsfile
+├── prod.jenkinsfile
+└── package.json       → Root convenience scripts (dev, debug, frontend, backend)
+```
+
+**Not in this repository:**
+
+- Production nginx reverse proxy configuration
+- Docker Compose host setup (MongoDB, networking, env secrets)
+- CI/CD pipeline definitions (managed in Jenkins)
+- Domain DNS / TLS certificates
+
+---
+
+## System Architecture
+
+```
+Browser
+   │
+   ├──[SPA route]──→ React (frontend/build/)
+   │                    │
+   │                    ├── page components (pages/)
+   │                    ├── shared UI (components/)
+   │                    ├── auth context (context/AuthContext.jsx)
+   │                    └── API calls via fetch()
+   │                         │
+   ├──[API call]───→ Express (backend/)
+   │                    │
+   │                    ├── app.js          (middleware stack + route mount)
+   │                    ├── models.js       (Mongoose model registration)
+   │                    ├── routes/api/v1/  (controller modules)
+   │                    └── schemas/        (Mongoose schema definitions, submodule)
+   │                         │
+   │                    MongoDB (Atlas dev / local prod)
+   │
+   └──[static asset]──→ Express serves frontend/build/
+```
+
+### Frontend Responsibilities
+
+- Serve the single-page application (SPA) shell (`index.html`)
+- Client-side routing with React Router v6
+- Render pages: Home, Events, Resources, About, Elections, Election FAQ
+- Manage authentication state via Azure MSAL (Microsoft Authentication Library)
+- In **production**: fetch data from `REACT_APP_API_URL` (set via `.env.production`)
+- In **development**: use mock data from `src/assets/mock-data/` — no backend needed
+
+### Backend Responsibilities
+
+- Express.js HTTP server (default port **7777**)
+- Serve the built SPA as static files (`GET /`, `/events`, `/resources`, etc.)
+- Mount REST API at `/api/v1`
+- Manage server-side sessions with `express-session`
+- Connect to MongoDB (Mongoose ODM)
+- Models registered at startup: `Events`, `Participants`, `Users`
+- Handle Microsoft Graph token exchange for authentication
+
+### Database (MongoDB)
+
+Connection depends on `DEPLOY_ENV`:
+
+| Environment | Connection String | Host |
+|---|---|---|
+| `production` | `mongodb://user:pass@mongo:27017/iuga` | Docker container |
+| `staging` | same as production | Docker container |
+| `development` | `mongodb+srv://user:pass@cluster0.mongodb.net/` | MongoDB Atlas |
+
+The **schemas** live in a separate GitHub repository (`UW-IUGA/iuga-web-schemas`) mounted as a submodule at `backend/schemas/`. The main repo imports `eventsSchema`, `participantsSchema`, and `usersSchema` from `./schemas/schemas.js`.
+
+---
+
+## Request Flow (Production)
+
+```
+1.  Browser loads https://iuga.info
+2.  nginx (external) → Express :7777
+3.  Express serves frontend/build/index.html
+4.  React boots, React Router reads URL path
+5.  Browser renders matched page component
+6.  If page needs live data (events):
+    fetch(REACT_APP_API_URL/api/v1/events/upcoming)
+7.  Express API controller queries MongoDB
+8.  Response flows back: MongoDB → Mongoose → Controller → Browser JSON → React state → DOM
+```
+
+**SPA routes** (handled by Express sending the same `index.html`):
+`/`, `/events`, `/resources`, `/about`, `/electionfaq`, `/contact`
+
+**API routes** (JSON responses):
+All mounted under `/api/v1` — see [BACKEND.md](./BACKEND.md).
+
+---
+
+## Authentication Flow
+
+```
+Frontend                         Backend                       Azure AD / Graph
+   │                                │                              │
+   ├─ loginRedirect() ──────────────┼────────────────────────────►│
+   │◄──── redirect back ────────────┼─────────────────────────────│
+   │                                │                              │
+   ├─ acquireTokenSilent() ─────────┼────────────────────────────►│
+   │◄──── access token ─────────────┼─────────────────────────────│
+   │                                │                              │
+   ├─ POST /api/v1/user/login ─────►│                              │
+   │   Authorization: Bearer <tok>  │                              │
+   │                                ├─ GET /v1.0/me (Graph) ─────►│
+   │                                │◄── user profile ────────────│
+   │                                │                              │
+   │                                ├─ Create/Fetch MongoDB user   │
+   │                                ├─ Create server session       │
+   │◄── { user object } ───────────│                              │
+   │                                │                              │
+   ├─ Session cookie set            │                              │
+   └─ AuthContext updated           │                              │
+```
+
+Authentication uses **Microsoft Azure AD** (UW enterprise directory). The frontend never sees the user's password — only MSAL access tokens. The backend validates tokens via Microsoft Graph API, then creates its own server-side session.
+
+---
+
+## Deployment Boundary
+
+**What the Dockerfile does** (multi-stage build):
+
+1. **Build stage**: Install frontend dependencies, compile React app, substitute API URL based on `DEPLOY_ENV`
+2. **Production stage**: Install backend production dependencies, copy built frontend, run Express server
+
+The Docker image runs the backend Node.js process which serves both the API and the static SPA. In production, a reverse proxy (nginx, external to this repo) forwards requests to the container.
+
+**Jenkins pipelines** (`dev.jenkinsfile`, `staging.jenkinsfile`, `prod.jenkinsfile`) handle the CI/CD process — they are not documented here because they reference external infrastructure.
+
+---
+## Navigation
+
+| Document | Content |
+|---|---|
+| [QUICKSTART.md](./QUICKSTART.md) | Prerequisites, installation, environment setup, running, verification |
+| [DEVELOPMENT.md](./DEVELOPMENT.md) | Setup, scripts, workflow, conventions |
+| [FRONTEND.md](./FRONTEND.md) | Frontend structure, pages, components, styling, auth |
+| [BACKEND.md](./BACKEND.md) | Backend structure, API routes, controllers, models, database |
+| [DEPLOYMENT.md](./DEPLOYMENT.md) | Environments, CI/CD, Docker build and deploy |
+| [MAINTAINERS.md](./MAINTAINERS.md) | Monitoring, maintenance, incident response |
+| [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) | Diagnosis guide for pipeline and runtime failures |

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -1,0 +1,237 @@
+> **See also:** [Architecture overview](ARCHITECTURE.md) · [Development guide](DEVELOPMENT.md) · [Frontend docs](FRONTEND.md) · [Troubleshooting](TROUBLESHOOTING.md)
+
+> This document describes the backend structure and API. For the frontend, see [FRONTEND.md](./FRONTEND.md).
+
+---
+
+# IUGA Website — Backend
+
+**Tech stack:** Express.js 4, Mongoose 6, MongoDB, express-session, Microsoft MSAL
+
+---
+
+## Entry Points
+
+| File | Role |
+|---|---|
+| `bin/www.cjs` | HTTP server bootstrap — imports `app.js`, listens on `PORT` (default 7777) |
+| `app.js` | Express application setup — middleware stack, static serving, API mount |
+| `models.js` | MongoDB connection + Mongoose model registration |
+
+---
+
+## Directory Layout
+
+```
+backend/
+├── bin/
+│   └── www.cjs              ← Server entry point (CommonJS)
+├── app.js                   ← Express app config
+├── models.js                ← Database connection + model registration
+├── schemas/                 ← Git submodule → UW-IUGA/iuga-web-schemas
+├── routes/
+│   └── api/v1/
+│       ├── apiv1.js         ← API router (mounts controller modules)
+│       ├── controllers/
+│       │   ├── user.js           ← Login, logout, user info
+│       │   ├── events.js         ← Event CRUD, RSVP
+│       │   ├── feedback.js       ← Feedback form CRUD (not currently mounted — see Feedback section)
+│       │   └── administration.js ← Officer/committee stubs (not currently mounted — see Administration section)
+│       └── utils/
+│           └── auth.js          ← (empty — auth is inline in controllers)
+├── env/
+│   ├── .env.example          ← Template for environment files
+│   └── (actual .env.* files are gitignored)
+└── package.json             ← ES module ("type": "module")
+```
+
+---
+
+## SPA Routes
+
+These routes in `app.js` serve the built frontend (`frontend/build/index.html`) for every path the React Router handles. This enables **deep linking** — users can navigate directly to `/events` and get the SPA shell.
+
+| Route | Purpose |
+|---|---|
+| `GET /` | Home page |
+| `GET /events` | Events calendar |
+| `GET /resources` | Resources page |
+| `GET /about` | About page |
+| `GET /electionfaq` | Election FAQ |
+| `GET /contact` | Contact page |
+
+Each handler reads `../frontend/build/index.html` and sends it. If the build directory is missing, these routes return 500.
+
+Express also serves:
+- Static files from `../frontend/build/` (line: `app.use(express.static("../frontend/build"))`)
+- Uploaded files from `public/uploads/` via `GET /uploads`
+
+---
+
+## API Routes
+
+All API routes are mounted under `/api/v1`. They return JSON.
+
+### Events (`/api/v1/events`)
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/` | No | All events for the calendar. Populates participant info only if authenticated; otherwise `hasRSVPd: false`. |
+| `GET` | `/upcoming` | No | Latest 3 events (sorted by start date descending). Used by the homepage. |
+| `GET` | `/id/:eId` | No | Single event details. Includes RSVP questions, participant count, thumbnail. If authenticated, includes user's RSVP answers. |
+| `POST` | `/rsvp` | Yes | RSVP to an event. Body: `{ eId, rsvpAnswers }`. Validates: event exists, RSVP enabled, event hasn't started, user not already RSVPed. |
+| `DELETE` | `/withdraw/:eId/:pId` | Yes | Withdraw from an event. |
+| `GET` | `/:pId` | No | Get participant info by participant ID. |
+
+### User (`/api/v1/user`)
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `POST` | `/login` | No* | Exchange MS access token for a server session. Validates token via Microsoft Graph API. Creates user in MongoDB if new. |
+| `POST` | `/logout` | Yes | Destroy server session. |
+| `GET` | `/` | Yes | Return current session user info (firstName, lastName, displayName, email, memberType). |
+| `GET` | `/:uId` | Yes | Get user by ID (stub — controller has empty branches for owner/admin/outsider views). |
+| `POST` | `/:uId` | Yes | Update user by ID (stub — branches for self-edit and admin-edit, no implementation). |
+
+\* `/login` does not require a session but does require a Bearer token from Microsoft.
+
+### Feedback (`/api/v1/feedback`) — *not currently wired*
+
+⚠️ **These endpoints are defined in `controllers/feedback.js` but are NOT imported by `apiv1.js`. All requests to `/api/v1/feedback/*` currently return 404.**
+
+The controller provides full CRUD (no auth required):
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/` | Get a feedback form by `fID` query parameter |
+| `POST` | `/` | Submit a new feedback form. Body: `{ fUID, fType, fTopic, fDescription }` |
+| `DELETE` | `/` | Delete a feedback form by `fID` query parameter |
+
+To activate, import and mount `feedbackRouter` in `apiv1.js`.
+
+### Administration (`/api/v1/administration`) — *not currently wired*
+
+⚠️ **These endpoints are defined in `controllers/administration.js` but are NOT imported by `apiv1.js`. All requests to `/api/v1/administration/*` currently return 404.**
+
+All endpoints are **stubs** returning placeholder text:
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/officers` | Save/update officer (stub) |
+| `GET` | `/officers` | Retrieve officer (stub) |
+| `DELETE` | `/officers` | Remove officer (stub) |
+| `POST` | `/committees` | Save/update committee (stub) |
+| `GET` | `/committees` | Retrieve committee (stub) |
+| `DELETE` | `/committees` | Remove committee (stub) |
+
+To activate, import and mount `administrationRouter` in `apiv1.js`.
+
+---
+
+## Authentication
+
+The backend uses **server-side sessions** with `express-session`.
+
+### Session creation (login flow)
+
+1. Frontend sends `POST /api/v1/user/login` with `Authorization: Bearer <ms-access-token>`
+2. Backend calls `https://graph.microsoft.com/v1.0/me` with the token to verify identity
+3. On success, the backend:
+   - Sets `req.session.isAuthenticated = true`
+   - Stores profile data (displayName, email, firstName, lastName) in session
+   - Looks up or creates a `Users` document in MongoDB
+   - Stores `userId`, `memberType`, and `isAdmin` in session
+4. Responds with the user document
+
+### Session check
+
+Route handlers check `req.session.isAuthenticated` to determine auth state. There is no dedicated middleware — each controller checks inline.
+
+### Session destruction
+
+`POST /api/v1/user/logout` destroys the session and responds with `{ status: "success" }`.
+
+---
+
+## Database
+
+### Connection
+
+Connection logic is in `models.js` and depends on `DEPLOY_ENV`:
+
+```javascript
+if (DEPLOY_ENV === "production" || DEPLOY_ENV === "staging") {
+  // mongodb://user:pass@mongo:27017/iuga  (Docker network)
+} else {
+  // mongodb+srv://user:pass@cluster0.mongodb.net/  (Atlas)
+}
+```
+
+### Models
+
+Three Mongoose models are registered at startup:
+
+| Model | Schema Source | Collection |
+|---|---|---|
+| `Events` | `eventsSchema` | `events` |
+| `Participants` | `participantsSchema` | `participants` |
+| `Users` | `usersSchema` | `users` |
+
+The schemas live in a **separate GitHub repository** (`UW-IUGA/iuga-web-schemas`) mounted as a submodule at `backend/schemas/`. If the submodule is not initialized, the backend will fail to start.
+
+### Schema details (from submodule)
+
+Based on controller usage, the schemas include these fields:
+
+**Events**: `eId`, `eName`, `eStartDate`, `eEndDate`, `eLocation`, `eOrganizers`, `eDescription`, `eLabels`, `ePics`, `eParticipants` (ref → Participants), `eThumbnailPath`, `eRsvpEnabled`, `rsvpQuestions`, `eAltLink`, `eShowParticipants`
+
+**Participants**: `pUID` (ref → Users), `eID` (ref → Events), `rsvpAnswers` (array of `{ qId, aString }`), `isAnon`
+
+**Users**: `uFirstName`, `uLastName`, `uDisplayName`, `uEmail`, `uType` (e.g., "Admin")
+
+---
+
+## Middleware Stack (in order)
+
+1. `cors()` — enabled only when `DEPLOY` environment variable is not set (dev)
+2. `morgan('dev')` — HTTP request logging
+3. `express.json()` — JSON body parsing
+4. `express.urlencoded({ extended: false })` — URL-encoded body parsing
+5. `cookie-parser` — Cookie parsing
+6. `express.static("../frontend/build")` — Static file serving
+7. `express-session` — Server-side session management
+8. Custom middleware — attaches `req.models` (Mongoose models) to each request
+9. SPA route handlers — serve `index.html` for browser routes
+10. `app.use('/api/v1', apiv1Router)` — API route mount
+
+Note: ETag is **disabled** (`app.disable('etag')`) to ensure clients always get the latest version.
+
+---
+
+## Key Backend Dependencies
+
+| Package | Purpose |
+|---|---|
+| `express` | HTTP framework |
+| `mongoose` | MongoDB ODM |
+| `express-session` | Server-side sessions |
+| `morgan` | HTTP request logging |
+| `cors` | Cross-origin resource sharing (dev only) |
+| `cookie-parser` | Cookie parsing |
+| `dotenv-cli` | Load environment files |
+| `node-fetch` | HTTP requests to Microsoft Graph API |
+| `@sendgrid/mail` | Email sending (installed, usage unconfirmed from source) |
+| `node-cache` | In-memory caching |
+| `node-cron` | Scheduled tasks |
+| `handlebars` | Template engine (installed, not used in current routes) |
+
+---
+
+## Related Documents
+
+- [Architecture Overview](ARCHITECTURE.md) — System components and data flow
+- [Development Guide](DEVELOPMENT.md) — Setup, scripts, code conventions
+- [Frontend Documentation](FRONTEND.md) — React app structure, routing, auth flow
+- [Deployment Guide](DEPLOYMENT.md) — Environments, CI/CD, Docker
+- [Maintainers Guide](MAINTAINERS.md) — Monitoring and maintenance
+- [Troubleshooting Guide](TROUBLESHOOTING.md) — Common failures and diagnosis

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,234 @@
+# Deployment Guide
+
+> **Audience:** Developers and maintainers deploying IUGA Web App.
+> **Pipeline:** GitHub → Jenkins → Docker → Production server.
+> **Reference:** [Architecture overview](ARCHITECTURE.md), [Quickstart](QUICKSTART.md), [Maintainers](MAINTAINERS.md), [Troubleshooting](TROUBLESHOOTING.md).
+
+---
+
+## Pipeline Overview
+
+Every environment (dev, staging, production) follows the same five-stage pipeline:
+
+| Stage | What happens | Responsibility |
+|---|---|---|
+| Checkout | Jenkins clones `github.com/UW-IUGA/iuga-web-app` (branch `main`) with submodules using the `github_classic` credential. | Jenkins |
+| Build | `docker build` with `--build-arg DEPLOY_ENV` selects the target environment's API URL via sed transforms in the Dockerfile. | Jenkins |
+| Push to Registry | `docker push` to Docker Hub after authenticating with the `dockerhub` credential. | Docker Hub |
+| Deploy | `docker pull`, stop/remove old container, `docker run` with env variables and volume mounts. | Production host |
+| Status report | Jenkins posts a commit status to GitHub (`iuga/jenkins/cicd/<env>`). | Jenkins |
+
+### Trigger
+
+- **Dev / Staging / Production:** A push to `main` triggers all three pipelines (they run independently).
+- **Staging only:** Uses `checkout scm` (multibranch pipeline); the others use explicit branch `*/main`.
+
+> **Note:** All environments deploy from the `main` branch. There is no per-environment branch strategy.
+
+---
+
+## Jenkinsfile Comparison
+
+### `dev.jenkinsfile` (Development)
+
+- **Image name:** `iuga/iuga-web-app-development`
+- **Container name:** `iuga-web-dev`
+- **Host port:** `6666` → container port `7777`
+- **Network:** None (default bridge)
+- **Volume:** `/var/lib/iuga-web-app/uploads/dev:/app/backend/public/uploads`
+- **DB credentials:** `devDBUsername`, `devDBPassword` (Jenkins string credentials)
+- **Database:** MongoDB Atlas (`cluster0.ejo8heu.mongodb.net`)
+- **Commit status context:** `iuga/jenkins/cicd/dev`
+
+### `staging.jenkinsfile` (Staging)
+
+- **Source:** `checkout scm` (Jenkins multibranch pipeline — uses the branch/tag that triggered the job)
+- **Image name:** `iuga/iuga-web-app-staging`
+- **Container name:** `iuga-web-staging`
+- **Host port:** `7777` → container port `7777`
+- **Network:** `iuga-server-config_default`
+- **Volume:** `/var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads`
+- **DB credentials:** `prodDBUsername`, `prodDBPassword` (Jenkins string credentials — staging shares the production database)
+- **Database:** MongoDB container at `mongo:27017` (via `iuga-server-config_default` network)
+- **Commit status context:** `iuga/jenkins/cicd/staging`
+
+### `prod.jenkinsfile` (Production)
+
+- **Image name:** `iuga/iuga-web-app-production`
+- **Container name:** `iuga-web-prod`
+- **Host port:** `8888` → container port `7777`
+- **Network:** `iuga-server-config_default`
+- **Volume:** `/var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads`
+- **DB credentials:** `prodDBUsername`, `prodDBPassword` (Jenkins string credentials)
+- **Database:** MongoDB container at `mongo:27017` (via `iuga-server-config_default` network)
+- **Commit status context:** `iuga/jenkins/cicd/prod`
+
+---
+
+## Credential Categories
+
+Jenkins requires these credential IDs (values are **not** in this repository):
+
+| Credential ID | Type | Purpose |
+|---|---|---|
+| `github_classic` | Username+Password | GitHub API authentication for checkout and commit status updates |
+| `dockerhub` | Username+Password | Docker Hub login for image push |
+| `devDBUsername` | String | MongoDB dev database username |
+| `devDBPassword` | String | MongoDB dev database password |
+| `prodDBUsername` | String | MongoDB production/staging database username |
+| `prodDBPassword` | String | MongoDB production/staging database password |
+
+---
+
+## Docker Build Process
+
+The [Dockerfile](../Dockerfile) is a multi-stage build:
+
+1. **Build stage** (`FROM node:22-alpine AS build`)
+   - Copies `frontend/` into `/app/frontend`
+   - Installs npm dependencies
+   - Transforms API URLs via `sed` based on `DEPLOY_ENV`:
+
+     | `DEPLOY_ENV` | API URL in build | Served domain |
+     |---|---|---|
+     | `development` | `https://dev.iuga.info` | `localhost:6666` (via nginx proxy) |
+     | `staging` | `https://staging.iuga.info` | `staging.iuga.info` (via nginx proxy) |
+     | `production` | `https://iuga.info` | `iuga.info` (via nginx proxy) |
+
+   - Runs `npm run build`
+
+2. **Runtime stage** (`FROM node:22-alpine`)
+   - Installs `tzdata` (sets `TZ=America/Los_Angeles`) and `git`
+   - Copies `backend/` into `/app/backend`
+   - Copies built frontend from build stage into `/app/frontend/build`
+   - Exposes `$PORT` (default 7777)
+   - Runs **`npm run deploy`** → `dotenv -e ./env/.env.prod node ./bin/www.cjs`
+
+---
+
+## Runtime Architecture
+
+```
+                         External nginx
+                              │
+                    ┌─────────┴──────────┐
+                    │ iuga-server-config  │
+                    │  _default network  │
+                    └─────────┬──────────┘
+                              │
+         ┌────────────────────┼────────────────────┐
+         │                    │                    │
+  iuga-web-dev          iuga-web-staging     iuga-web-prod
+  :6666 → :7777         :7777 → :7777        :8888 → :7777
+         │                    │                    │
+         │              ┌─────┴─────┐              │
+         │              │  mongo:27017 (MongoDB container via external config)
+         │              └───────────┘
+         │
+    MongoDB Atlas
+    (cluster0.ejo8heu.mongodb.net)
+```
+
+### What is managed by this repository
+
+- Application code (backend Express server + frontend React SPA)
+- Docker build
+- Jenkins pipeline definitions (`dev.jenkinsfile`, `staging.jenkinsfile`, `prod.jenkinsfile`)
+
+### What is NOT managed by this repository (external boundaries)
+
+- **Jenkins server:** URL, configuration, plugins, and credential storage are outside this repo.
+- **Nginx reverse proxy:** TLS termination and domain routing are configured externally (likely in a separate `iuga-server-config` repository or host config).
+- **MongoDB container:** The `mongo` service and the `iuga-server-config_default` Docker network are created and managed externally.
+- **MongoDB Atlas cluster:** Dev database is a SaaS resource configured outside this repo.
+- **Docker Hub account:** The `iuga/` organization on Docker Hub is managed separately.
+- **DNS records:** `dev.iuga.info`, `staging.iuga.info`, `iuga.info` are configured outside this repo.
+- **Upload volume directory:** `/var/lib/iuga-web-app/uploads/` must exist on the host before deployment.
+
+---
+
+## How to Verify a Deployment
+
+### 1. Check Jenkins build status
+
+Navigate to the Jenkins job for the target environment and confirm the pipeline is green. Alternatively, check the GitHub commit status (look for `iuga/jenkins/cicd/<env>`).
+
+### 2. Check the container is running
+
+```bash
+# Requires host access
+docker ps --filter name=iuga-web-<env>   # e.g., iuga-web-prod, iuga-web-staging, iuga-web-dev
+```
+
+Expected output: `STATUS Up <time>`, port mapping matches the table above.
+
+### 3. Check the application health
+
+```bash
+# From the host
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/
+# Dev: 6666, Staging: 7777, Prod: 8888
+```
+
+Expected: `200`
+
+### 4. Check API endpoint
+
+```bash
+curl -s https://<domain>/api/v1/   # Replace with target domain
+```
+
+Expected: JSON response (empty array or API result — not a 404/502).
+
+### 5. Check container logs for startup errors
+
+```bash
+docker logs iuga-web-<env> --tail 50
+```
+
+Expected: The last lines should show:
+```
+Listening at 0.0.0.0:7777
+connecting to <prod|dev> database
+successfully connected to <prod|dev> mongodb
+mongoose models created
+```
+
+### 6. Check image was pushed to Docker Hub
+
+Visit `https://hub.docker.com/r/iuga/iuga-web-app-<env>/tags` and confirm the latest tag has the expected build timestamp.
+
+---
+
+## Rollback
+
+This repo does not define an automated rollback mechanism. To roll back:
+
+1. Identify the previous working image tag on Docker Hub.
+2. On the production host, pull and run the old image:
+   ```bash
+   docker pull iuga/iuga-web-app-<env>:<previous-tag>
+   docker rm -f iuga-web-<env>
+   docker run ... iuga/iuga-web-app-<env>:<previous-tag>
+   ```
+3. (If appropriate) revert the Git commit and re-run the pipeline.
+
+---
+
+## Common Port Reference
+
+| Environment | Internal Port | Host Port | Container Name |
+|---|---|---|---|
+| Development | 7777 | 6666 | `iuga-web-dev` |
+| Staging | 7777 | 7777 | `iuga-web-staging` |
+| Production | 7777 | 8888 | `iuga-web-prod` |
+
+All environments bind to `127.0.0.1` only. External access goes through nginx.
+
+---
+
+## Related Documents
+
+- [Maintainers Guide](MAINTAINERS.md) — Safe monitoring and maintenance procedures.
+- [Troubleshooting Guide](TROUBLESHOOTING.md) — Common failures and diagnosis sequences.
+- [README](../README.md) — Project overview, scripts, and quickstart.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,204 @@
+# IUGA Website — Development Guide
+
+## Prerequisites
+
+- **Node.js** 22+ (matching the Docker image `node:22-alpine`)
+- **npm** (bundled with Node.js)
+- **Git**
+- **MongoDB** (only needed for backend development; dev mode uses mock data)
+
+---
+
+## Quick Start
+
+```bash
+# Install everything and run in dev mode
+npm run dev
+```
+
+This runs: `cd frontend; npm install && npm run build && cd ../backend; npm install && npm start`
+
+The app is served at **http://localhost:7777**.
+
+---
+
+## Running Parts Individually
+
+| Command | What it does |
+|---|---|
+| `npm run frontend` | Install and start CRA dev server on `:3000` |
+| `npm run backend`  | Install and start Express on `:7777` (uses production build of frontend) |
+| `npm run backend-debug` | Start backend with debug logging |
+| `npm run debug`    | Full rebuild + backend with debug logging |
+
+### Frontend-only development
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+This starts the Create React App dev server on `http://localhost:3000` with hot reload. It uses **mock data** (no backend calls) because `NODE_ENV` is `development`.
+
+### Backend-only development
+
+```bash
+cd backend
+npm install
+npm start                    # uses .env.dev
+# or
+npm run deploy               # uses .env.prod
+# or
+npm run debug                # uses .env.debug + verbose logging (create it first!)
+```
+
+> **Note:** `.env.debug` is not committed. Create it from `.env.example`: `cp backend/env/.env.example backend/env/.env.debug`
+
+The backend requires:
+1. A built frontend at `../frontend/build/`
+2. Environment files in `backend/env/` (see below)
+3. A MongoDB connection (Atlas for dev)
+
+---
+
+## Environment Configuration
+
+Backend environment files live in `backend/env/` and are **gitignored** (except `.env.example`).
+
+```
+backend/env/
+├── .env.example       ← Copy this to create your config
+├── .env.dev           ← npm start
+├── .env.debug         ← npm run debug (create from .env.example)
+└── .env.prod          ← npm run deploy
+```
+
+Required variables (see `.env.example`):
+
+| Variable | Purpose |
+|---|---|
+| `PORT` | Server port (default 7777) |
+| `DEPLOY_ENV` | `development`, `staging`, or `production` |
+| `SESSION_SECRET` | Strong random string for session signing |
+| `DB_DEV_USERNAME` | MongoDB Atlas username (dev) |
+| `DB_DEV_PASSWORD` | MongoDB Atlas password (dev) |
+| `DB_PROD_USERNAME` | MongoDB username (prod/staging) |
+| `DB_PROD_PASSWORD` | MongoDB password (prod/staging) |
+
+Frontend environment (checked in):
+
+| File | Variable | Value |
+|---|---|---|
+| `frontend/.env.dev` | `REACT_APP_API_URL` | `http://localhost:7777` |
+| `frontend/.env.production` | `REACT_APP_API_URL` | `https://dev.iuga.info` |
+
+In dev mode, the frontend uses **mock data** from `src/assets/mock-data/` instead of fetching from the API. In production builds (`npm run build`), it uses the live API.
+
+---
+
+## Project Scripts (Root `package.json`)
+
+| Script | Action |
+|---|---|
+| `npm run dev` | Build frontend → start backend (dev env) |
+| `npm run debug` | Build frontend → start backend (debug env) |
+| `npm run frontend` | Start CRA dev server only |
+| `npm run backend` | Install + start backend (dev env) |
+| `npm run backend-dev` | Same as above |
+| `npm run backend-debug` | Install + start backend (debug env) |
+
+---
+
+## Codebase Conventions
+
+### General
+
+- **JavaScript** (ES Modules with `import`/`export`). Backend uses `.js` with `"type": "module"` in package.json except `bin/www.cjs` (CommonJS for bootstrapping).
+- **JSX** for React components (`.jsx` extension).
+- **SCSS** for styles, organized in the [7-1 pattern](https://sass-guidelin.es/#architecture).
+- Indentation: 4 spaces.
+
+### Frontend
+
+- One component per file.
+- Pages go in `pages/`, reusable UI in `components/`, shared state in `context/`.
+- CSS class naming follows BEM-like conventions (`.nav-container`, `.nav-items-wrapper`).
+
+### Backend
+
+- Route handlers in `routes/api/v1/controllers/`.
+- Middleware and utilities in `routes/api/v1/utils/`.
+- Mongoose models registered in `models.js`, schemas imported from the submodule.
+- Error responses use shape: `{ status: "error", message: "..." }`
+
+### Git
+
+- **Submodule**: `backend/schemas` — after cloning, run `git submodule init && git submodule update`
+- Branches: feature branches from `main`, PRs into `main`
+- Jenkins pipelines build and deploy from specific branches
+
+---
+
+## Common Tasks
+
+### Add a new page
+
+1. Create `frontend/src/pages/YourPage.jsx`
+2. Add `<Route>` in `frontend/src/App.jsx`
+3. Add a matching `GET /your-page` route in `backend/app.js` (to serve SPA on direct navigation)
+4. Add a Navbar link in `frontend/src/layouts/Navbar.jsx`
+5. Create page-specific SCSS at `frontend/src/stylesheets/pages/_yourpage.scss` and import in `main.scss`
+
+### Add a new API endpoint
+
+1. Create or edit a controller in `backend/routes/api/v1/controllers/`
+2. Mount it in `backend/routes/api/v1/apiv1.js` with `router.use()`
+3. If a new collection is needed, add a schema in the `iuga-web-schemas` submodule and register the model in `backend/models.js`
+
+### Work with the schema submodule
+
+```bash
+# After cloning this repo
+git submodule update --init --recursive
+
+# After updating schemas in the remote
+git submodule update --remote
+
+# The submodule is pinned to a commit in the main repo
+```
+
+---
+
+## Testing
+
+The project currently has **limited test infrastructure**:
+
+- Frontend includes `@testing-library/react` (installed) but no test files were found during documentation authoring.
+- Backend has no test runner or test files.
+
+To add tests, the project would benefit from:
+
+- **Frontend**: `react-scripts test` (Jest) — add tests alongside components in `__tests__/` directories
+- **Backend**: Jest or Mocha for controller integration tests with a test MongoDB
+
+---
+
+## Docker Build
+
+```bash
+docker build --build-arg DEPLOY_ENV=development -t iuga-web-app .
+```
+
+The Dockerfile performs a multi-stage build:
+
+1. Installs and builds the React frontend
+2. Replaces the API URL based on `DEPLOY_ENV` (production → `iuga.info`, staging → `staging.iuga.info`, development → `dev.iuga.info`)
+3. Copies only production backend dependencies into the final image
+4. Runs `npm run deploy` as the container command
+
+---
+
+## Troubleshooting
+
+> For diagnosis of common issues, see the **[Troubleshooting Guide](TROUBLESHOOTING.md)** — it covers pipeline failures, runtime failures, 502 errors, stale content, and more.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,0 +1,157 @@
+# IUGA Website — Frontend
+
+**Tech stack:** React 18, Create React App (react-scripts 5), React Router v6, SCSS, Azure MSAL
+
+---
+
+## Entry Points
+
+| File | Role |
+|---|---|
+| `public/index.html` | HTML shell — font loading, meta tags, `<div id="root">` |
+| `src/index.jsx` | React bootstrap — MSAL provider, auth context, browser router |
+| `src/App.jsx` | Layout wrapper — navbar, toast notifications, route definitions |
+| `src/authConfig.js` | MSAL client ID, tenant authority, redirect URI |
+
+---
+
+## Directory Layout
+
+```
+frontend/src/
+├── assets/
+│   ├── data/          ← Static JS data files (teams, candidates, resources, etc.)
+│   ├── mock-data/     ← Mock API responses for development mode
+│   ├── gallery/       ← Event gallery images
+│   └── icons/         ← SVG icons (career, social, academic)
+├── components/        ← Reusable UI components
+│   ├── Button.jsx
+│   ├── Calendar.jsx
+│   ├── CharacterCard.jsx
+│   ├── Dropdown.jsx
+│   ├── ElectionFAQCard.jsx
+│   ├── EventCard.jsx
+│   ├── EventDetailsCard.jsx
+│   ├── EventDetailsLoader.jsx
+│   ├── GradientLine.jsx
+│   ├── ResourceCard.jsx
+│   ├── RolePage.jsx
+│   └── Tag.jsx
+├── context/
+│   └── AuthContext.jsx   ← Authentication state (React Context)
+├── hooks/
+│   └── useAuth.jsx       ← MSAL token acquisition + backend handshake
+├── layouts/
+│   ├── Navbar.jsx        ← Top navigation (responsive, scroll-aware)
+│   └── Footer.jsx
+├── pages/
+│   ├── Home.jsx          ← Landing page: intro, character cards, events, gallery
+│   ├── Events.jsx        ← Calendar view (desktop only; mobile shows "under construction")
+│   ├── Resources.jsx     ← Resource links list
+│   ├── About.jsx         ← Team member cards by year
+│   ├── Elections.jsx     ← Candidate profiles for current election
+│   └── ElectionsFAQ.jsx  ← FAQ accordion about elections
+└── stylesheets/
+    ├── main.scss          ← Central import file (7-1 architecture)
+    ├── abstracts/         ← Variables, mixins, functions, media queries
+    ├── base/              ← Reset, typography, colors, misc
+    ├── components/        ← Component-specific styles
+    ├── layout/            ← Container, navigation, footer, form
+    ├── pages/             ← Page-specific styles
+    └── addons/            ← Third-party overrides (toastify)
+```
+
+---
+
+## Routing
+
+Defined in `src/App.jsx`:
+
+| Path | Page Component | Data Source |
+|---|---|---|
+| `/` | `HomePage` | `upcomingEvents` (prop — mock or API) |
+| `/events` | `EventsPage` | Mock data or `GET /api/v1/events` |
+| `/resources` | `ResourcesPage` | Static data from `assets/data/ResourcesData.js` |
+| `/about` | `AboutPage` | Static data from `assets/data/AboutData.js` |
+| `/elections` | `ElectionPage` | Static data from `assets/data/CandidateData.js` |
+| `/electionfaq` | `ElectionsFAQPage` | Static data from `assets/data/ElectionFAQData.js` |
+
+The backend also serves `index.html` for each of these paths to enable deep linking (see [BACKEND.md](./BACKEND.md#spa-routes)).
+
+---
+
+## Data Flow
+
+### Development Mode
+
+In dev mode (`NODE_ENV !== "production"`), the frontend uses **mock data**:
+
+- **Homepage events**: `MockCalendarData.js`
+- **Calendar events**: `MockCalendarData.js` (imported directly, no fetch)
+- **Single event details**: `mockEvent` from `MockCalendarData.js`
+
+No backend is required for frontend development.
+
+### Production Mode
+
+In production (`NODE_ENV === "production"`), the frontend fetches from the API:
+
+- `GET {REACT_APP_API_URL}/api/v1/events/upcoming` → homepage
+- `GET {REACT_APP_API_URL}/api/v1/events` → calendar
+- `GET {REACT_APP_API_URL}/api/v1/events/id/{eId}` → event details
+
+The API base URL comes from the `REACT_APP_API_URL` environment variable, substituted at build time.
+
+---
+
+## Authentication
+
+Authentication uses **Microsoft Azure AD** via the `@azure/msal-browser` and `@azure/msal-react` packages.
+
+### Auth flow in the frontend
+
+1. **User clicks "UW NetID Login"** → `signIn()` in `AuthContext.jsx` calls `instance.loginRedirect()`
+2. **Redirect to Azure AD** → user authenticates with UW credentials
+3. **Redirect back** → MSAL detects the auth code in the URL
+4. **`useAuth.jsx`**: acquires a token silently → sends it to `POST /api/v1/user/login`
+5. **Backend validates token** (via Microsoft Graph API) → creates server session → returns user data
+6. **`AuthContext`** stores user data and sets `isAuthenticated = true`
+7. **Navbar** shows user greeting + logout button instead of login button
+
+### Key files
+
+- `authConfig.js` — MSAL app configuration (client ID, tenant, redirect URI)
+- `context/AuthContext.jsx` — React Context provider for auth state
+- `hooks/useAuth.jsx` — Token acquisition and backend handshake logic
+
+The backend creates **server-side sessions** (express-session), so the frontend sends a session cookie on subsequent API calls.
+
+---
+
+## Styling
+
+- **SCSS** with [7-1 architecture](https://sass-guidelin.es/#architecture)
+- Compiled via `sass` (devDependency)
+- Main entry: `src/stylesheets/main.scss` — imports all partials
+- Fonts: **NotoSans** (body) and **PlayfairDisplay** (headings), served from `public/font/`
+- Responsive breakpoints: desktop (≥1024px) and mobile (340–1023px)
+- Some pages (Events calendar) are desktop-only with a "under construction" message on mobile
+- Toast notifications: `react-toastify` for user feedback
+
+---
+
+## Key Dependencies
+
+| Package | Purpose |
+|---|---|
+| `react-router-dom` | Client-side routing |
+| `@azure/msal-browser`, `@azure/msal-react` | UW Azure AD authentication |
+| `react-awesome-reveal` | Scroll-triggered animations |
+| `react-just-parallax` | Parallax effects on homepage character cards |
+| `react-ga4` | Google Analytics 4 |
+| `react-responsive` | Responsive breakpoint rendering |
+| `react-bootstrap` / `bootstrap` | Bootstrap 5 UI components |
+| `react-toastify` | Toast notifications |
+| `date-fns` / `dateformat` | Date formatting |
+| `sass` | SCSS compilation |
+| `@fortawesome/*` | Icon set |

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -1,0 +1,192 @@
+# Maintainers Guide
+
+> **Audience:** Maintainers performing routine checks, maintenance, and incident response.
+> **Assumes:** Access to the production host, Jenkins, and Docker Hub. Credentials are **not** in this repository.
+> **Reference:** [Deployment Guide](DEPLOYMENT.md), [Troubleshooting Guide](TROUBLESHOOTING.md).
+
+---
+
+## 1. Safe Monitoring Checks (read-only, least privilege)
+
+These commands are safe to run on any host. They do **not** modify state.
+
+### 1.1 List running containers
+
+```bash
+docker ps --filter name=iuga-web-
+```
+
+Expected output shows three containers (if all are deployed):
+
+```
+CONTAINER ID   IMAGE                              COMMAND                  CREATED       STATUS       PORTS                      NAMES
+abc12345       iuga/iuga-web-app-development      "npm run deploy"         2 hours ago   Up 2 hours   127.0.0.1:6666->7777/tcp   iuga-web-dev
+def67890       iuga/iuga-web-app-staging          "npm run deploy"         2 hours ago   Up 2 hours   127.0.0.1:7777->7777/tcp   iuga-web-staging
+ghi11223       iuga/iuga-web-app-production       "npm run deploy"         2 hours ago   Up 2 hours   127.0.0.1:8888->7777/tcp   iuga-web-prod
+```
+
+### 1.2 Check container resource usage
+
+```bash
+docker stats --no-stream iuga-web-prod iuga-web-staging iuga-web-dev
+```
+
+Watch for CPU > 80% or memory growing steadily (possible leak).
+
+### 1.3 View recent logs
+
+```bash
+docker logs iuga-web-<env> --tail 100
+```
+
+Look for:
+- Startup errors (failed DB connection, port conflicts).
+- Repeated error stacks (possible runtime bug).
+- `GET /` or `GET /api/v1/...` entries with non-2xx status codes.
+
+### 1.4 Check HTTP health from the host
+
+```bash
+for port in 6666 7777 8888; do
+  echo -n "localhost:$port → "
+  curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$port/
+  echo
+done
+```
+
+All three should return `200`.
+
+### 1.5 Check public endpoints (external)
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" https://dev.iuga.info/
+curl -s -o /dev/null -w "%{http_code}" https://staging.iuga.info/
+curl -s -o /dev/null -w "%{http_code}" https://iuga.info/
+```
+
+All should return `200`. A `502` or `503` indicates nginx cannot reach the backend (see [Troubleshooting: 502 Bad Gateway](TROUBLESHOOTING.md#3-502-bad-gateway)).
+
+### 1.6 Check disk space on host
+
+```bash
+df -h /var/lib/iuga-web-app/
+```
+
+Ensure the uploads volume has free space. MongoDB data and user uploads live here.
+
+### 1.7 Verify Jenkins job status via GitHub commit status
+
+On any commit in the `main` branch, look for these contexts:
+- `iuga/jenkins/cicd/dev`
+- `iuga/jenkins/cicd/staging`
+- `iuga/jenkins/cicd/prod`
+
+All must be green (`success`) for a fully healthy deployment.
+
+---
+
+## 2. Routine Maintenance Procedures
+
+### 2.1 Clean up old Docker images
+
+> **Requires host access.** Images not used by any container are safe to prune.
+
+```bash
+docker image prune -f
+```
+
+To see what would be removed first (dry-run):
+
+```bash
+docker image prune --all -f --filter "until=720h"  # Remove images older than 30 days
+```
+
+### 2.2 Restart a container cleanly
+
+> Use when the app is running but misbehaving (e.g., memory leak, hung connections).
+
+```bash
+docker restart iuga-web-<env>
+```
+
+Wait 10 seconds, then verify:
+```bash
+docker ps --filter name=iuga-web-<env> --format "{{.Status}}"
+docker logs iuga-web-<env> --tail 10
+```
+
+### 2.3 Check uploads directory
+
+```bash
+ls -la /var/lib/iuga-web-app/uploads/<env>/
+```
+
+Verify that files are accessible and not accumulating unexpectedly.
+
+### 2.4 Check MongoDB connectivity (from inside the container)
+
+```bash
+docker exec iuga-web-<env> node -e "
+  const mongoose = require('mongoose');
+  mongoose.connect('mongodb://...').then(() => {
+    console.log('OK');
+    process.exit(0);
+  }).catch(e => {
+    console.error('FAIL:', e.message);
+    process.exit(1);
+  });
+"
+```
+
+> **Note:** Replace the connection string with the actual URI (prod uses `mongo:27017`, dev uses Atlas). Run this only during incident response.
+
+---
+
+## 3. Observation Points (what to watch for)
+
+| Symptom | Possible cause | Action |
+|---|---|---|
+| Container restarting repeatedly | Crash loop (DB auth, port conflict) | Check logs, verify credentials |
+| HTTP 502 from public URL | nginx cannot reach container | [See Troubleshooting](TROUBLESHOOTING.md#3-502-bad-gateway) |
+| HTTP 502 from host `curl` | Container not listening or wrong port | `docker ps`, check port mapping |
+| Stale content served | nginx cache or old container still running | `docker ps`, verify correct image tag |
+| `docker push` fails in Jenkins | Docker Hub credential expired or rate-limited | Renew `dockerhub` credential in Jenkins |
+| MongoDB connection failure | Network down, Atlas IP whitelist changed, credentials rotated | Verify network, check `DB_PROD_USERNAME`/`DB_PROD_PASSWORD` |
+
+---
+
+## 4. Credential Rotation
+
+Credentials are stored in Jenkins. This repository references them by ID only.
+
+| Credential ID | Rotation frequency | Owner |
+|---|---|---|
+| `github_classic` | Per GitHub token expiry | [Team lead / IT] — *Escalate to fill* |
+| `dockerhub` | Per Docker Hub policy | [Team lead / IT] — *Escalate to fill* |
+| `devDBUsername` / `devDBPassword` | As needed | [Database admin] — *Escalate to fill* |
+| `prodDBUsername` / `prodDBPassword` | As needed | [Database admin] — *Escalate to fill* |
+
+When rotating, update the credential in Jenkins directly. No application code changes are needed.
+
+---
+
+## 5. Escalation Contacts
+
+> **Placeholder:** Fill in the actual team/individual for each area.
+
+| Area | Contact | Notes |
+|---|---|---|
+| Jenkins server | <!-- E.g., DevOps team / Slack #infra --> | |
+| Docker Hub org | <!-- E.g., DevOps team --> | |
+| DNS / nginx | <!-- E.g., Sysadmin --> | `dev.iuga.info`, `staging.iuga.info`, `iuga.info` |
+| MongoDB Atlas | <!-- E.g., Database admin --> | Dev cluster |
+| Production host | <!-- E.g., Sysadmin --> | Physical server access |
+| GitHub repo admin | <!-- E.g., Tech lead --> | `github_classic` token management |
+
+---
+
+## 6. Related Documents
+
+- [Deployment Guide](DEPLOYMENT.md) — Full pipeline walkthrough.
+- [Troubleshooting Guide](TROUBLESHOOTING.md) — Symptom-to-cause diagnosis.
+- [Architecture overview](ARCHITECTURE.md) — System components and data flow.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,152 @@
+# Quickstart Guide
+
+Get the **Informatics Undergraduate Association (IUGA)** website running on your machine for development.
+
+---
+
+## Prerequisites
+
+- **Node.js 22+** (matches the `node:22-alpine` Docker image used in production)
+- **npm** (bundled with Node.js)
+- **Git**
+- **MongoDB** — only needed if you are working on backend features. Frontend development uses mock data.
+
+---
+
+## Installation
+
+```bash
+# Clone the repository with submodules
+git clone --recurse-submodules https://github.com/UW-IUGA/iuga-web-app
+cd iuga-web-app
+
+# If you already cloned without --recurse-submodules:
+git submodule update --init --recursive
+```
+
+---
+
+## Running the App
+
+### Full stack (one command)
+
+```bash
+npm run dev
+```
+
+This builds the frontend and starts the Express backend at **http://localhost:7777**.
+
+### Frontend only (hot reload)
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+Starts the Create React App dev server on **http://localhost:3000** with hot reload. The frontend uses **mock data** — no backend or database needed.
+
+### Backend only
+
+```bash
+cd backend
+npm install
+npm start                    # uses env/.env.dev
+```
+
+The backend requires:
+1. A built frontend at `../frontend/build/` (run `npm run build` in `frontend/`)
+2. Environment files in `backend/env/` (see [Environment Setup](#environment-setup) below)
+3. A MongoDB connection (Atlas for dev)
+
+---
+
+## Environment Setup
+
+### Backend environment files
+
+Backend environment files live in `backend/env/` and are **gitignored** (except `.env.example`).
+
+```
+backend/env/
+├── .env.example       ← Copy this to create your config
+├── .env.dev           ← Used by `npm start`
+├── .env.debug         ← Used by `npm run debug` (must be created)
+└── .env.prod          ← Used by `npm run deploy` (production secrets)
+```
+
+**To create `.env.dev`:**
+
+```bash
+cp backend/env/.env.example backend/env/.env.dev
+# Then edit the file with your actual values
+```
+
+Required variables (see `.env.example`):
+
+| Variable | Purpose |
+|---|---|
+| `PORT` | Server port (default 7777) |
+| `DEPLOY_ENV` | `development`, `staging`, or `production` |
+| `SESSION_SECRET` | Strong random string for session signing |
+| `DB_DEV_USERNAME` | MongoDB Atlas username (dev) |
+| `DB_DEV_PASSWORD` | MongoDB Atlas password (dev) |
+| `DB_PROD_USERNAME` | MongoDB username (prod/staging) |
+| `DB_PROD_PASSWORD` | MongoDB password (prod/staging) |
+
+### Debug backend setup (optional)
+
+The `npm run debug` and `npm run backend-debug` commands load `backend/env/.env.debug` with verbose logging.
+
+```bash
+cp backend/env/.env.example backend/env/.env.debug
+# Edit with your credentials, then:
+npm run backend-debug
+```
+
+> **Note:** `.env.debug` is not committed to the repository. You must create it from `.env.example`. If it is missing, the `debug` scripts will fail with a missing-file error.
+
+### Frontend environment
+
+Frontend env files are checked in:
+
+| File | Variable | Value |
+|---|---|---|
+| `frontend/.env.dev` | `REACT_APP_API_URL` | `http://localhost:7777` |
+| `frontend/.env.production` | `REACT_APP_API_URL` | `https://dev.iuga.info` |
+
+---
+
+## How API Calls Work
+
+The frontend switches between mock data and live API based on `NODE_ENV`:
+
+- **Development** (`NODE_ENV !== "production"`): The frontend imports **mock data** from `src/assets/mock-data/`. No backend or database is needed. This is the default when running `npm start` (CRA dev server) or `npm run dev`.
+- **Production build** (`NODE_ENV === "production"`): The frontend makes direct `fetch()` calls to `REACT_APP_API_URL`. For example:
+  ```js
+  fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/upcoming`)
+  ```
+  This value is substituted at build time. There is **no CRA proxy** — in production builds the frontend is served as static files by the Express backend, and API requests go directly to the same origin.
+
+---
+
+## Verify It Works
+
+1. Run `npm run dev`
+2. Open **http://localhost:7777** in your browser
+3. You should see the IUGA homepage with upcoming events (from mock data)
+4. Confirm no errors appear in the terminal
+
+---
+
+## Next Steps
+
+| If you want to… | Read this |
+|---|---|
+| Understand the project structure | [Architecture](ARCHITECTURE.md) |
+| Start developing features | [Development](DEVELOPMENT.md) |
+| Work on the frontend | [Frontend](FRONTEND.md) |
+| Work on the backend | [Backend](BACKEND.md) |
+| Deploy the app | [Deployment](DEPLOYMENT.md) |
+| Maintain in production | [Maintainers](MAINTAINERS.md) |
+| Fix something broken | [Troubleshooting](TROUBLESHOOTING.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# IUGA Web App — Documentation Index
+
+This directory contains the full documentation set for the **Informatics Undergraduate Association (IUGA)** website application.
+
+> **Looking for the project overview?** See the [project README](../README.md) for quickstart, scripts, and project structure.
+
+## Documents
+
+| Document | Audience | Content |
+|---|---|---|
+| [Quickstart](QUICKSTART.md) | New developers | Prerequisites, installation, environment setup, running the app, verification |
+| [Architecture](ARCHITECTURE.md) | All | Repository structure, system architecture, request flow, authentication flow, deployment boundary |
+| [Development](DEVELOPMENT.md) | Developers | Setup, scripts, environment configuration, code conventions, common tasks, testing |
+| [Frontend](FRONTEND.md) | Frontend devs | Tech stack, directory layout, routing, data flow, authentication, styling, dependencies |
+| [Backend](BACKEND.md) | Backend devs | Entry points, directory layout, SPA routes, API routes, authentication, database, middleware stack, dependencies |
+| [Deployment](DEPLOYMENT.md) | Maintainers | Pipeline overview, Jenkinsfile comparison, credentials, Docker build, runtime architecture, verification, rollback |
+| [Maintainers](MAINTAINERS.md) | Maintainers | Monitoring checks, maintenance procedures, observation points, credential rotation |
+| [Troubleshooting](TROUBLESHOOTING.md) | Developers & maintainers | Pipeline failures, runtime failures, 502 Bad Gateway, stale content, diagnosis sequences |
+
+## Reading Order
+
+1. **New to the project?** Start with [Quickstart](QUICKSTART.md) to get the app running.
+2. **Understand the system?** Read [Architecture](ARCHITECTURE.md) for the big picture.
+3. **Working on a feature?** See [Development](DEVELOPMENT.md) for workflow and conventions, then dive into [Frontend](FRONTEND.md) or [Backend](BACKEND.md).
+4. **Deploying or maintaining?** Read [Deployment](DEPLOYMENT.md) and [Maintainers](MAINTAINERS.md).
+5. **Something broken?** Check [Troubleshooting](TROUBLESHOOTING.md).
+
+## Related
+
+- [UW-IUGA/iuga-web-app](https://github.com/UW-IUGA/iuga-web-app) — Main repository on GitHub
+- [UW-IUGA/iuga-web-schemas](https://github.com/UW-IUGA/iuga-web-schemas) — Shared Mongoose schema definitions (git submodule)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,340 @@
+# Troubleshooting Guide
+
+> **Audience:** Developers and maintainers diagnosing failures in the IUGA Web App pipeline or runtime.
+> **Approach:** Symptoms → probable causes → diagnosis steps.
+> **Reference:** [Deployment Guide](DEPLOYMENT.md), [Maintainers Guide](MAINTAINERS.md).
+
+---
+
+## 1. Pipeline Failures
+
+### 1.1 Checkout: GitHub authentication failure
+
+**Symptom:** Jenkins pipeline fails at the Checkout stage with:
+```
+stderr: fatal: could not read Username for 'https://github.com': terminal prompts disabled
+```
+or
+```
+ERROR: Error cloning remote repo 'origin'
+```
+
+**Probable causes:**
+1. The `github_classic` Jenkins credential has expired (GitHub Personal Access Token expired).
+2. The credential was deleted or renamed in Jenkins.
+3. GitHub app installation permissions changed.
+
+**Diagnosis steps:**
+1. **(Requires Jenkins admin)** Navigate to Jenkins → Credentials → System → Global credentials → `github_classic`.
+2. Verify the credential exists and check its expiry date.
+3. If expired, generate a new GitHub Personal Access Token (`Settings → Developer settings → Personal access tokens → Fine-grained tokens`) with **Contents: Read** and **Metadata: Read** scopes for `UW-IUGA` org repos.
+4. Update the credential in Jenkins.
+
+**Prevention:** Set a calendar reminder 2 weeks before the token's expiry date.
+
+---
+
+### 1.2 Checkout: Submodule fetch failure
+
+**Symptom:** Pipeline fails at the Checkout or Initialize Submodules stage with:
+```
+fatal: could not read Username for 'https://github.com/UW-IUGA/iuga-web-schemas'
+```
+
+**Probable causes:**
+1. The `github_classic` credential lacks access to the submodule repository (`UW-IUGA/iuga-web-schemas`).
+2. The submodule URL in `.gitmodules` has changed (currently: `https://github.com/UW-IUGA/iuga-web-schemas`).
+
+**Diagnosis steps:**
+1. Verify the submodule URL in `.gitmodules` is reachable:
+   ```bash
+   git ls-remote https://github.com/UW-IUGA/iuga-web-schemas
+   ```
+   If this fails from the Jenkins host, the credential or network is the issue.
+2. Confirm the PAT used in `github_classic` has access to `UW-IUGA/iuga-web-schemas`.
+
+---
+
+### 1.3 Build: Docker build fails
+
+**Symptom:** Jenkins fails at the Build stage with:
+```
+The command '/bin/sh -c npm run build' returned a non-zero code
+```
+
+**Probable causes:**
+1. A frontend dependency changed without a lockfile update.
+2. The `sed` transform for API URL substitution failed (unexpected `DEPLOY_ENV` value).
+3. Out of disk space on the Jenkins worker.
+
+**Diagnosis steps:**
+1. Check the Jenkins build log for the specific `npm` or `sed` error.
+2. Verify `DEPLOY_ENV` is one of `development`, `staging`, or `production`.
+3. Reproduce locally:
+   ```bash
+   docker build . -t test --build-arg DEPLOY_ENV=development
+   ```
+
+---
+
+### 1.4 Push: Docker Hub authentication failure
+
+**Symptom:** Jenkins fails at the Push to Registry stage with:
+```
+denied: requested access to the resource is denied
+```
+or
+```
+unauthorized: authentication required
+```
+
+**Probable causes:**
+1. The `dockerhub` Jenkins credential is expired or invalid.
+2. Docker Hub rate limits reached (anonymous pull limits).
+
+**Diagnosis steps:**
+1. **(Requires Jenkins admin)** Check Jenkins → Credentials → `dockerhub` expiry date.
+2. Verify credentials work manually:
+   ```bash
+   echo <password> | docker login --username <username> --password-stdin
+   docker push iuga/iuga-web-app-<env>:latest  # verify push permission
+   ```
+
+---
+
+### 1.5 Deploy: Container fails to start
+
+**Symptom:** Jenkins Deploy stage succeeds but the container exits immediately.
+
+**Probable causes:**
+1. Port conflict on the host (e.g., another process already bound to the port).
+2. MongoDB credentials are incorrect or the DB is unreachable.
+3. Volume mount path `/var/lib/iuga-web-app/uploads/<env>` does not exist on the host.
+
+**Diagnosis steps:**
+1. Check if the container exists:
+   ```bash
+   docker ps -a --filter name=iuga-web-<env>
+   ```
+2. Check logs:
+   ```bash
+   docker logs iuga-web-<env> --tail 50
+   ```
+3. Common log errors:
+   - `MongooseServerSelectionError: getaddrinfo ENOTFOUND mongo` → MongoDB container unreachable (staging/prod only).
+   - `MongooseError: uri` or `Authentication failed` → DB credentials issue.
+   - `EADDRINUSE` → Port already in use on the host.
+4. Verify the uploads directory exists:
+   ```bash
+   ls -la /var/lib/iuga-web-app/uploads/<env>/
+   ```
+
+---
+
+## 2. Runtime Failures
+
+### 2.1 MongoDB connection failure
+
+**Symptom:** Application starts but API requests fail or return 500 errors. Logs show:
+```
+MongooseServerSelectionError: Connection timed out
+```
+
+**Probable causes:**
+1. **Staging / Production:** The `mongo` container is not running or the `iuga-server-config_default` network is disconnected.
+2. **Development:** The MongoDB Atlas cluster IP whitelist has changed (the Jenkins worker's IP may have changed).
+3. Database credentials were rotated in Jenkins but the container was not re-deployed (environment variables are injected at `docker run` time).
+
+**Diagnosis steps:**
+
+*Staging / Production:*
+```bash
+# Check MongoDB container
+docker ps --filter name=mongo
+# Check network
+docker network inspect iuga-server-config_default | grep iuga-web-<env>
+# Test connectivity from app container
+docker exec iuga-web-<env> ping mongo
+```
+
+*Development:*
+Check that the Jenkins worker's public IP is whitelisted in MongoDB Atlas (Project → Network Access → IP Whitelist).
+
+---
+
+### 2.2 Application crashes on startup
+
+**Symptom:** Container exits within seconds of starting. `docker ps -a` shows `STATUS Exited`.
+
+**Probable causes:**
+1. Missing `.env.prod` file (the runtime stage copies `backend/` but `.env.prod` is gitignored and must exist on the build host).
+2. Node.js `app.js` throws an uncaught exception during `import`.
+
+**Diagnosis steps:**
+1. Check full logs:
+   ```bash
+   docker logs iuga-web-<env>
+   ```
+2. Look for the exact stack trace.
+3. Common pattern: `Error [ERR_MODULE_NOT_FOUND]` — a new import was added but the dependency is missing.
+
+---
+
+### 2.3 Uploads directory missing
+
+**Symptom:** File uploads fail or return 500 errors. Logs show `ENOENT: no such file or directory`.
+
+**Cause:** The volume mount path `/var/lib/iuga-web-app/uploads/<env>` does not exist on the host.
+
+**Fix (requires host access):**
+```bash
+sudo mkdir -p /var/lib/iuga-web-app/uploads/<env>
+# Then redeploy or restart the container
+```
+
+---
+
+## 3. 502 Bad Gateway
+
+**Symptom:** `https://<domain>/` returns HTTP 502 from nginx. The page shows "502 Bad Gateway" or a generic nginx error.
+
+**Diagnosis sequence (least to most invasive):**
+
+### Step 1 — Is the container running?
+
+```bash
+# Requires host access
+docker ps --filter name=iuga-web-<env>
+```
+
+If the container is not running, check `docker ps -a` to see if it exited:
+- **Exited:** follow [Application crashes on startup](#22-application-crashes-on-startup).
+- **Not found:** the deployment may not have run yet, or the container was manually removed.
+
+### Step 2 — Is the container listening on the expected port?
+
+The application listens on port 7777 inside the container. The host port depends on the environment:
+
+| Environment | Host port | Container port |
+|---|---|---|
+| Dev | 6666 | 7777 |
+| Staging | 7777 | 7777 |
+| Production | 8888 | 7777 |
+
+Verify the port mapping:
+```bash
+docker port iuga-web-<env>
+```
+
+Expected output: `7777/tcp → 127.0.0.1:<host-port>`
+
+If no ports are shown, the `-p` flag was omitted from `docker run`.
+
+### Step 3 — Can you reach the application from the host?
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:<host-port>/
+```
+
+- **200:** The app is healthy. The issue is in nginx configuration (TLS, proxy_pass URL, upstream definition). **Not managed by this repo.**
+- **000 or connection refused:** The container is not listening. Check logs.
+- **Other status:** The app returned a response but nginx may be misconfigured.
+
+### Step 4 — Check nginx configuration (external boundary)
+
+The nginx proxy is not managed by this repository. Common issues:
+
+- `proxy_pass` URL points to the wrong port.
+- The upstream server is defined but the container is on a different network.
+- TLS certificate expired (shows as certificate error in browser, or nginx refuses to start).
+
+**Check nginx config (if accessible):**
+```bash
+nginx -t
+```
+
+**Expected:** `syntax is ok` / `test is successful`
+
+### Step 5 — Restart steps
+
+Only try these if Steps 1–4 confirm the container is healthy and nginx is the issue.
+
+1. Restart nginx (requires host access):
+   ```bash
+   sudo nginx -s reload
+   ```
+2. Or check if the container needs restarting:
+   ```bash
+   docker restart iuga-web-<env>
+   ```
+
+---
+
+## 4. Stale Content
+
+**Symptom:** The live site shows old content even after a successful Jenkins deployment.
+
+**Probable causes:**
+1. Browser cache (hard refresh usually fixes — `Cmd+Shift+R` on macOS).
+2. nginx cache is serving a stale response.
+3. The old container was not stopped (check `docker ps` for multiple `iuga-web-` containers).
+4. The deployment is still in progress (check Jenkins build for that environment).
+
+**Diagnosis:**
+1. Append a query parameter: `https://<domain>/?_t=<timestamp>`.
+2. Run from the host:
+   ```bash
+   curl -s -I https://<domain>/ | grep -i "x-cache\|age\|etag"
+   ```
+3. Check container images:
+   ```bash
+   docker inspect iuga-web-<env> --format '{{.Config.Image}}'
+   ```
+   Compare with the latest tag on Docker Hub.
+
+---
+
+## 5. Jenkins Build Status Not Updating in GitHub
+
+**Symptom:** Jenkins pipeline runs successfully but the GitHub commit status remains yellow/pending or doesn't appear.
+
+**Probable causes:**
+1. The `github_classic` credential is expired (affects the `setBuildStatus` API calls).
+2. The GitHub API URL in `setBuildStatus` is wrong (currently: `https://api.github.com/repos/UW-IUGA/iuga-web-app/statuses/$gitCommit`).
+
+**Diagnosis:**
+1. Check if the `setBuildStatus` calls succeed in Jenkins build logs. Search for `curl -X POST` output.
+2. Verify the credential:
+   ```bash
+   curl -u <username>:<token> https://api.github.com/repos/UW-IUGA/iuga-web-app
+   ```
+   Should return repo metadata, not `401`.
+
+---
+
+## 6. Pipeline Stage Summary
+
+| Stage | What to check if it fails | Credential required |
+|---|---|---|
+| Checkout | `github_classic` validity, repo access, network | `github_classic` |
+| Initialize Submodules | Submodule repo access, `.gitmodules` correctness | `github_classic` |
+| Build | `npm` errors, `sed` transform, disk space | None |
+| Push to Registry | Docker Hub auth, rate limits, image name | `dockerhub` |
+| Deploy | Port conflict, DB credentials, volume path, network | `devDBUsername`/`devDBPassword` or `prodDBUsername`/`prodDBPassword` |
+
+---
+
+## 7. Known Failure Modes Not Yet Documented
+
+If you encounter a failure not covered by this guide, capture the following and escalate:
+
+1. Exact error message from Jenkins build log.
+2. Container status and logs (`docker ps -a`, `docker logs iuga-web-<env> --tail 100`).
+3. Any recent changes to Jenkins credentials, Docker Hub, or host configuration.
+
+---
+
+## 8. Related Documents
+
+- [Deployment Guide](DEPLOYMENT.md) — Verified pipeline steps and expected outcomes.
+- [Maintainers Guide](MAINTAINERS.md) — Safe monitoring and maintenance procedures.


### PR DESCRIPTION
## Summary

Adds the project's first documentation set — nine guides under `docs/` covering
quickstart, architecture, development, frontend, backend, deployment,
maintainers, and troubleshooting — and rewrites the root README from a one-line
script note into the project entry point with quickstart, documentation index,
and project structure overview.

## Rationale

The repo had no onboarding material: the README was a single line and nothing
explained the architecture, Microsoft Graph authentication flow, deployment
pipeline, or how to diagnose failures. New contributors had to reverse-engineer
the stack from scratch. This change makes `docs/` the starting point for anyone
working on the project.