### PR TITLE
merge main into dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm install
 COPY frontend/ ./
-RUN if [ "$DEPLOY_ENV" = "production" ] ; then sed -i 's#https://dev.iuga.info#https://iuga.info#' .env.production ; fi
-RUN if [ "$DEPLOY_ENV" = "staging" ] ; then sed -i 's#https://dev.iuga.info#https://staging.iuga.info#' .env.production ; fi
 
 RUN if [ "$DEPLOY_ENV" = "production" ] ; then sed -i 's#http://localhost:7777/#https://iuga.info/#' src/authConfig.js ; fi
 RUN if [ "$DEPLOY_ENV" = "staging" ] ; then sed -i 's#http://localhost:7777/#https://staging.iuga.info/#' src/authConfig.js ; fi

--- a/backend/models.js
+++ b/backend/models.js
@@ -8,20 +8,11 @@ import {
 let models = {};
 
 async function connectToDatabase(){
-    if (process.env.DEPLOY_ENV === "production" || process.env.DEPLOY_ENV === "staging") {
-        console.log('connecting to prod database')
-        const prod_uri = process.env.DB_PROD_URI;
-        if (!prod_uri) throw new Error('DB_PROD_URI is not set in .env.prod');
-        await mongoose.connect(prod_uri);
-        console.log("successfully connected to prod mongodb")
-    } else {
-        console.log('connecting to dev database')
-        const dev_uri = process.env.DB_DEV_URI;
-        if (!dev_uri) throw new Error('DB_DEV_URI is not set in .env.dev');
-        await mongoose.connect(dev_uri);
-        console.log("successfully connected to dev mongodb")
-    }
-    
+    const db_uri = process.env.DB_URI;
+    if (!db_uri) throw new Error('DB_URI is not set (set it in backend/env/.env.dev or inject via pipeline)');
+    console.log('connecting to mongodb')
+    await mongoose.connect(db_uri);
+    console.log("successfully connected to mongodb")
 
     models.Events = mongoose.model('Events', eventsSchema)
     models.Participants = mongoose.model('Participants', participantsSchema)

--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -53,13 +53,13 @@ pipeline {
                 sh 'docker pull iuga/iuga-web-app-development'
                 sh 'docker rm -f iuga-web-dev || true'
                 withCredentials([
-                    string(credentialsId: 'devDBUri', variable: 'DB_DEV_URI'),
+                    string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
                     sh '''
                     docker run -d -p "127.0.0.1:6666:7777" --name iuga-web-dev \
                     -e DEPLOY_ENV=development \
-                    -e DB_DEV_URI="$DB_DEV_URI" \
+                    -e DB_URI="$DB_URI" \
                     -e SESSION_SECRET="$SESSION_SECRET" \
                     -v /var/lib/iuga-web-app/uploads/dev:/app/backend/public/uploads \
                     iuga/iuga-web-app-development

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -81,8 +81,7 @@ Required variables (see `.env.example`):
 | `PORT` | Server port (default 7777) |
 | `DEPLOY_ENV` | `development`, `staging`, or `production` |
 | `SESSION_SECRET` | Strong random string for session signing |
-| `DB_DEV_URI` | Full MongoDB Atlas connection string (dev), e.g. `mongodb+srv://<user>:<pass>@cluster...` |
-| `DB_PROD_URI` | Full MongoDB connection string (prod/staging), e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` |
+| `DB_URI` | Full MongoDB connection string, e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` (local dev: `mongodb://127.0.0.1:27017/iuga`) |
 
 Frontend environment (checked in):
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -151,7 +151,7 @@ docker exec iuga-web-<env> node -e "
 | HTTP 502 from host `curl` | Container not listening or wrong port | `docker ps`, check port mapping |
 | Stale content served | nginx cache or old container still running | `docker ps`, verify correct image tag |
 | `docker push` fails in Jenkins | Docker Hub credential expired or rate-limited | Renew `dockerhub` credential in Jenkins |
-| MongoDB connection failure | Network down, Atlas IP whitelist changed, credentials rotated | Verify network, check `DB_PROD_URI`/`DB_DEV_URI` |
+| MongoDB connection failure | Network down, Atlas IP whitelist changed, credentials rotated | Verify network, check `DB_URI` |
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -89,8 +89,7 @@ Required variables (see `.env.example`):
 | `PORT` | Server port (default 7777) |
 | `DEPLOY_ENV` | `development`, `staging`, or `production` |
 | `SESSION_SECRET` | Strong random string for session signing |
-| `DB_DEV_URI` | Full MongoDB Atlas connection string (dev), e.g. `mongodb+srv://<user>:<pass>@cluster...` |
-| `DB_PROD_URI` | Full MongoDB connection string (prod/staging), e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` |
+| `DB_URI` | Full MongoDB connection string, e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` (local dev: `mongodb://127.0.0.1:27017/iuga`) |
 
 ### Debug backend setup (optional)
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,6 +22,3 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Env var's
-/.env.dev
-/.env.production

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:7777",
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,7 +25,7 @@ function App() {
 
     useEffect(() => {
         if (process.env.NODE_ENV === "production") {
-            fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/upcoming`, {
+            fetch('/api/v1/events/upcoming', {
                 method: "GET",
             })
                 .then((res) => res.json())

--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -61,7 +61,7 @@ const Calendar = ({ calendarEvents, highlightEvent }) => {
         setActive(true);
         setSelectedDate(date);
         if (process.env.NODE_ENV === "production") {
-            fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/id/${eid}`, {
+            fetch(`/api/v1/events/id/${eid}`, {
                 method: "GET",
             }).then((res) => res.json())
             .then((event) => {

--- a/frontend/src/components/EventDetailsCard.jsx
+++ b/frontend/src/components/EventDetailsCard.jsx
@@ -37,7 +37,7 @@ const EventDetailsCard = ({selectedEvent, handleRSVP, deselectEventDetails}) => 
                 });
             });
 
-            fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/rsvp`, {
+            fetch('/api/v1/events/rsvp', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -64,7 +64,7 @@ export const AuthProvider = ({ children }) => {
 
   const signOut = async () => {
     try {
-      await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:7777'}/api/v1/user/logout`, {
+      await fetch('/api/v1/user/logout', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -41,7 +41,7 @@ const useAuth = () => {
 
 const sendTokenToBackend = async (accessToken) => {
   try {
-    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/user/login`, {
+    const response = await fetch('/api/v1/user/login', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/pages/Events.jsx
+++ b/frontend/src/pages/Events.jsx
@@ -12,7 +12,7 @@ function EventsPage() {
 
     const fetchCalendarData = () => {
         if (process.env.NODE_ENV === "production") {
-            fetch(`${process.env.REACT_APP_API_URL}/api/v1/events/`, {
+            fetch('/api/v1/events/', {
                 method: "GET",
             }).then((res) => {
               if (!res.ok) {

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -53,13 +53,13 @@ pipeline {
                 sh 'docker pull iuga/iuga-web-app-production'
                 sh 'docker rm -f iuga-web-prod || true'
                 withCredentials([
-                    string(credentialsId: 'prodDBUri', variable: 'DB_PROD_URI'),
+                    string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
                     sh '''
                     docker run -d -p "127.0.0.1:8888:7777" --name iuga-web-prod \
                     -e DEPLOY_ENV=production \
-                    -e DB_PROD_URI="$DB_PROD_URI" \
+                    -e DB_URI="$DB_URI" \
                     -e SESSION_SECRET="$SESSION_SECRET" \
                     -v /var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads \
                     --network iuga-server-config_default \

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -42,13 +42,13 @@ pipeline {
         sh 'docker pull iuga/iuga-web-app-staging'
         sh 'docker rm -f iuga-web-staging || true'
         withCredentials([
-          string(credentialsId: 'prodDBUri', variable: 'DB_PROD_URI'),
+          string(credentialsId: 'devDBUri', variable: 'DB_URI'),
           string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
         ]) {
           sh '''
             docker run -d -p "127.0.0.1:7777:7777" --name iuga-web-staging \
             -e DEPLOY_ENV=staging \
-            -e DB_PROD_URI="$DB_PROD_URI" \
+            -e DB_URI="$DB_URI" \
             -e SESSION_SECRET="$SESSION_SECRET" \
             -v /var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads \
             --network iuga-server-config_default \


### PR DESCRIPTION
## Summary
Brings main's infra fixes into dev: relative API URLs (removes the .env.production build dependency), and single DB_URI consolidation (reuses the devDBUri credential — no missing prodDBUri error). 16 files, 2 auto-merged (dev.jenkinsfile, frontend/src/App.jsx).

## Rationale
Dev and main diverged from e938abd. Main had 3 commits dev needed: e59779b (relative API URLs), 96d70d3 (merge #22), 3188b37 (DB URI consolidation #23). This makes dev a superset of main so feature branches off dev start from the fixed baseline, and dev→main later merges clean.

## Tests
- git merge origin/main: clean, ort strategy, 16 files (21 insertions, 36 deletions)
- Invariants: 0 REACT_APP_API_URL in frontend/src, 0 DB_DEV_URI/DB_PROD_URI/prodDBUri in code, models.js reads DB_URI, dev.jenkinsfile still checks out */dev, 0 node_modules tracked
- Frontend: npm test → 65/66 pass (1 pre-existing dev failure: GetInvolved.test.jsx expects 'Nitya Shankar photo unavailable' but nitya.png was added in 947fcb6 — not merge-related)
- Docker: build --build-arg DEPLOY_ENV=production GREEN; bundle bakes https://iuga.info/, all 6 fetch calls relative /api/v1, no REACT_APP_API_URL leak