### PR TITLE
fix(docker): restore tracked .env.production for prod/staging builds

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://dev.iuga.info

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 # Env var's
 /.env.dev
 /.env.production
+!/.env.production


### PR DESCRIPTION
## Summary

Restores `frontend/.env.production` to version control after it was untracked in `80928bd`, and un-ignores it so it stays tracked.

## Rationale

The production (`iuga.info` #96) and staging Jenkins builds fail in the Docker **Build** stage:

```
#11 [build 6/11] RUN if [ "$DEPLOY_ENV" = "production" ] ; then sed -i 's#https://dev.iuga.info#https://iuga.info#' .env.production ; fi
#11 0.600 sed: .env.production: No such file or directory
#11 ERROR: ... exit code: 1
```

Commit `80928bd chore(frontend): untrack env files from version control` deleted the file from git, but the Dockerfile still rewrites it with `sed` during production/staging builds (`COPY frontend/ ./` only gets files present in the repo). The file is not a secret — it only holds the baseline `REACT_APP_API_URL=https://dev.iuga.info`, which the Dockerfile rewrites per-env at build time.

## Tests / Verification

- `docker build --build-arg DEPLOY_ENV=production .` → **green**; prod bundle bakes `https://iuga.info` (verified via grep in the built image), no `dev.iuga.info` leakage
- `docker build --build-arg DEPLOY_ENV=staging .` → **green**; staging bundle bakes `https://staging.iuga.info`, no dev leakage
- `authConfig.js` redirect also correctly rewritten to `https://iuga.info/`

## Notes

- `.env.production` content matches the original (`git show 80928bd~1:frontend/.env.production`): `REACT_APP_API_URL=https://dev.iuga.info`
- `.gitignore` negation `!/.env.production` must follow the ignore rules (order matters)
- Fixes the same failure mode for all three pipelines (dev was unaffected — it never seds `.env.production`)