### PR TITLE
refactor(db): consolidate MongoDB URI into single DB_URI var

### DIFF
--- a/backend/models.js
+++ b/backend/models.js
@@ -8,20 +8,11 @@ import {
 let models = {};
 
 async function connectToDatabase(){
-    if (process.env.DEPLOY_ENV === "production" || process.env.DEPLOY_ENV === "staging") {
-        console.log('connecting to prod database')
-        const prod_uri = process.env.DB_PROD_URI;
-        if (!prod_uri) throw new Error('DB_PROD_URI is not set in .env.prod');
-        await mongoose.connect(prod_uri);
-        console.log("successfully connected to prod mongodb")
-    } else {
-        console.log('connecting to dev database')
-        const dev_uri = process.env.DB_DEV_URI;
-        if (!dev_uri) throw new Error('DB_DEV_URI is not set in .env.dev');
-        await mongoose.connect(dev_uri);
-        console.log("successfully connected to dev mongodb")
-    }
-    
+    const db_uri = process.env.DB_URI;
+    if (!db_uri) throw new Error('DB_URI is not set (set it in backend/env/.env.dev or inject via pipeline)');
+    console.log('connecting to mongodb')
+    await mongoose.connect(db_uri);
+    console.log("successfully connected to mongodb")
 
     models.Events = mongoose.model('Events', eventsSchema)
     models.Participants = mongoose.model('Participants', participantsSchema)

--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -53,13 +53,13 @@ pipeline {
                 sh 'docker pull iuga/iuga-web-app-development'
                 sh 'docker rm -f iuga-web-dev || true'
                 withCredentials([
-                    string(credentialsId: 'devDBUri', variable: 'DB_DEV_URI'),
+                    string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
                     sh '''
                     docker run -d -p "127.0.0.1:6666:7777" --name iuga-web-dev \
                     -e DEPLOY_ENV=development \
-                    -e DB_DEV_URI="$DB_DEV_URI" \
+                    -e DB_URI="$DB_URI" \
                     -e SESSION_SECRET="$SESSION_SECRET" \
                     -v /var/lib/iuga-web-app/uploads/dev:/app/backend/public/uploads \
                     iuga/iuga-web-app-development

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -81,8 +81,7 @@ Required variables (see `.env.example`):
 | `PORT` | Server port (default 7777) |
 | `DEPLOY_ENV` | `development`, `staging`, or `production` |
 | `SESSION_SECRET` | Strong random string for session signing |
-| `DB_DEV_URI` | Full MongoDB Atlas connection string (dev), e.g. `mongodb+srv://<user>:<pass>@cluster...` |
-| `DB_PROD_URI` | Full MongoDB connection string (prod/staging), e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` |
+| `DB_URI` | Full MongoDB connection string, e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` (local dev: `mongodb://127.0.0.1:27017/iuga`) |
 
 Frontend environment (checked in):
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -151,7 +151,7 @@ docker exec iuga-web-<env> node -e "
 | HTTP 502 from host `curl` | Container not listening or wrong port | `docker ps`, check port mapping |
 | Stale content served | nginx cache or old container still running | `docker ps`, verify correct image tag |
 | `docker push` fails in Jenkins | Docker Hub credential expired or rate-limited | Renew `dockerhub` credential in Jenkins |
-| MongoDB connection failure | Network down, Atlas IP whitelist changed, credentials rotated | Verify network, check `DB_PROD_URI`/`DB_DEV_URI` |
+| MongoDB connection failure | Network down, Atlas IP whitelist changed, credentials rotated | Verify network, check `DB_URI` |
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -89,8 +89,7 @@ Required variables (see `.env.example`):
 | `PORT` | Server port (default 7777) |
 | `DEPLOY_ENV` | `development`, `staging`, or `production` |
 | `SESSION_SECRET` | Strong random string for session signing |
-| `DB_DEV_URI` | Full MongoDB Atlas connection string (dev), e.g. `mongodb+srv://<user>:<pass>@cluster...` |
-| `DB_PROD_URI` | Full MongoDB connection string (prod/staging), e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` |
+| `DB_URI` | Full MongoDB connection string, e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` (local dev: `mongodb://127.0.0.1:27017/iuga`) |
 
 ### Debug backend setup (optional)
 

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -53,13 +53,13 @@ pipeline {
                 sh 'docker pull iuga/iuga-web-app-production'
                 sh 'docker rm -f iuga-web-prod || true'
                 withCredentials([
-                    string(credentialsId: 'prodDBUri', variable: 'DB_PROD_URI'),
+                    string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
                     sh '''
                     docker run -d -p "127.0.0.1:8888:7777" --name iuga-web-prod \
                     -e DEPLOY_ENV=production \
-                    -e DB_PROD_URI="$DB_PROD_URI" \
+                    -e DB_URI="$DB_URI" \
                     -e SESSION_SECRET="$SESSION_SECRET" \
                     -v /var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads \
                     --network iuga-server-config_default \

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -42,13 +42,13 @@ pipeline {
         sh 'docker pull iuga/iuga-web-app-staging'
         sh 'docker rm -f iuga-web-staging || true'
         withCredentials([
-          string(credentialsId: 'prodDBUri', variable: 'DB_PROD_URI'),
+          string(credentialsId: 'devDBUri', variable: 'DB_URI'),
           string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
         ]) {
           sh '''
             docker run -d -p "127.0.0.1:7777:7777" --name iuga-web-staging \
             -e DEPLOY_ENV=staging \
-            -e DB_PROD_URI="$DB_PROD_URI" \
+            -e DB_URI="$DB_URI" \
             -e SESSION_SECRET="$SESSION_SECRET" \
             -v /var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads \
             --network iuga-server-config_default \


### PR DESCRIPTION
# Summary

Backend now uses one `DB_URI` variable for MongoDB. `backend/models.js` no longer picks between `DB_PROD_URI` / `DB_DEV_URI` based on `DEPLOY_ENV` — it just reads `DB_URI` and errors if it's missing. All three Jenkinsfiles inject the existing `devDBUri` credential as `DB_URI`.

# Rationale

Prod builds #97/#98 failed at deploy: `ERROR: Could not find credentials entry with ID 'prodDBUri'`. The pipelines referenced a credential that was never created in Jenkins — only `devDBUri` exists. Instead of creating a new credential, we simplified the code to use the one that already works.

Changes:
- `models.js` drops the prod/dev branch, reads `DB_URI` only
- dev/staging/prod pipelines inject `devDBUri` as `DB_URI`
- local dev uses a local MongoDB container (`mongodb://127.0.0.1:27017/iuga`)
- docs updated from `DB_DEV_URI`/`DB_PROD_URI` to `DB_URI`

Note: staging and prod now connect to the same Atlas database as deployed dev (shared `devDBUri` connection string). If prod needs its own cluster later, create a `prodDBUri` credential and flip one line per pipeline — no code change needed.

# Tests

- `docker build --build-arg DEPLOY_ENV=production` → green
- Ran the image locally with `DB_URI` pointing at a Mongo instance:
  - `GET /api/v1/events/` → `[]` HTTP 200 (app boots, API works)
  - Inserted a test doc, fetched it back via `GET /api/v1/events/`, deleted it (full roundtrip through the new `connectToDatabase()` path)
- `git grep` for `DB_DEV_URI|DB_PROD_URI|prodDBUri` (excluding docs) → zero hits
