### PR TITLE
ci(db): inject DB_*_URI env in deploy pipelines

### DIFF
--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -53,14 +53,12 @@ pipeline {
                 sh 'docker pull iuga/iuga-web-app-development'
                 sh 'docker rm -f iuga-web-dev || true'
                 withCredentials([
-                    string(credentialsId: 'devDBUsername', variable: 'DB_DEV_USERNAME'),
-                    string(credentialsId: 'devDBPassword', variable: 'DB_DEV_PASSWORD'),
+                    string(credentialsId: 'devDBUri', variable: 'DB_DEV_URI'),
                 ]) {
                     sh '''
                     docker run -d -p "127.0.0.1:6666:7777" --name iuga-web-dev \
                     -e DEPLOY_ENV=development \
-                    -e DB_DEV_USERNAME="$DB_DEV_USERNAME" \
-                    -e DB_DEV_PASSWORD="$DB_DEV_PASSWORD" \
+                    -e DB_DEV_URI="$DB_DEV_URI" \
                     -v /var/lib/iuga-web-app/uploads/dev:/app/backend/public/uploads \
                     iuga/iuga-web-app-development
                     '''

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -81,10 +81,8 @@ Required variables (see `.env.example`):
 | `PORT` | Server port (default 7777) |
 | `DEPLOY_ENV` | `development`, `staging`, or `production` |
 | `SESSION_SECRET` | Strong random string for session signing |
-| `DB_DEV_USERNAME` | MongoDB Atlas username (dev) |
-| `DB_DEV_PASSWORD` | MongoDB Atlas password (dev) |
-| `DB_PROD_USERNAME` | MongoDB username (prod/staging) |
-| `DB_PROD_PASSWORD` | MongoDB password (prod/staging) |
+| `DB_DEV_URI` | Full MongoDB Atlas connection string (dev), e.g. `mongodb+srv://<user>:<pass>@cluster...` |
+| `DB_PROD_URI` | Full MongoDB connection string (prod/staging), e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` |
 
 Frontend environment (checked in):
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -151,7 +151,7 @@ docker exec iuga-web-<env> node -e "
 | HTTP 502 from host `curl` | Container not listening or wrong port | `docker ps`, check port mapping |
 | Stale content served | nginx cache or old container still running | `docker ps`, verify correct image tag |
 | `docker push` fails in Jenkins | Docker Hub credential expired or rate-limited | Renew `dockerhub` credential in Jenkins |
-| MongoDB connection failure | Network down, Atlas IP whitelist changed, credentials rotated | Verify network, check `DB_PROD_USERNAME`/`DB_PROD_PASSWORD` |
+| MongoDB connection failure | Network down, Atlas IP whitelist changed, credentials rotated | Verify network, check `DB_PROD_URI`/`DB_DEV_URI` |
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -89,10 +89,8 @@ Required variables (see `.env.example`):
 | `PORT` | Server port (default 7777) |
 | `DEPLOY_ENV` | `development`, `staging`, or `production` |
 | `SESSION_SECRET` | Strong random string for session signing |
-| `DB_DEV_USERNAME` | MongoDB Atlas username (dev) |
-| `DB_DEV_PASSWORD` | MongoDB Atlas password (dev) |
-| `DB_PROD_USERNAME` | MongoDB username (prod/staging) |
-| `DB_PROD_PASSWORD` | MongoDB password (prod/staging) |
+| `DB_DEV_URI` | Full MongoDB Atlas connection string (dev), e.g. `mongodb+srv://<user>:<pass>@cluster...` |
+| `DB_PROD_URI` | Full MongoDB connection string (prod/staging), e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` |
 
 ### Debug backend setup (optional)
 

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -53,14 +53,12 @@ pipeline {
                 sh 'docker pull iuga/iuga-web-app-production'
                 sh 'docker rm -f iuga-web-prod || true'
                 withCredentials([
-                    string(credentialsId: 'prodDBUsername', variable: 'DB_PROD_USERNAME'),
-                    string(credentialsId: 'prodDBPassword', variable: 'DB_PROD_PASSWORD'),
+                    string(credentialsId: 'prodDBUri', variable: 'DB_PROD_URI'),
                 ]) {
                     sh '''
                     docker run -d -p "127.0.0.1:8888:7777" --name iuga-web-prod \
                     -e DEPLOY_ENV=production \
-                    -e DB_PROD_USERNAME="$DB_PROD_USERNAME" \
-                    -e DB_PROD_PASSWORD="$DB_PROD_PASSWORD" \
+                    -e DB_PROD_URI="$DB_PROD_URI" \
                     -v /var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads \
                     --network iuga-server-config_default \
                     iuga/iuga-web-app-production

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -42,14 +42,12 @@ pipeline {
         sh 'docker pull iuga/iuga-web-app-staging'
         sh 'docker rm -f iuga-web-staging || true'
         withCredentials([
-          string(credentialsId: 'prodDBUsername', variable: 'DB_PROD_USERNAME'),
-          string(credentialsId: 'prodDBPassword', variable: 'DB_PROD_PASSWORD'),
+          string(credentialsId: 'prodDBUri', variable: 'DB_PROD_URI'),
         ]) {
           sh '''
             docker run -d -p "127.0.0.1:7777:7777" --name iuga-web-staging \
             -e DEPLOY_ENV=staging \
-            -e DB_PROD_USERNAME="$DB_PROD_USERNAME" \
-            -e DB_PROD_PASSWORD="$DB_PROD_PASSWORD" \
+            -e DB_PROD_URI="$DB_PROD_URI" \
             -v /var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads \
             --network iuga-server-config_default \
             iuga/iuga-web-app-staging


### PR DESCRIPTION
## Summary

Updates the deploy pipelines and docs to the new env contract from #5: Jenkins now injects a single `DB_DEV_URI` / `DB_PROD_URI` (full connection string) instead of the removed `DB_*_USERNAME` / `DB_*_PASSWORD` pairs.

## Rationale

After #5, `backend/models.js` only reads `DB_DEV_URI` / `DB_PROD_URI` and fails loudly at startup when they are missing. The Jenkinsfiles still injected the old variable names, so every dev/staging/prod deployment would have failed to boot. Pipelines now consume new Secret-text credentials (`devDBUri`, `prodDBUri`) that hold the full connection strings; docs reflect the same contract.
