### PR TITLE
refactor(frontend): replace absolute API URL with relative paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm install
 COPY frontend/ ./
-RUN if [ "$DEPLOY_ENV" = "production" ] ; then sed -i 's#https://dev.iuga.info#https://iuga.info#' .env.production ; fi
-RUN if [ "$DEPLOY_ENV" = "staging" ] ; then sed -i 's#https://dev.iuga.info#https://staging.iuga.info#' .env.production ; fi
 
 RUN if [ "$DEPLOY_ENV" = "production" ] ; then sed -i 's#http://localhost:7777/#https://iuga.info/#' src/authConfig.js ; fi
 RUN if [ "$DEPLOY_ENV" = "staging" ] ; then sed -i 's#http://localhost:7777/#https://staging.iuga.info/#' src/authConfig.js ; fi

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,6 +22,3 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Env var's
-/.env.dev
-/.env.production

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:7777",
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,7 +25,7 @@ function App() {
 
     useEffect(() => {
         if (process.env.NODE_ENV === "production") {
-            fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/upcoming`, {
+            fetch('/api/v1/events/upcoming', {
                 method: "GET",
             })
                 .then((res) => res.json())

--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -61,7 +61,7 @@ const Calendar = ({ calendarEvents, highlightEvent }) => {
         setActive(true);
         setSelectedDate(date);
         if (process.env.NODE_ENV === "production") {
-            fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/id/${eid}`, {
+            fetch(`/api/v1/events/id/${eid}`, {
                 method: "GET",
             }).then((res) => res.json())
             .then((event) => {

--- a/frontend/src/components/EventDetailsCard.jsx
+++ b/frontend/src/components/EventDetailsCard.jsx
@@ -37,7 +37,7 @@ const EventDetailsCard = ({selectedEvent, handleRSVP, deselectEventDetails}) => 
                 });
             });
 
-            fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/rsvp`, {
+            fetch('/api/v1/events/rsvp', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -64,7 +64,7 @@ export const AuthProvider = ({ children }) => {
 
   const signOut = async () => {
     try {
-      await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:7777'}/api/v1/user/logout`, {
+      await fetch('/api/v1/user/logout', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -41,7 +41,7 @@ const useAuth = () => {
 
 const sendTokenToBackend = async (accessToken) => {
   try {
-    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/user/login`, {
+    const response = await fetch('/api/v1/user/login', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/pages/Events.jsx
+++ b/frontend/src/pages/Events.jsx
@@ -12,7 +12,7 @@ function EventsPage() {
 
     const fetchCalendarData = () => {
         if (process.env.NODE_ENV === "production") {
-            fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/`, {
+            fetch('/api/v1/events/', {
                 method: "GET",
             }).then((res) => {
               if (!res.ok) {


### PR DESCRIPTION
# Summary

Replace the `REACT_APP_API_URL` absolute-URL mechanism with relative API paths. The app runs a single container where Express serves the frontend build (`app.js` `express.static`) and mounts the `/api/v1` router on the same origin — so the browser can resolve `/api/v1/...` against its own host with zero per-env configuration.

Also deletes the Dockerfile sed lines that rewrote `.env.production` per environment — the mechanism that broke prod/staging builds.

# Rationale

- **Old mechanism**: `fetch(`${process.env.REACT_APP_API_URL}/api/v1/...`)` where `REACT_APP_API_URL` was injected per environment by Dockerfile `sed` on `frontend/.env.production`.
- **What broke**: commit `80928bd` untracked the env file; the Dockerfile `sed` then failed (`sed: .env.production: No such file or directory`) and every prod/staging build went red.
- **Fix**: relative paths resolve against the browser's current origin automatically — `iuga.info/api`, `staging.iuga.info/api`, and `localhost:3000/api` in dev — no injection needed.
- **Dev preserved**: CRA `proxy: http://localhost:7777` forwards `/api` to Express in dev only; grep-verified it never appears in the production bundle.
- **Intentionally kept**: the `src/authConfig.js` `redirectUri` seds — MSAL OAuth requires an absolute, per-env URL registered with Azure AD and cannot be relative.

# Tests

- `docker build --build-arg DEPLOY_ENV=production` → **green**. Bundle verified: all 6 fetch call sites relative, zero `REACT_APP_API_URL` / `dev.iuga.info` / `localhost:7777` leakage; authConfig baked `https://iuga.info/`.
- `docker build --build-arg DEPLOY_ENV=staging` → **green**. authConfig baked `https://staging.iuga.info/`.
- `grep -r REACT_APP_API_URL frontend/src` → 0 hits.