### PR TITLE
fix: return 404 instead of 500 when event not found in DELETE /withdraw

### DIFF
--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -323,6 +323,10 @@ router.delete("/withdraw/:eId/:pId", async function (req, res) {
       const pId = req.params.pId;
       const eId = req.params.eId;
       const event = await req.models.Events.findById(eId);
+      if (!event) {
+        return sendError(res, 404, "Event not found");
+      }
+
 
       let newParticipants = [];
       event.eParticipants.forEach((participant) => {


### PR DESCRIPTION
## Summary

Add null check in `DELETE /withdraw/:eId/:pId` to return 404 when event doesn't exist, instead of 500 (TypeError).

## The Bug

`findById(eId)` result was used immediately with `event.eParticipants.forEach` without checking if `event` is null. Unknown/invalid `eId` → `event` is null → TypeError → **500 Internal Server Error**.

## The Fix

Add null check after `findById()` and return `404 Not Found` with a clear message — matching the existing pattern used in `GET /id/:eId` (lines 126-127).

```javascript
const event = await req.models.Events.findById(eId);
if (!event) {
  return sendError(res, 404, "Event not found");
}
```

## Testing

- Unknown `eId` now returns `404` instead of `500`
- Existing authenticated participant-withdrawal flow unchanged
- Surgical 4-line change, no side effects

Fixes #12.