### PR TITLE
test(frontend): decouple photo fallback test from roster data

### DIFF
--- a/frontend/src/pages/GetInvolved.test.jsx
+++ b/frontend/src/pages/GetInvolved.test.jsx
@@ -48,12 +48,19 @@ describe("GetInvolvedPage", () => {
         expect(officerNames).toEqual(approvedNames);
     });
 
-    test("officers without photos render the default icon and Yonie renders the provided photo", () => {
-        render(<GetInvolvedPage teams={iugaTeams} />);
-        expect(screen.getByLabelText("Ellie Marsh photo unavailable")).toBeInTheDocument();
-        expect(screen.getByLabelText("Nitya Shankar photo unavailable")).toBeInTheDocument();
-        expect(screen.getByLabelText("Dia Dora photo unavailable")).toBeInTheDocument();
-        expect(screen.getByRole("img", { name: "Yonie Rivera" })).toBeInTheDocument();
+    test("members without a photo render the fallback placeholder; members with one render the image", () => {
+        const fakeTeams = {
+            2026: {
+                [groupType.OFFICERS]: [
+                    { name: "Fabricated Student", position: "President", picture: null, socials: null },
+                    { name: "Fabricated Photographer", position: "Co-President", picture: "fabricated.jpg", socials: null },
+                ],
+            },
+        };
+        render(<GetInvolvedPage teams={fakeTeams} />);
+        expect(screen.getByLabelText("Fabricated Student photo unavailable")).toBeInTheDocument();
+        expect(screen.queryByRole("img", { name: "Fabricated Student" })).not.toBeInTheDocument();
+        expect(screen.getByRole("img", { name: "Fabricated Photographer" })).toHaveAttribute("src", "fabricated.jpg");
     });
 
     test("returning officers render their photos with name-based alt text", () => {


### PR DESCRIPTION
# Summary

Fixes the stale `GetInvolvedPage` test that failed after officers Nitya Shankar and Dia Dora received photos. The test now renders a **fabricated** team — one member without a picture, one with — so the fallback-placeholder and photo branches of `GetInvolvedMemberCard` are exercised deterministically, independent of whatever the real roster data looks like.

# Rationale

- The old test asserted `"Nitya Shankar photo unavailable"` and `"Dia Dora photo unavailable"` on real roster names. When those officers got photos (commits `947fcb6`, `bfd375c`), the placeholder stopped rendering and the test broke — the failure the merge branch surfaced.
- Testing against real people means every future roster photo change can silently break the suite again. A fabricated student makes the fallback behavior explicit and stable forever.
- Component-level fallback coverage (`GetInvolvedMemberCard.test.jsx`) already used a made-up member; this brings the page-level test in line with that approach.

# Tests

- `CI=true npm test -- --watchAll=false` in `frontend/`: **66/66 pass** (was 65/66 with this stale failure), 8 suites green.