### PR TITLE
refactor(api): unify error/success responses and repair withdraw

### DIFF
--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -8,6 +8,8 @@ Schemas addressed in events.js:
 
 import express from "express";
 import mongoose from "mongoose";
+import { sendError } from "../helpers/sendError.js";
+import { sendSuccess } from "../helpers/sendSuccess.js";
 
 var router = express.Router();
 //-------------------------------Event Endpoints----------------------------------------------
@@ -83,9 +85,7 @@ router.get("/", async function (req, res) {
     }
   } catch (error) {
     console.log(error);
-    res
-      .status(500)
-      .json({ status: "error", message: "There was an error on our side :(" });
+    return sendError(res, 500);
   }
 });
 
@@ -124,7 +124,7 @@ router.get("/id/:eId", async function (req, res) {
         .populate("eParticipants", "pUID")
         .exec();
       if (event == null) {
-        res.status(404).json({ status: "error", message: "Event not found" });
+        return sendError(res, 404, "Event not found");
       } else {
         let hasRSVPd = false;
         let rsvpAnswers = [];
@@ -169,13 +169,11 @@ router.get("/id/:eId", async function (req, res) {
       }
     } else {
       console.error(`/events/id/${eId} Failed regex test!`);
-      res.status(400).json({ status: "error", message: "Bad request..." });
+      return sendError(res, 400, "Bad request...");
     }
   } catch (error) {
     console.log(error);
-    res
-      .status(500)
-      .json({ status: "error", message: "Sorry something bad happened :(" });
+    return sendError(res, 500);
   }
 });
 
@@ -226,12 +224,7 @@ router.get("/upcoming", async function (req, res) {
     res.json(events);
   } catch (error) {
     console.log(error);
-    res
-      .status(500)
-      .json({
-        status: "error",
-        message: "Sorry! Something happened on our side :(",
-      });
+    return sendError(res, 500);
   }
 });
 
