### PR TITLE
ci: disable concurrent builds across pipelines

### DIFF
--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -9,7 +9,9 @@ void setBuildStatus(String credential_id, String context, String state, String m
 
 pipeline {
     agent any
-    
+    options {
+        disableConcurrentBuilds()
+    }
     stages {
         stage('Checkout') {
             steps {

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -9,7 +9,9 @@ void setBuildStatus(String credential_id, String context, String state, String m
 
 pipeline {
     agent any
-    
+    options {
+        disableConcurrentBuilds()
+    }
     stages {
         stage('Checkout') {
             steps {

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -9,8 +9,9 @@ void setBuildStatus(String credential_id, String context, String state, String m
 
 pipeline {
   agent any
-
-
+  options {
+    disableConcurrentBuilds()
+  }
   stages {
     stage('Checkout') {
       steps {


### PR DESCRIPTION
# Summary

Add `options { disableConcurrentBuilds() }` to the dev, staging, and prod Jenkinsfiles so two pipeline runs can never deploy to the same fixed container name at the same time.

# Rationale

dev.iuga.info build #467 failed in the Deploy stage because it overlapped with #466 (127s run). Both builds race on the fixed container name `iuga-web-dev`:

1. #467's `docker rm -f iuga-web-dev` ran before #466 had created the container
2. #466's `docker run` created container `01663ff23a5ec`
3. #467's `docker run --name iuga-web-dev` then failed with `Conflict. The container name \"/iuga-web-dev\" is already in use` (exit 125)

Same latent race exists in staging (`iuga-web-staging`) and prod (`iuga-web-prod`) — both have the identical Deploy pattern, so all three get the guard.

# Tests

- Verified the failing #467 console: Build and Push stages green; Deploy failed only on the container-name conflict
- #466 deployed successfully — the dev app is currently running (container 01663ff23a5ec)
- **Declarative linter on the live Jenkins server accepts all 3 fixed jenkinsfiles** (`pipeline-model-converter/validate` → `Jenkinsfile successfully validated` for dev, staging, prod)
- After merge: rebuild dev pipeline and trigger two builds concurrently to confirm the second queues instead of racing