@@ -246,12 +239,12 @@ Expected Request Information (<r> indicates a required field to include in the c
             <r> uId: Current user's id to add them to event,
             <r> eId: find the event,
             aList: Array of key:value pairs with question number and answer string,
-            isAnon: Boolean if user is participating anon or not 
+            isAnon: Boolean if user is participating anon or not
         }
 
 Expected Response Information:
 - {
-    status:"Success"
+    status: "success"
   }
 */
 router.post("/rsvp", async function (req, res) {
@@ -265,30 +258,19 @@ router.post("/rsvp", async function (req, res) {
       const userObjectId = mongoose.Types.ObjectId(req.session.userId);
 
       if (!event) {
-          .status(404)
-          .json({ status: "error", message: "Event not found" });
+        return sendError(res, 404, "Event not found");
       }
 
       // Check if RSVP is enabled for this event
       if (!event.eRsvpEnabled) {
-        return res
-          .status(400)
-          .json({
-            status: "error",
-            message: "RSVP is not enabled for this event",
-          });
+        return sendError(res, 400, "RSVP is not enabled for this event");
       }
 
       // Check if today's date is past the start date
       const today = new Date();
       const eventStartDate = new Date(event.eStartDate);
       if (today > eventStartDate) {
-        return res
-          .status(400)
-          .json({
-            status: "error",
-            message: "The event has already started or passed.",
-          });
+        return sendError(res, 400, "The event has already started or passed.");
       }
 
       // Check if the user is already a participant
@@ -296,9 +278,7 @@ router.post("/rsvp", async function (req, res) {
         participant.pUID.equals(userObjectId),
       );
       if (userIsParticipant) {
-        return res
-          .status(400)
-          .json({ status: "error", message: "You already RSVPd!" });
+        return sendError(res, 400, "You already RSVPd!");
       }
 
       const newParticipant = new req.models.Participants({
@@ -313,18 +293,13 @@ router.post("/rsvp", async function (req, res) {
 
       await event.save();
 
-      res.status(200).json({ status: "success", message: "RSVP successful!" });
+      return sendSuccess(res, { message: "RSVP successful!" });
     } else {
-      res.status(401).json({
-        status: "error",
-        error: "User is not logged in",
-      });
+      return sendError(res, 401, "User is not logged in");
     }
   } catch (error) {
     console.log(error);
-    res
-      .status(500)
-      .json({ status: "error", message: "Something bad happened :(" });
+    return sendError(res, 500);
   }
 });
 
@@ -339,7 +314,7 @@ Expected Request Information (<r> indicates a required field to include in the c
 
 Expected Response Information:
 - {
-    status:"Success"
+    status: "success"
   }
 */
 router.delete("/withdraw/:eId/:pId", async function (req, res) {
@@ -359,18 +334,13 @@ router.delete("/withdraw/:eId/:pId", async function (req, res) {
       event.eParticipants = newParticipants;
       await event.save();
 
-      res.json({ status: "Success" });
+      return sendSuccess(res);
     } else {
-      res.status(401).json({
-        status: "error",
-        message: "User is not logged in",
-      });
+      return sendError(res, 401, "User is not logged in");
     }
   } catch (error) {
     console.log(error);
-    res
-      .status(500)
-      .json({ status: "error", error: "Something bad happened :(" });
+    return sendError(res, 500);
   }
 });
 
@@ -380,9 +350,7 @@ router.get("/:pId", async function (req, res) {
     const pId = req.params.pId;
     const participant = await req.models.Participants.findById(pId);
     if (!participant) {
-      return res
-        .status(404)
-        .json({ status: "error", message: "Participant not found." });
+      return sendError(res, 404, "Participant not found.");
     }
     const participantData = {
       id: pId,
@@ -391,13 +359,12 @@ router.get("/:pId", async function (req, res) {
       isAnon: participant.isAnon,
     };
     // fix this
-    res.json({ status: "Success", participant: participantData });
+    return sendSuccess(res, { participant: participantData });
   } catch (error) {
     console.log(error);
-    res
-      .status(500)
-      .json({ status: "error", message: "Sorry something bad happened :(" });
+    return sendError(res, 500);
   }
 });
 
 export default router;
+

--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -124,7 +124,7 @@ router.get("/id/:eId", async function (req, res) {
         .populate("eParticipants", "pUID")
         .exec();
       if (event == null) {
-        res.status(400).json({ status: "error", message: "Bad request..." });
+        res.status(404).json({ status: "error", message: "Event not found" });
       } else {
         let hasRSVPd = false;
         let rsvpAnswers = [];
@@ -265,8 +265,7 @@ router.post("/rsvp", async function (req, res) {
       const userObjectId = mongoose.Types.ObjectId(req.session.userId);
 
       if (!event) {
-        return res
-          .status(400)
+          .status(404)
           .json({ status: "error", message: "Event not found" });
       }
 
@@ -348,23 +347,23 @@ router.delete("/withdraw/:eId/:pId", async function (req, res) {
     if (req.session.isAuthenticated) {
       const pId = req.params.pId;
       const eId = req.params.eId;
-      const event = await req.models.Events.findById({ eId });
+      const event = await req.models.Events.findById(eId);
 
       let newParticipants = [];
-      event.participants.forEach((participant) => {
-        if (participant != pId) {
+      event.eParticipants.forEach((participant) => {
+        if (participant.toString() !== pId) {
           newParticipants.push(participant);
         }
       });
 
-      event.participants = newParticipants;
+      event.eParticipants = newParticipants;
       await event.save();
 
       res.json({ status: "Success" });
     } else {
-      res.status(400).json({
+      res.status(401).json({
         status: "error",
-        error: "User is not logged in",
+        message: "User is not logged in",
       });
     }
   } catch (error) {
@@ -379,7 +378,7 @@ router.delete("/withdraw/:eId/:pId", async function (req, res) {
 router.get("/:pId", async function (req, res) {
   try {
     const pId = req.params.pId;
-    const participant = await req.models.Participants.findById({ pId });
+    const participant = await req.models.Participants.findById(pId);
     if (!participant) {
       return res
         .status(404)

--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -6,8 +6,8 @@ Schemas addressed in events.js:
 - Participants
 */
 
-import express from 'express';
-import mongoose from 'mongoose';
+import express from "express";
+import mongoose from "mongoose";
 
 var router = express.Router();
 //-------------------------------Event Endpoints----------------------------------------------
@@ -33,54 +33,60 @@ Expected Response Information:
             eLabels: Array of String event category label(s)
         }]
 */
-router.get("/", async function(req, res) {
-    try {
-        if (req.session.isAuthenticated) {
-            const events = await req.models.Events.find({}).populate('eParticipants').exec();
-            const userObjectId = mongoose.Types.ObjectId(req.session.userId);
+router.get("/", async function (req, res) {
+  try {
+    if (req.session.isAuthenticated) {
+      const events = await req.models.Events.find({})
+        .populate("eParticipants")
+        .exec();
+      const userObjectId = mongoose.Types.ObjectId(req.session.userId);
 
-            const eventsData = await Promise.all(
-                events.map(async event => {
-                    const hasRSVPd = event.eParticipants.some(participant => participant.pUID.equals(userObjectId));
-                    return {
-                        eId:event._id,
-                        eName:event.eName,
-                        eStartDate:event.eStartDate,
-                        eEndDate:event.eEndDate,
-                        eLocation:event.eLocation,
-                        eOrganizers: event.eOrganizers,
-                        eDescription: event.eDescription,
-                        eLabels: event.eLabels,
-                        hasRSVPd: hasRSVPd
-                    };
-                })
-            );
+      const eventsData = await Promise.all(
+        events.map(async (event) => {
+          const hasRSVPd = event.eParticipants.some((participant) =>
+            participant.pUID.equals(userObjectId),
+          );
+          return {
+            eId: event._id,
+            eName: event.eName,
+            eStartDate: event.eStartDate,
+            eEndDate: event.eEndDate,
+            eLocation: event.eLocation,
+            eOrganizers: event.eOrganizers,
+            eDescription: event.eDescription,
+            eLabels: event.eLabels,
+            hasRSVPd: hasRSVPd,
+          };
+        }),
+      );
 
-            res.json(eventsData);
-        } else {
-            const events = await req.models.Events.find({})  
-            const eventsData = await Promise.all(
-                events.map(async event => {
-                    return {
-                        eId:event._id,
-                        eName:event.eName,
-                        eStartDate:event.eStartDate,
-                        eEndDate:event.eEndDate,
-                        eLocation:event.eLocation,
-                        eOrganizers: event.eOrganizers,
-                        eDescription: event.eDescription,
-                        eLabels: event.eLabels,
-                        hasRSVPd: false
-                    };
-                })
-            );
+      res.json(eventsData);
+    } else {
+      const events = await req.models.Events.find({});
+      const eventsData = await Promise.all(
+        events.map(async (event) => {
+          return {
+            eId: event._id,
+            eName: event.eName,
+            eStartDate: event.eStartDate,
+            eEndDate: event.eEndDate,
+            eLocation: event.eLocation,
+            eOrganizers: event.eOrganizers,
+            eDescription: event.eDescription,
+            eLabels: event.eLabels,
+            hasRSVPd: false,
+          };
+        }),
+      );
 
-            res.json(eventsData);
-        }
-    } catch (error) {
-        console.log(error);
-        res.status(500).json({status:"error", message: "There was an error on our side :("});
+      res.json(eventsData);
     }
+  } catch (error) {
+    console.log(error);
+    res
+      .status(500)
+      .json({ status: "error", message: "There was an error on our side :(" });
+  }
 });
 
 /*
@@ -108,61 +114,70 @@ Expected Response Information:
             eThumbnail: a Image of event
         }]
 */
-router.get("/id/:eId", async function(req,res) {
-    //When getting an event based on an id, get all info about the event asked for
-    try {
-        const eId = req.params.eId;
-        const regex = new RegExp("[0-9A-Fa-f]{24}");
-        if (regex.test(eId)) {
-            const event = await req.models.Events.findById(eId).populate('eParticipants', 'pUID').exec();
-            if (event == null) {
-                res.status(400).json({status:"error", message: "Bad request..."});
-            } else {
-                let hasRSVPd = false;
-                let rsvpAnswers = [];
-                if (req.session.isAuthenticated) {
-                    const userObjectId = mongoose.Types.ObjectId(req.session.userId);
-                    const participant = await req.models.Participants.findOne({ pUID: userObjectId, eID: eId }).exec();
-                    if (participant) {
-                        hasRSVPd = true;
-                        rsvpAnswers = participant.rsvpAnswers.map(answer => ({
-                            qId: answer.qId,
-                            aString: answer.aString
-                        }));
-                    }
-                }
-
-                const eventData = {
-                    eId:event._id,
-                    eName:event.eName,
-                    eOrganizers:event.eOrganizers,
-                    eStartDate:event.eStartDate,
-                    eEndDate:event.eEndDate,
-                    eLocation:event.eLocation,
-                    eDescription:event.eDescription,
-                    ePics:event.ePics,
-                    eLabels:event.eLabels,
-                    rsvpQuestions: event.rsvpQuestions,
-                    rsvpAnswers: rsvpAnswers,
-                    participants: event.eShowParticipants ? event.eParticipants.length : null,
-                    showParticipants: event.eShowParticipants,
-                    eThumbnailPath: event.eThumbnailPath,
-                    rsvpEnabled: event.eRsvpEnabled,
-                    eAltLink: event.eAltLink,
-                    hasRSVPd: hasRSVPd
-                };
-
-                res.json(eventData);
-            }
-        } else {
-            console.error(`/events/id/${eId} Failed regex test!`);
-            res.status(400).json({status:"error", message: "Bad request..."});
+router.get("/id/:eId", async function (req, res) {
+  //When getting an event based on an id, get all info about the event asked for
+  try {
+    const eId = req.params.eId;
+    const regex = new RegExp("[0-9A-Fa-f]{24}");
+    if (regex.test(eId)) {
+      const event = await req.models.Events.findById(eId)
+        .populate("eParticipants", "pUID")
+        .exec();
+      if (event == null) {
+        res.status(400).json({ status: "error", message: "Bad request..." });
+      } else {
+        let hasRSVPd = false;
+        let rsvpAnswers = [];
+        if (req.session.isAuthenticated) {
+          const userObjectId = mongoose.Types.ObjectId(req.session.userId);
+          const participant = await req.models.Participants.findOne({
+            pUID: userObjectId,
+            eID: eId,
+          }).exec();
+          if (participant) {
+            hasRSVPd = true;
+            rsvpAnswers = participant.rsvpAnswers.map((answer) => ({
+              qId: answer.qId,
+              aString: answer.aString,
+            }));
+          }
         }
-    } catch (error) {
-        console.log(error);
-        res.status(500).json({status:"error", message: "Sorry something bad happened :("});
+
+        const eventData = {
+          eId: event._id,
+          eName: event.eName,
+          eOrganizers: event.eOrganizers,
+          eStartDate: event.eStartDate,
+          eEndDate: event.eEndDate,
+          eLocation: event.eLocation,
+          eDescription: event.eDescription,
+          ePics: event.ePics,
+          eLabels: event.eLabels,
+          rsvpQuestions: event.rsvpQuestions,
+          rsvpAnswers: rsvpAnswers,
+          participants: event.eShowParticipants
+            ? event.eParticipants.length
+            : null,
+          showParticipants: event.eShowParticipants,
+          eThumbnailPath: event.eThumbnailPath,
+          rsvpEnabled: event.eRsvpEnabled,
+          eAltLink: event.eAltLink,
+          hasRSVPd: hasRSVPd,
+        };
+
+        res.json(eventData);
+      }
+    } else {
+      console.error(`/events/id/${eId} Failed regex test!`);
+      res.status(400).json({ status: "error", message: "Bad request..." });
     }
-})
+  } catch (error) {
+    console.log(error);
+    res
+      .status(500)
+      .json({ status: "error", message: "Sorry something bad happened :(" });
+  }
+});
 
 /*
 Purpose: For the homepage's 3 displayed latest events
@@ -185,36 +200,40 @@ Expected Response Information:
             eThumbnail: a Image of event
         }]
 */
-router.get("/upcoming", async function(req, res) {
-    try {
-        const events = await req.models.Events.aggregate([
-            {
-                $project: {
-                    eId: "$_id",
-                    eName: 1,
-                    eOrganizers: 1,
-                    eDescription: 1,
-                    eLabels: 1,
-                    eStartDate: 1,
-                    eThumbnailPath: 1,
-                    _id: 0 // Exclude the original _id field
-                }
-            },
-            {
-                $sort: { eStartDate: -1 }
-            },
-            {
-                $limit: 3
-            }
-        ]);
-        
-        res.json(events);
-    } catch (error) {
-        console.log(error);
-        res.status(500).json({status:"error", message: "Sorry! Something happened on our side :("});    
-    }
-})
+router.get("/upcoming", async function (req, res) {
+  try {
+    const events = await req.models.Events.aggregate([
+      {
+        $project: {
+          eId: "$_id",
+          eName: 1,
+          eOrganizers: 1,
+          eDescription: 1,
+          eLabels: 1,
+          eStartDate: 1,
+          eThumbnailPath: 1,
+          _id: 0, // Exclude the original _id field
+        },
+      },
+      {
+        $sort: { eStartDate: -1 },
+      },
+      {
+        $limit: 3,
+      },
+    ]);
 
+    res.json(events);
+  } catch (error) {
+    console.log(error);
+    res
+      .status(500)
+      .json({
+        status: "error",
+        message: "Sorry! Something happened on our side :(",
+      });
+  }
+});
 
 /*
 Purpose: User signs up as a participant to an event
@@ -235,62 +254,80 @@ Expected Response Information:
     status:"Success"
   }
 */
-router.post("/rsvp", async function(req,res) { 
-    //Using the given event id and user id parameters, create a participant profile for the user and this pId into the event's participant list
-    try {
-        if(req.session.isAuthenticated) {
-            const { eId, rsvpAnswers } = req.body;
-            const event = await req.models.Events.findById(eId).populate('eParticipants').exec();
-            const userObjectId = mongoose.Types.ObjectId(req.session.userId);
+router.post("/rsvp", async function (req, res) {
+  //Using the given event id and user id parameters, create a participant profile for the user and this pId into the event's participant list
+  try {
+    if (req.session.isAuthenticated) {
+      const { eId, rsvpAnswers } = req.body;
+      const event = await req.models.Events.findById(eId)
+        .populate("eParticipants")
+        .exec();
+      const userObjectId = mongoose.Types.ObjectId(req.session.userId);
 
-            if (!event) {
-                return res.status(400).json({ status: 'error', message: 'Event not found' });
-            }
+      if (!event) {
+        return res
+          .status(400)
+          .json({ status: "error", message: "Event not found" });
+      }
 
-            // Check if RSVP is enabled for this event
-            if (!event.eRsvpEnabled) {
-                return res.status(400).json({ status: 'error', message: 'RSVP is not enabled for this event' });
-            }
+      // Check if RSVP is enabled for this event
+      if (!event.eRsvpEnabled) {
+        return res
+          .status(400)
+          .json({
+            status: "error",
+            message: "RSVP is not enabled for this event",
+          });
+      }
 
-            // Check if today's date is past the start date
-            const today = new Date();
-            const eventStartDate = new Date(event.eStartDate);
-            if (today > eventStartDate) {
-                return res.status(400).json({ status: 'error', message: 'The event has already started or passed.' });
-            }
-    
-            // Check if the user is already a participant
-            const userIsParticipant = event.eParticipants.some(participant => participant.pUID.equals(userObjectId));
-            if (userIsParticipant) {
-                return res.status(400).json({ status: 'error', message: 'You already RSVPd!' });
-            }
+      // Check if today's date is past the start date
+      const today = new Date();
+      const eventStartDate = new Date(event.eStartDate);
+      if (today > eventStartDate) {
+        return res
+          .status(400)
+          .json({
+            status: "error",
+            message: "The event has already started or passed.",
+          });
+      }
 
-            const newParticipant = new req.models.Participants({
-                pUID: userObjectId,
-                eID: eId, 
-                rsvpAnswers: rsvpAnswers,
-            });
-    
+      // Check if the user is already a participant
+      const userIsParticipant = event.eParticipants.some((participant) =>
+        participant.pUID.equals(userObjectId),
+      );
+      if (userIsParticipant) {
+        return res
+          .status(400)
+          .json({ status: "error", message: "You already RSVPd!" });
+      }
 
-            const savedParticipant = await newParticipant.save();
+      const newParticipant = new req.models.Participants({
+        pUID: userObjectId,
+        eID: eId,
+        rsvpAnswers: rsvpAnswers,
+      });
 
-            event.eParticipants.push(savedParticipant);
+      const savedParticipant = await newParticipant.save();
 
-            await event.save();
+      event.eParticipants.push(savedParticipant);
 
-            res.status(200).json({ status: 'success', message: 'RSVP successful!' });
-        } else {
-            res.status(401).json({
-                status: "error",
-                error: "User is not logged in"
-            })
-        }
-    } catch (error) {
-        console.log(error);
-        res.status(500).json({status:"error", message: "Something bad happened :("});
+      await event.save();
+
+      res.status(200).json({ status: "success", message: "RSVP successful!" });
+    } else {
+      res.status(401).json({
+        status: "error",
+        error: "User is not logged in",
+      });
     }
-})
-
+  } catch (error) {
+    console.log(error);
+    res
+      .status(500)
+      .json({ status: "error", message: "Something bad happened :(" });
+  }
+});
 
 /*
 Purpose: User withdraws from an event
@@ -306,56 +343,62 @@ Expected Response Information:
     status:"Success"
   }
 */
-router.delete("/withdraw/:eId/:pId", async function(req,res) {
-    try {
-        if(req.session.isAuthenticated) {
-            const pId = req.params.pId;
-            const eId = req.params.eId;
-            const event = await req.models.Events.findById({eId});
-            
-            let newParticipants = [] 
-            event.participants.forEach(participant => { 
-                if(participant != pId) { 
-                    newParticipants.push(participant); 
-                }
-            });
+router.delete("/withdraw/:eId/:pId", async function (req, res) {
+  try {
+    if (req.session.isAuthenticated) {
+      const pId = req.params.pId;
+      const eId = req.params.eId;
+      const event = await req.models.Events.findById({ eId });
 
-            event.participants = newParticipants;
-            await event.save();
+      let newParticipants = [];
+      event.participants.forEach((participant) => {
+        if (participant != pId) {
+          newParticipants.push(participant);
+        }
+      });
 
-            res.json({status:"Success"});
-        } else {
-            res.status(400).json({
-                status: "error",
-                error: "User is not logged in"
-            })        
-        } 
-    } catch (error) {
-        console.log(error);
-        res.status(500).json({status:"error", error: "Something bad happened :("});
+      event.participants = newParticipants;
+      await event.save();
+
+      res.json({ status: "Success" });
+    } else {
+      res.status(400).json({
+        status: "error",
+        error: "User is not logged in",
+      });
     }
-})
+  } catch (error) {
+    console.log(error);
+    res
+      .status(500)
+      .json({ status: "error", error: "Something bad happened :(" });
+  }
+});
 
 //Given a participant's id, pull their answer list, user profile, and other info about them
-router.get("/:pId", async function(req, res) {
-    try {
-        const pId = req.params.pId;
-        const participant = await req.models.Participants.findById({pId});
-        if (!participant) {
-            return res.status(404).json({status:"error", message:"Participant not found."});
-        }
-        const participantData = {
-            id: pId,
-            userId: participant.pUID,
-            aList: participant.aList,
-            isAnon: participant.isAnon
-        }
-        // fix this
-        res.json({status:"Success", participant: participantData});
-    } catch (error) {
-        console.log(error);
-        res.status(500).json({status:"error", message: "Sorry something bad happened :("});
+router.get("/:pId", async function (req, res) {
+  try {
+    const pId = req.params.pId;
+    const participant = await req.models.Participants.findById({ pId });
+    if (!participant) {
+      return res
+        .status(404)
+        .json({ status: "error", message: "Participant not found." });
     }
-})
+    const participantData = {
+      id: pId,
+      userId: participant.pUID,
+      aList: participant.aList,
+      isAnon: participant.isAnon,
+    };
+    // fix this
+    res.json({ status: "Success", participant: participantData });
+  } catch (error) {
+    console.log(error);
+    res
+      .status(500)
+      .json({ status: "error", message: "Sorry something bad happened :(" });
+  }
+});
 
 export default router;

--- a/backend/routes/api/v1/controllers/feedback.js
+++ b/backend/routes/api/v1/controllers/feedback.js
@@ -6,6 +6,8 @@ Schema addressed in feedback.js:
 */
 
 import express from 'express';
+import { sendError } from '../helpers/sendError.js';
+import { sendSuccess } from '../helpers/sendSuccess.js';
 
 var router = express.Router();
 
@@ -37,7 +39,7 @@ router.get('/', async (req,res) => {
 
     } catch(error) {
         console.log(error);
-        res.status(500).json({status:"error", message:error.message});
+        return sendError(res, 500);
     }
 
 })
@@ -69,11 +71,11 @@ router.post('/', async (req,res) => {
         await newFeedback.save();
 
         //Give the client a proper reply saying it went well.
-        res.json({status:"success"});
+        return sendSuccess(res);
 
     } catch(error) {
         console.log(error);
-        res.status(500).json({status:"error", message:error.message});
+        return sendError(res, 500);
     }
 })
 
@@ -93,11 +95,11 @@ router.delete('/', async (req,res) => {
         await req.models.Feedback.deleteOne({ _id:fID});
         
         //Tell the client it worked
-        res.json({status:"success"})
+        return sendSuccess(res);
 
     } catch(error){
         console.log(error);
-        res.status(500).json({status:"error", message:error.message});
+        return sendError(res, 500);
     }
 })
 

--- a/backend/routes/api/v1/controllers/user.js
+++ b/backend/routes/api/v1/controllers/user.js
@@ -7,10 +7,12 @@ Schemas addressed in users.js:
 
 import express from "express";
 import fetch from "node-fetch";
+import { sendError } from "../helpers/sendError.js";
+import { sendSuccess } from "../helpers/sendSuccess.js";
 
 var router = express.Router();
 
-/* 
+/*
     @endpoint: /login
     @method: GET
     @description: Given the Microsoft Access Token in the Authorization header,
@@ -57,14 +59,11 @@ router.post("/login", async function (req, res) {
     }
   } catch (err) {
     console.log(err);
-    res.status(500).json({
-      status: "error",
-      error: "Error from our side :(",
-    });
+    return sendError(res, 500);
   }
 });
 
-/* 
+/*
     @endpoint: /logout
     @method: POST
     @description: destroy user session.
@@ -73,14 +72,9 @@ router.post("/logout", function (req, res, next) {
   if (req.session.isAuthenticated) {
     req.session.destroy();
 
-    res.status(200).json({
-      status: "success",
-    });
+    return sendSuccess(res);
   } else {
-    res.status(400).json({
-      status: "error",
-      error: "User is not logged in",
-    });
+    return sendError(res, 401, "User is not logged in");
   }
 });
 
@@ -95,10 +89,7 @@ router.get("/", async function (req, res) {
       memberType: req.session.memberType,
     });
   } else {
-    res.status(400).json({
-      status: "error",
-      error: "User is not logged in",
-    });
+    return sendError(res, 401, "User is not logged in");
   }
 });
 
@@ -119,13 +110,10 @@ router.get("/:uId", async function (req, res) {
       }
     } catch (error) {
       console.log(error);
-      res.status(500).json({ status: "error", message: error.message });
+      return sendError(res, 500);
     }
   } else {
-    res.status(400).json({
-      status: "error",
-      error: "User is not logged in",
-    });
+    return sendError(res, 401, "User is not logged in");
   }
 });
 
@@ -141,21 +129,16 @@ router.post("/:uId", async function (req, res) {
       } else if (currId != uId && currUser.uType === "Admin") {
         //if admin edits user account
       } else {
-        res.status(400).json({
-          status: "error",
-          error: "Access denied",
-        });
+        return sendError(res, 403, "Access denied");
       }
     } catch (error) {
       console.log(error);
-      res.status(500).json({ status: "error", message: error.message });
+      return sendError(res, 500);
     }
   } else {
-    res.status(400).json({
-      status: "error",
-      error: "User is not logged in",
-    });
+    return sendError(res, 401, "User is not logged in");
   }
 });
 
 export default router;
+

--- a/backend/routes/api/v1/controllers/user.js
+++ b/backend/routes/api/v1/controllers/user.js
@@ -5,8 +5,8 @@ Schemas addressed in users.js:
 - Users
 */
 
-import express from 'express';
-import fetch from 'node-fetch';
+import express from "express";
+import fetch from "node-fetch";
 
 var router = express.Router();
 
@@ -16,151 +16,146 @@ var router = express.Router();
     @description: Given the Microsoft Access Token in the Authorization header,
                   get information about the user using Graph API. Save information
                   about the user if already exists. Create user session.
-*/ 
-router.post('/login', async function(req, res) {
-    const authorizationHeader = req.headers.authorization;
-    try {
-        const accessToken = authorizationHeader.split(' ')[1];
-        const response = await fetch('https://graph.microsoft.com/v1.0/me', {
-            headers: {
-                'Authorization': `Bearer ${accessToken}`
-            }
+*/
+router.post("/login", async function (req, res) {
+  const authorizationHeader = req.headers.authorization;
+  try {
+    const accessToken = authorizationHeader.split(" ")[1];
+    const response = await fetch("https://graph.microsoft.com/v1.0/me", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (response.ok) {
+      const userData = await response.json();
+
+      // Create a new session with the user
+      req.session.isAuthenticated = true;
+      req.session.displayName = userData.displayName;
+      req.session.email = userData.mail;
+      req.session.firstName = userData.givenName;
+      req.session.lastName = userData.surname;
+
+      //Check if user is already in database, if not then make them an account
+      let user = await req.models.Users.findOne({ uEmail: req.session.email });
+      if (!user) {
+        const newUser = new req.models.Users({
+          uFirstName: req.session.firstName,
+          uLastName: req.session.lastName,
+          uDisplayName: req.session.displayName,
+          uEmail: req.session.email,
         });
 
-        if (response.ok) {
-            const userData = await response.json();
+        user = await newUser.save();
+      }
 
-            // Create a new session with the user
-            req.session.isAuthenticated = true;
-            req.session.displayName = userData.displayName;
-            req.session.email = userData.mail;
-            req.session.firstName = userData.givenName;
-            req.session.lastName = userData.surname;
-
-            //Check if user is already in database, if not then make them an account
-            let user = await req.models.Users.findOne({uEmail:req.session.email})
-            if (!user) {
-                const newUser = new req.models.Users({
-                    uFirstName: req.session.firstName,
-                    uLastName: req.session.lastName,
-                    uDisplayName: req.session.displayName,
-                    uEmail: req.session.email,
-                })
-
-                user = await newUser.save();
-            }
-
-            req.session.userId = user._id;
-            req.session.memberType = user.uType;
-            req.session.isAdmin = user.uType === "Admin";
-            res.status(200).json(user);
-        }
-    } catch (err) {
-        console.log(err);
-        res.status(500).json(
-            {
-                status: "error",
-                error: "Error from our side :("
-             }
-        )
+      req.session.userId = user._id;
+      req.session.memberType = user.uType;
+      req.session.isAdmin = user.uType === "Admin";
+      res.status(200).json(user);
     }
-})
+  } catch (err) {
+    console.log(err);
+    res.status(500).json({
+      status: "error",
+      error: "Error from our side :(",
+    });
+  }
+});
 
 /* 
     @endpoint: /logout
     @method: POST
     @description: destroy user session.
-*/ 
-router.post('/logout', function(req, res, next) {
-    if (req.session.isAuthenticated) {
-        req.session.destroy();
+*/
+router.post("/logout", function (req, res, next) {
+  if (req.session.isAuthenticated) {
+    req.session.destroy();
 
-        res.status(200).json({
-            "status": "success"
-        });
-    } else {
-        res.status(400).json(
-            {
-                status: "error",
-                error: "User is not logged in"
-            }
-        )
-    }
+    res.status(200).json({
+      status: "success",
+    });
+  } else {
+    res.status(400).json({
+      status: "error",
+      error: "User is not logged in",
+    });
+  }
 });
 
 //Get the user's specific information from the user's perspective, from an outsider perspective, and from the admin perspective
-router.get("/", async function(req,res) {
-    if(req.session.isAuthenticated) {
-        res.status(200).json({
-            firstName: req.session.firstName,
-            lastName: req.session.lastName,
-            displayName: req.session.displayName,
-            email: req.session.email,
-            memberType: req.session.memberType
-        });  
-    } else {
-        res.status(400).json({
-            status: "error",
-            error: "User is not logged in"
-        })
-    } 
-})
+router.get("/", async function (req, res) {
+  if (req.session.isAuthenticated) {
+    res.status(200).json({
+      firstName: req.session.firstName,
+      lastName: req.session.lastName,
+      displayName: req.session.displayName,
+      email: req.session.email,
+      memberType: req.session.memberType,
+    });
+  } else {
+    res.status(400).json({
+      status: "error",
+      error: "User is not logged in",
+    });
+  }
+});
 
 //Get the user's specific information from the user's perspective, from an outsider perspective, and from the admin perspective
-router.get("/:uId", async function(req,res) {
-    if(req.session.isAuthenticated) {
-        try {
-            const uId = req.params.uId;
-            const currId = req.session.id;
-            const currUser = await req.models.Users.findById({currId})
+router.get("/:uId", async function (req, res) {
+  if (req.session.isAuthenticated) {
+    try {
+      const uId = req.params.uId;
+      const currId = req.session.id;
+      const currUser = await req.models.Users.findById({ currId });
 
-            if (currId == uId) { //Current user is viewing their own account (account owner view)
-                
-            } else if (currId != uId && currUser.uType === "Admin") { //An admin is viewing a users account (admin view)
-
-            } else { //An outside user is viewing another user's account (Outside user view)
-
-            }
-        } catch (error) {
-            console.log(error);
-            res.status(500).json({status:"error", message:error.message});
-        }
-    } else {
-        res.status(400).json({
-            status: "error",
-            error: "User is not logged in"
-        })
-    }    
-})
-
-//User wants to update their own profile information, or an admin is trying to change a user's information. 
-router.post("/:uId", async function(req,res) {
-    if(req.session.isAuthenticated) {
-        try {
-            const uId = req.params.uId;
-            const currId = req.session.id;
-            const currUser = await req.models.Users.findById({currId})
-            if (currId == uId) { //If current user edits their own account
-
-            } else if (currId != uId && currUser.uType === "Admin") { //if admin edits user account
-
-            } else {
-                res.status(400).json({
-                    status:"error",
-                    error: "Access denied"
-                })
-            }
-            
-        } catch (error) {
-            console.log(error);
-            res.status(500).json({status:"error", message:error.message});
-        }
-    } else {
-        res.status(400).json({
-            status: "error",
-            error: "User is not logged in"
-        })
+      if (currId == uId) {
+        //Current user is viewing their own account (account owner view)
+      } else if (currId != uId && currUser.uType === "Admin") {
+        //An admin is viewing a users account (admin view)
+      } else {
+        //An outside user is viewing another user's account (Outside user view)
+      }
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ status: "error", message: error.message });
     }
-})
+  } else {
+    res.status(400).json({
+      status: "error",
+      error: "User is not logged in",
+    });
+  }
+});
 
-export default router
+//User wants to update their own profile information, or an admin is trying to change a user's information.
+router.post("/:uId", async function (req, res) {
+  if (req.session.isAuthenticated) {
+    try {
+      const uId = req.params.uId;
+      const currId = req.session.id;
+      const currUser = await req.models.Users.findById({ currId });
+      if (currId == uId) {
+        //If current user edits their own account
+      } else if (currId != uId && currUser.uType === "Admin") {
+        //if admin edits user account
+      } else {
+        res.status(400).json({
+          status: "error",
+          error: "Access denied",
+        });
+      }
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ status: "error", message: error.message });
+    }
+  } else {
+    res.status(400).json({
+      status: "error",
+      error: "User is not logged in",
+    });
+  }
+});
+
+export default router;

--- a/backend/routes/api/v1/helpers/sendError.js
+++ b/backend/routes/api/v1/helpers/sendError.js
@@ -1,0 +1,9 @@
+export function sendError(res, status, message) {
+  const fallback =
+    status === 500
+      ? "There was an error on our side :("
+      : "Something went wrong";
+  return res
+    .status(status)
+    .json({ status: "error", message: message ?? fallback });
+}

--- a/backend/routes/api/v1/helpers/sendSuccess.js
+++ b/backend/routes/api/v1/helpers/sendSuccess.js
@@ -1,0 +1,3 @@
+export function sendSuccess(res, data = {}) {
+  return res.status(200).json({ status: "success", ...data });
+}

--- a/backend/test/makeFakeRes.js
+++ b/backend/test/makeFakeRes.js
@@ -1,0 +1,13 @@
+export function makeFakeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.body = data;
+    },
+  };
+}

--- a/backend/test/sendError.test.js
+++ b/backend/test/sendError.test.js
@@ -1,0 +1,38 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { sendError } from "../routes/api/v1/helpers/sendError.js";
+import { makeFakeRes } from "./makeFakeRes.js";
+
+
+describe("sendError", () => {
+  it("returns 404 with the error message", () => {
+    // arrange
+    const res = makeFakeRes();
+
+    // act
+    sendError(res, 404, "Event not found");
+
+    // assert
+    assert.strictEqual(res.statusCode, 404);
+    assert.deepStrictEqual(res.body, {
+      status: "error",
+      message: "Event not found",
+    });
+  });
+
+  it("falls back to the default message for 500", () => {
+    const res = makeFakeRes();
+
+    sendError(res, 500);
+
+    assert.strictEqual(res.body.message, "There was an error on our side :(");
+  });
+
+  it("uses the explicit message when one is given", () => {
+    const res = makeFakeRes();
+
+    sendError(res, 500, "message was given");
+
+    assert.strictEqual(res.body.message, "message was given");
+  });
+});

--- a/backend/test/sendSuccess.test.js
+++ b/backend/test/sendSuccess.test.js
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { sendSuccess } from "../routes/api/v1/helpers/sendSuccess.js";
+import { makeFakeRes } from "./makeFakeRes.js";
+
+
+describe("sendSuccess", () => {
+  it("returns 200 with the success status", () => {
+    const res = makeFakeRes();
+    sendSuccess(res);
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body, {
+      status: "success",
+    });
+  });
+
+  it("includes the data payload when one is given", () => {
+    const res = makeFakeRes();
+    sendSuccess(res, { message: "RSVP successful!" });
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body, {
+      status: "success",
+      message: "RSVP successful!",
+    });
+  });
+});

--- a/frontend/.env.dev
+++ b/frontend/.env.dev
@@ -1,1 +1,0 @@
-REACT_APP_API_URL=http://localhost:7777

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,0 @@
-REACT_APP_API_URL=https://dev.iuga.info

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Env var's
+/.env.dev
+/.env.production

--- a/frontend/src/pages/Events.jsx
+++ b/frontend/src/pages/Events.jsx
@@ -14,7 +14,13 @@ function EventsPage() {
         if (process.env.NODE_ENV === "production") {
             fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/`, {
                 method: "GET",
-            }).then((res) => res.json())
+            }).then((res) => {
+              if (!res.ok) {
+                throw new Error(`${res.status}, ${res.statusText}`)
+              } else {
+                return res.json()
+              }
+            })
             .then((events) => {
                 setCalendarEvents(events);
             }).catch((error) => {


### PR DESCRIPTION
## Summary
All API error and success responses now flow through two shared helpers with one source of truth for the response shape and the generic 500 message. The withdraw endpoint — which could never remove a participant — is repaired, and the helper contracts are locked by the project's first unit tests.

The branch also carries two earlier atomic commits on the base: the Events.jsx non-OK response guard and the frontend env-file untracking.

## Why
- Error responses were built inline in each controller, with inconsistent keys (`error:` vs `message:`) and five different 500 phrasings
- `feedback.js` and `user.js` 500s leaked raw `error.message` to clients
- `withdraw` was guaranteed-broken: `findById({eId})` object wrapper → null, wrong schema field (`participants` vs `eParticipants`), strict `!==` on ObjectId vs string
- The repo had no test infrastructure at all

## Approach
- Added `helpers/sendError.js` and `helpers/sendSuccess.js` (route-layer response builders; `??` fallback owns the generic 500 wording)
- Converted all three controllers; status-code corrections ride along (not-found → 404, auth failures → 401, access denied → 403)
- Raw GET responses intentionally untouched — the frontend consumes those array shapes directly
- First tests via built-in `node:test` with a minimal fake `res` (no new dependencies)
- Accepted tradeoff: `events.js`/`user.js` were reformatted to 2-space/double-quote (Prettier defaults) — isolated in a dedicated `style:` commit

## Architecture and Contracts
- **New**: `backend/routes/api/v1/helpers/`; normalized error contract `{ status: "error", message }`, success contract `{ status: "success", ...data }`
- **Fixed**: withdraw removes participants; not-found and auth failures return correct codes (404/401); client never receives raw server errors
- **New**: `backend/test/` — 6 passing unit tests over both helpers

```mermaid
flowchart LR
    C[Controller] --> E[sendError] --> J[JSON to client]
    C --> S[sendSuccess] --> J
    C -->|logs error| L[Server log]
```


