### PR TITLE
ci(jenkins): health-gate deploys so a broken build never takes the site down

### DIFF
--- a/ci/deploy.groovy
+++ b/ci/deploy.groovy
@@ -1,0 +1,113 @@
+// ci/deploy.groovy
+/*
+Purpose: DRY the Docker build + push + health-gated deploy shared by the per-env Jenkinsfiles
+         (dev.jenkinsfile, staging.jenkinsfile, prod.jenkinsfile). Loaded via `load 'ci/deploy.groovy'`,
+         so all build/push/deploy logic lives here exactly once and the pipelines cannot drift
+         (e.g. the earlier bug where staging mounted the prod uploads directory).
+Authentication/Authorization Requirements: N/A (pipeline helper, runs on the Jenkins agent)
+
+Expected Request Information (<r> indicates a required field):
+- cfg (Map, required): image, deployEnv, container, tempPort, realPort, uploadsDir, network
+
+Expected Response Information:
+- return N/A (side effects: images built/pushed; candidate health-checked; live swap or rollback)
+*/
+
+
+// Build an immutable, build-numbered image tag.
+void buildImage(Map cfg) {
+    sh "docker build . -t \"${cfg.image}:${env.BUILD_NUMBER}\" --build-arg DEPLOY_ENV=${cfg.deployEnv}"
+}
+
+// Push the build-numbered image to the registry.
+void pushImage(Map cfg) {
+    sh "docker push ${cfg.image}:${env.BUILD_NUMBER}"
+}
+
+// Health-gated deploy: start the new build as a candidate on a temp port, health
+// check it before touching the live container, swap only if healthy, and roll
+// back to :last-good if the post-swap verification fails. A broken build never
+// takes the site down — the previous working container keeps serving.
+void healthGatedDeploy(Map cfg) {
+    def newImage = "${cfg.image}:${env.BUILD_NUMBER}"
+    def lastGoodImage = "${cfg.image}:last-good"
+    def netFlag = cfg.network ? "--network iuga-server-config_default" : ""
+    sh """
+    CANDIDATE="${cfg.container}-candidate"
+    CONTAINER="${cfg.container}"
+    HEALTH_URL="http://127.0.0.1:${cfg.tempPort}/api/v1/events"
+
+    docker pull "${newImage}"
+    docker rm -f "\${CANDIDATE}" || true
+    docker run -d --name "\${CANDIDATE}" \\
+      -p "127.0.0.1:${cfg.tempPort}:7777" \\
+      -e DEPLOY_ENV=${cfg.deployEnv} \\
+      -e DB_URI="\$DB_URI" \\
+      -e SESSION_SECRET="\$SESSION_SECRET" \\
+      -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
+      ${netFlag}\\
+      "${newImage}"
+
+    # Wait up to 90s for the candidate to pass a health check (app + DB).
+    HEALTHY=0
+    for i in \$(seq 1 30); do
+      if curl -fsS -o /dev/null "\${HEALTH_URL}"; then
+        HEALTHY=1
+        break
+      fi
+      sleep 3
+    done
+
+    if [ "\${HEALTHY}" != "1" ]; then
+      echo "New build failed health check. Keeping the previous working build."
+      docker rm -f "\${CANDIDATE}" || true
+      exit 1
+    fi
+
+    # Healthy: swap the candidate onto the real port and retire the old container.
+    docker rm -f "\${CONTAINER}" || true
+    docker rm -f "\${CANDIDATE}"
+    docker run -d -p "127.0.0.1:${cfg.realPort}:7777" --name "\${CONTAINER}" \\
+      -e DEPLOY_ENV=${cfg.deployEnv} \\
+      -e DB_URI="\$DB_URI" \\
+      -e SESSION_SECRET="\$SESSION_SECRET" \\
+      -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
+      ${netFlag}\\
+      "${newImage}"
+
+    # Verify the promoted container on the real port; roll back if it fails.
+    PROMOTED_OK=0
+    for i in \$(seq 1 10); do
+      if curl -fsS -o /dev/null "http://127.0.0.1:${cfg.realPort}/api/v1/events"; then
+        PROMOTED_OK=1
+        break
+      fi
+      sleep 3
+    done
+
+    if [ "\${PROMOTED_OK}" != "1" ]; then
+      echo "Promoted build failed verification. Rolling back to last-good."
+      docker rm -f "\${CONTAINER}" || true
+      docker pull "${lastGoodImage}" || true
+      docker run -d -p "127.0.0.1:${cfg.realPort}:7777" --name "\${CONTAINER}" \\
+        -e DEPLOY_ENV=${cfg.deployEnv} \\
+        -e DB_URI="\$DB_URI" \\
+        -e SESSION_SECRET="\$SESSION_SECRET" \\
+        -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
+        ${netFlag}\\
+        "${lastGoodImage}"
+      exit 1
+    fi
+    """
+}
+
+// After a successful deploy, record the build as the last known good image so a
+// future deploy can roll back to it. Caller must provide dockerhub credentials.
+void tagLastGood(Map cfg) {
+    sh """
+    docker tag "${cfg.image}:${env.BUILD_NUMBER}" "${cfg.image}:last-good"
+    docker push "${cfg.image}:last-good"
+    """
+}
+
+return this

--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -1,3 +1,35 @@
+// dev.jenkinsfile
+/*
+Purpose: CI/CD pipeline for the dev environment (dev.iuga.info). Builds, pushes, and
+         health-gated-deploys the app image whenever code lands on the `dev` branch.
+         Deploy logic is loaded from ci/deploy.groovy; this file only supplies the
+         per-environment configuration (image names, ports, mounts, network).
+Authentication/Authorization Requirements: N/A (Jenkins job, triggered by GitHub push webhook)
+
+Expected Request Information:
+- SCM: checks out the `dev` branch with its submodules
+- Credentials used (Configure Jenkins > Credentials): dockerhub (image push),
+  devDBUri → DB_URI, SESSION_SECRET (runtime env vars)
+- cfg (Map): per-environment values passed to the shared deploy helpers
+
+Expected Response Information:
+- return N/A (sets GitHub status context iuga/jenkins/cicd/dev; deploys or fails safely)
+*/
+
+// Shared Docker build/push/deploy helpers, defined once in ci/deploy.groovy.
+def deploy = load 'ci/deploy.groovy'
+
+// Per-environment config consumed by the shared helpers in ci/deploy.groovy.
+def cfg = [
+    image:     'iuga/iuga-web-app-development',
+    deployEnv: 'development',
+    container: 'iuga-web-dev',
+    tempPort:  6667,
+    realPort:  6666,
+    uploadsDir: '/var/lib/iuga-web-app/uploads/dev',
+    network:   false,   // dev container does not join the shared docker network
+]
+
 void setBuildStatus(String credential_id, String context, String state, String message) {
     def gitCommit = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
     def targetUrl = env.RUN_DISPLAY_URL
@@ -16,7 +48,6 @@ pipeline {
         stage('Checkout') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/dev", "pending", "Checking out repository...");
-                // Checkout with submodules
                 checkout([
                     $class: 'GitSCM',
                     branches: [[name: '*/dev']],
@@ -34,43 +65,38 @@ pipeline {
             steps {
                 sh 'git submodule update --init --recursive'
             }
-        } 
+        }
         stage('Build') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/dev", "pending", "Building application...");
-                sh 'docker build . -t "iuga/iuga-web-app-development" --build-arg DEPLOY_ENV=development'
+                deploy.buildImage(cfg)
             }
         }
         stage('Push to Registry') {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        sh 'docker login -u $USERNAME -p $PASSWORD'
+                    sh 'docker login -u $USERNAME -p $PASSWORD'
                 }
-                sh 'docker push iuga/iuga-web-app-development'
+                deploy.pushImage(cfg)
             }
         }
         stage('Deploy') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/dev", "pending", "Deploying application...");
-                sh 'docker pull iuga/iuga-web-app-development'
-                sh 'docker rm -f iuga-web-dev || true'
                 withCredentials([
                     string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
-                    sh '''
-                    docker run -d -p "127.0.0.1:6666:7777" --name iuga-web-dev \
-                    -e DEPLOY_ENV=development \
-                    -e DB_URI="$DB_URI" \
-                    -e SESSION_SECRET="$SESSION_SECRET" \
-                    -v /var/lib/iuga-web-app/uploads/dev:/app/backend/public/uploads \
-                    iuga/iuga-web-app-development
-                    '''
+                    deploy.healthGatedDeploy(cfg)
+                }
+                // Record this build as the known-good image, available for future rollbacks.
+                withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                    deploy.tagLastGood(cfg)
                 }
             }
         }
     }
-    
+
     post {
         success {
             setBuildStatus("github_classic", "iuga/jenkins/cicd/dev", "success", "Pipeline succeeded!");

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,18 +12,19 @@ Every environment (dev, staging, production) follows the same five-stage pipelin
 
 | Stage | What happens | Responsibility |
 |---|---|---|
-| Checkout | Jenkins clones `github.com/UW-IUGA/iuga-web-app` (branch `main`) with submodules using the `github_classic` credential. | Jenkins |
+| Checkout | Jenkins clones `github.com/UW-IUGA/iuga-web-app` (dev & prod use explicit branches; staging uses `checkout scm`) with submodules using the `github_classic` credential. | Jenkins |
 | Build | `docker build` with `--build-arg DEPLOY_ENV` selects the target environment's API URL via sed transforms in the Dockerfile. | Jenkins |
 | Push to Registry | `docker push` to Docker Hub after authenticating with the `dockerhub` credential. | Docker Hub |
-| Deploy | `docker pull`, stop/remove old container, `docker run` with env variables and volume mounts. | Production host |
+| Deploy | `docker pull`, start the new build as a candidate on a temp port, health-check it (`/api/v1/events`), then swap onto the live port only if healthy. **A broken build never takes the site down** — the previous working container keeps serving and the pipeline fails. | Production host |
 | Status report | Jenkins posts a commit status to GitHub (`iuga/jenkins/cicd/<env>`). | Jenkins |
 
 ### Trigger
 
-- **Dev / Staging / Production:** A push to `main` triggers all three pipelines (they run independently).
-- **Staging only:** Uses `checkout scm` (multibranch pipeline); the others use explicit branch `*/main`.
+- **Dev:** A push to the `dev` branch triggers the dev pipeline (checks out `*/dev`).
+- **Production:** A push to `main` triggers the production pipeline (checks out `*/main`).
+- **Staging:** Uses `checkout scm` (multibranch pipeline — runs for whichever branch/tag triggered the job).
 
-> **Note:** All environments deploy from the `main` branch. There is no per-environment branch strategy.
+> **Note:** Dev and production have their own branches; staging follows whatever branch triggered its multibranch job. There is no single shared branch for all three.
 
 ---
 
@@ -36,8 +37,9 @@ Every environment (dev, staging, production) follows the same five-stage pipelin
 - **Host port:** `6666` → container port `7777`
 - **Network:** None (default bridge)
 - **Volume:** `/var/lib/iuga-web-app/uploads/dev:/app/backend/public/uploads`
-- **DB credentials:** `devDBUsername`, `devDBPassword` (Jenkins string credentials)
-- **Database:** MongoDB Atlas (`cluster0.ejo8heu.mongodb.net`)
+- **DB credentials:** `devDBUri` (Jenkins string credential → `DB_URI`), `SESSION_SECRET` (string credential)
+- **Database:** MongoDB Atlas (dev database)
+- **Deploy pattern:** health-gated candidate swap; temp port `6667` → live port `6666`; tags images `:${BUILD_NUMBER}` and `:last-good`
 - **Commit status context:** `iuga/jenkins/cicd/dev`
 
 ### `staging.jenkinsfile` (Staging)
@@ -47,9 +49,10 @@ Every environment (dev, staging, production) follows the same five-stage pipelin
 - **Container name:** `iuga-web-staging`
 - **Host port:** `7777` → container port `7777`
 - **Network:** `iuga-server-config_default`
-- **Volume:** `/var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads`
-- **DB credentials:** `prodDBUsername`, `prodDBPassword` (Jenkins string credentials — staging shares the production database)
+- **Volume:** `/var/lib/iuga-web-app/uploads/staging:/app/backend/public/uploads`
+- **DB credentials:** `devDBUri` (Jenkins string credential → `DB_URI`), `SESSION_SECRET` (string credential)
 - **Database:** MongoDB container at `mongo:27017` (via `iuga-server-config_default` network)
+- **Deploy pattern:** health-gated candidate swap; temp port `7778` → live port `7777`; tags images `:${BUILD_NUMBER}` and `:last-good`
 - **Commit status context:** `iuga/jenkins/cicd/staging`
 
 ### `prod.jenkinsfile` (Production)
@@ -59,8 +62,9 @@ Every environment (dev, staging, production) follows the same five-stage pipelin
 - **Host port:** `8888` → container port `7777`
 - **Network:** `iuga-server-config_default`
 - **Volume:** `/var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads`
-- **DB credentials:** `prodDBUsername`, `prodDBPassword` (Jenkins string credentials)
+- **DB credentials:** `devDBUri` (Jenkins string credential → `DB_URI`), `SESSION_SECRET` (string credential)
 - **Database:** MongoDB container at `mongo:27017` (via `iuga-server-config_default` network)
+- **Deploy pattern:** health-gated candidate swap; temp port `8889` → live port `8888`; tags images `:${BUILD_NUMBER}` and `:last-good`
 - **Commit status context:** `iuga/jenkins/cicd/prod`
 
 ---
@@ -73,10 +77,8 @@ Jenkins requires these credential IDs (values are **not** in this repository):
 |---|---|---|
 | `github_classic` | Username+Password | GitHub API authentication for checkout and commit status updates |
 | `dockerhub` | Username+Password | Docker Hub login for image push |
-| `devDBUsername` | String | MongoDB dev database username |
-| `devDBPassword` | String | MongoDB dev database password |
-| `prodDBUsername` | String | MongoDB production/staging database username |
-| `prodDBPassword` | String | MongoDB production/staging database password |
+| `devDBUri` | String | MongoDB connection URI (injected as `DB_URI` env var) for all environments |
+| `SESSION_SECRET` | String | Session signing secret for all environments |
 
 ---
 
@@ -125,9 +127,47 @@ The [Dockerfile](../Dockerfile) is a multi-stage build:
          │              │  mongo:27017 (MongoDB container via external config)
          │              └───────────┘
          │
-    MongoDB Atlas
-    (cluster0.ejo8heu.mongodb.net)
+    MongoDB Atlas (dev)
 ```
+
+### Deploy-time health-gated swap (try and fall back)
+
+Every deploy follows this flow per environment. The previous working container is never touched until the new build proves healthy:
+
+```
+                       ┌────────────────────────────────────────────────────────┐
+                       │ 1. Build & push image iuga/iuga-web-app-<env>:${BUILD_NUMBER} │
+                       └───────────────────────────┬────────────────────────────┘
+                                                   ▼
+                       ┌────────────────────────────────────────────────────────┐
+                       │ 2. Start candidate on TEMP port                       │
+                       │    (old container untouched — still serving on live)   │
+                       └───────────────────────────┬────────────────────────────┘
+                                                   ▼
+                       ┌────────────────────────────────────────────────────────┐
+                       │ 3. Health check  GET /api/v1/events  (up to 90s)      │
+                       └──────────┬─────────────────────────────┬───────────────┘
+                                  │ healthy (200)               │ failure
+                                  ▼                             ▼
+        ┌─────────────────────────────────────┐   ┌──────────────────────────────────┐
+        │ 4. Swap: retire old container,      │   │ 5. Remove candidate, pipeline    │
+        │    run new image on LIVE port       │   │    FAILS — previous working      │
+        └──────────────────┬──────────────────┘   │    container keeps serving       │
+                           ▼                       └──────────────────────────────────┘
+        ┌─────────────────────────────────────┐
+        │ 6. Re-check new container on live   │
+        │    port (up to 30s)                 │
+        └──────────┬──────────────────────────┘
+                   │ failure
+                   ▼
+        ┌─────────────────────────────────────┐
+        │ 7. Rollback: re-run the :last-good  │
+        │    image on live port, pipeline     │
+        │    FAILS (site stays up)            │
+        └─────────────────────────────────────┘
+```
+
+On a successful deploy, the image is tagged `:last-good` so the fallback image is always the last build that passed the health check.
 
 ### What is managed by this repository
 
@@ -166,7 +206,7 @@ Expected output: `STATUS Up <time>`, port mapping matches the table above.
 
 ```bash
 # From the host
-curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/api/v1/events
 # Dev: 6666, Staging: 7777, Prod: 8888
 ```
 
@@ -196,22 +236,25 @@ mongoose models created
 
 ### 6. Check image was pushed to Docker Hub
 
-Visit `https://hub.docker.com/r/iuga/iuga-web-app-<env>/tags` and confirm the latest tag has the expected build timestamp.
+Visit `https://hub.docker.com/r/iuga/iuga-web-app-<env>/tags` and confirm a tag for the latest `BUILD_NUMBER` exists. After a successful deploy, the matching `last-good` tag is also updated — that tag always points at the last build that passed the health check.
 
 ---
 
 ## Rollback
 
-This repo does not define an automated rollback mechanism. To roll back:
+The pipeline now deploys with an **automated health gate**, so a broken build does not take the site down:
 
-1. Identify the previous working image tag on Docker Hub.
-2. On the production host, pull and run the old image:
-   ```bash
-   docker pull iuga/iuga-web-app-<env>:<previous-tag>
-   docker rm -f iuga-web-<env>
-   docker run ... iuga/iuga-web-app-<env>:<previous-tag>
-   ```
-3. (If appropriate) revert the Git commit and re-run the pipeline.
+1. **Before switchover:** the new build starts as a candidate on a temp port and is health-checked against `GET /api/v1/events` (up to 90s). If it fails, the candidate is removed, the old container keeps serving, and the pipeline fails — **no action needed**.
+2. **After switchover:** the promoted container is re-checked on the live port (up to 30s). If it fails, the pipeline automatically rolls back to the `:last-good` image (the last build that passed the health check) and reports failure.
+3. **Immutable images:** every build is tagged with its Jenkins `BUILD_NUMBER`, so the previous working image is always available on Docker Hub.
+
+### Manual rollback (if ever needed)
+
+```bash
+docker pull iuga/iuga-web-app-<env>:last-good
+docker rm -f iuga-web-<env>
+docker run ... iuga/iuga-web-app-<env>:last-good
+```
 
 ---
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -76,7 +76,7 @@ Ensure the uploads volume has free space. MongoDB data and user uploads live her
 
 ### 1.7 Verify Jenkins job status via GitHub commit status
 
-On any commit in the `main` branch, look for these contexts:
+On any commit on the `dev`/`main` branches (or the triggering branch for staging), look for these contexts:
 - `iuga/jenkins/cicd/dev`
 - `iuga/jenkins/cicd/staging`
 - `iuga/jenkins/cicd/prod`
@@ -163,8 +163,8 @@ Credentials are stored in Jenkins. This repository references them by ID only.
 |---|---|---|
 | `github_classic` | Per GitHub token expiry | [Team lead / IT] — *Escalate to fill* |
 | `dockerhub` | Per Docker Hub policy | [Team lead / IT] — *Escalate to fill* |
-| `devDBUsername` / `devDBPassword` | As needed | [Database admin] — *Escalate to fill* |
-| `prodDBUsername` / `prodDBPassword` | As needed | [Database admin] — *Escalate to fill* |
+| `devDBUri` | As needed | [Database admin] — *Escalate to fill* |
+| `SESSION_SECRET` | As needed | [Team lead / IT] — *Escalate to fill* |
 
 When rotating, update the credential in Jenkins directly. No application code changes are needed.
 

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -1,3 +1,35 @@
+// prod.jenkinsfile
+/*
+Purpose: CI/CD pipeline for the production environment (iuga.info). Builds, pushes, and
+         health-gated-deploys the app image whenever code lands on the `main` branch.
+         Deploy logic is loaded from ci/deploy.groovy; this file only supplies the
+         per-environment configuration (image names, ports, mounts, network).
+Authentication/Authorization Requirements: N/A (Jenkins job, triggered by GitHub push webhook)
+
+Expected Request Information:
+- SCM: checks out the `main` branch with its submodules
+- Credentials used (Configure Jenkins > Credentials): dockerhub (image push),
+  devDBUri → DB_URI, SESSION_SECRET (runtime env vars)
+- cfg (Map): per-environment values passed to the shared deploy helpers
+
+Expected Response Information:
+- return N/A (sets GitHub status context iuga/jenkins/cicd/prod; deploys or fails safely)
+*/
+
+// Shared Docker build/push/deploy helpers, defined once in ci/deploy.groovy.
+def deploy = load 'ci/deploy.groovy'
+
+// Per-environment config consumed by the shared helpers in ci/deploy.groovy.
+def cfg = [
+    image:     'iuga/iuga-web-app-production',
+    deployEnv: 'production',
+    container: 'iuga-web-prod',
+    tempPort:  8889,
+    realPort:  8888,
+    uploadsDir: '/var/lib/iuga-web-app/uploads/prod',
+    network:   true,   // prod joins the shared docker network
+]
+
 void setBuildStatus(String credential_id, String context, String state, String message) {
     def gitCommit = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
     def targetUrl = env.RUN_DISPLAY_URL
@@ -34,44 +66,38 @@ pipeline {
             steps {
                 sh 'git submodule update --init --recursive'
             }
-        }   
+        }
         stage('Build') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/prod", "pending", "Building application...");
-                sh 'docker build . -t "iuga/iuga-web-app-production" --build-arg DEPLOY_ENV=production'
+                deploy.buildImage(cfg)
             }
         }
         stage('Push to Registry') {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        sh 'docker login -u $USERNAME -p $PASSWORD'
+                    sh 'docker login -u $USERNAME -p $PASSWORD'
                 }
-                sh 'docker push iuga/iuga-web-app-production'
+                deploy.pushImage(cfg)
             }
         }
         stage('Deploy') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/prod", "pending", "Deploying application...");
-                sh 'docker pull iuga/iuga-web-app-production'
-                sh 'docker rm -f iuga-web-prod || true'
                 withCredentials([
                     string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
-                    sh '''
-                    docker run -d -p "127.0.0.1:8888:7777" --name iuga-web-prod \
-                    -e DEPLOY_ENV=production \
-                    -e DB_URI="$DB_URI" \
-                    -e SESSION_SECRET="$SESSION_SECRET" \
-                    -v /var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads \
-                    --network iuga-server-config_default \
-                    iuga/iuga-web-app-production
-                    '''
+                    deploy.healthGatedDeploy(cfg)
+                }
+                // Record this build as the known-good image, available for future rollbacks.
+                withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                    deploy.tagLastGood(cfg)
                 }
             }
         }
     }
-    
+
     post {
         success {
             setBuildStatus("github_classic", "iuga/jenkins/cicd/prod", "success", "Pipeline succeeded!");

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -1,71 +1,98 @@
+// staging.jenkinsfile
+/*
+Purpose: CI/CD pipeline for the staging environment (staging.iuga.info). Builds, pushes,
+         and health-gated-deploys the app image. Runs as a multibranch job that deploys
+         whichever branch triggered it (typically a release candidate reviewed before prod).
+         Deploy logic is loaded from ci/deploy.groovy; this file only supplies the
+         per-environment configuration (image names, ports, mounts, network).
+Authentication/Authorization Requirements: N/A (Jenkins job, triggered by GitHub push webhook)
+
+Expected Request Information:
+- SCM: multibranch `checkout scm` with submodules initialized in the Checkout stage
+- Credentials used (Configure Jenkins > Credentials): dockerhub (image push),
+  devDBUri → DB_URI, SESSION_SECRET (runtime env vars)
+- cfg (Map): per-environment values passed to the shared deploy helpers
+
+Expected Response Information:
+- return N/A (sets GitHub status context iuga/jenkins/cicd/staging; deploys or fails safely)
+*/
+
+// Shared Docker build/push/deploy helpers, defined once in ci/deploy.groovy.
+def deploy = load 'ci/deploy.groovy'
+
+// Per-environment config consumed by the shared helpers in ci/deploy.groovy.
+def cfg = [
+    image:     'iuga/iuga-web-app-staging',
+    deployEnv: 'staging',
+    container: 'iuga-web-staging',
+    tempPort:  7778,
+    realPort:  7777,
+    uploadsDir: '/var/lib/iuga-web-app/uploads/staging',
+    network:   true,   // staging joins the shared docker network
+]
+
 void setBuildStatus(String credential_id, String context, String state, String message) {
-  def gitCommit = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
-  def targetUrl = env.RUN_DISPLAY_URL
-  def data = """{"state":"${state}","target_url":"${targetUrl}","description":"${message}","context":"${context}"}"""
-  withCredentials([usernamePassword(credentialsId: credential_id, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-    sh "curl -X POST --user $USERNAME:$PASSWORD --data '${data}' --url https://api.github.com/repos/UW-IUGA/iuga-web-app/statuses/${gitCommit}"
-  }
+    def gitCommit = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+    def targetUrl = env.RUN_DISPLAY_URL
+    def data = """{"state":"${state}","target_url":"${targetUrl}","description":"${message}","context":"${context}"}"""
+    withCredentials([usernamePassword(credentialsId: credential_id, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+        sh "curl -X POST --user $USERNAME:$PASSWORD --data '${data}' --url https://api.github.com/repos/UW-IUGA/iuga-web-app/statuses/${gitCommit}"
+    }
 }
 
 pipeline {
-  agent any
-  options {
-    disableConcurrentBuilds()
-  }
-  stages {
-    stage('Checkout') {
-      steps {
-        setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Checking out repository...')
-        checkout scm
-        sh 'git submodule update --init --recursive'
-      }
+    agent any
+    options {
+        disableConcurrentBuilds()
     }
-
-    stage('Build') {
-      steps {
-        setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Building application...')
-        sh 'docker build . -t "iuga/iuga-web-app-staging" --build-arg DEPLOY_ENV=staging'
-      }
-    }
-
-    stage('Push to Registry') {
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-          sh 'docker login -u $USERNAME -p $PASSWORD'
+    stages {
+        stage('Checkout') {
+            steps {
+                setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Checking out repository...')
+                checkout scm
+                sh 'git submodule update --init --recursive'
+            }
         }
-        sh 'docker push iuga/iuga-web-app-staging'
-      }
-    }
 
-    stage('Deploy') {
-      steps {
-        setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Deploying application...')
-        sh 'docker pull iuga/iuga-web-app-staging'
-        sh 'docker rm -f iuga-web-staging || true'
-        withCredentials([
-          string(credentialsId: 'devDBUri', variable: 'DB_URI'),
-          string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
-        ]) {
-          sh '''
-            docker run -d -p "127.0.0.1:7777:7777" --name iuga-web-staging \
-            -e DEPLOY_ENV=staging \
-            -e DB_URI="$DB_URI" \
-            -e SESSION_SECRET="$SESSION_SECRET" \
-            -v /var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads \
-            --network iuga-server-config_default \
-            iuga/iuga-web-app-staging
-          '''
+        stage('Build') {
+            steps {
+                setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Building application...')
+                deploy.buildImage(cfg)
+            }
         }
-      }
-    }
-  }
 
-  post {
-    success {
-      setBuildStatus('github_classic','iuga/jenkins/cicd/staging','success','Pipeline succeeded!')
+        stage('Push to Registry') {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                    sh 'docker login -u $USERNAME -p $PASSWORD'
+                }
+                deploy.pushImage(cfg)
+            }
+        }
+
+        stage('Deploy') {
+            steps {
+                setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Deploying application...')
+                withCredentials([
+                  string(credentialsId: 'devDBUri', variable: 'DB_URI'),
+                  string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
+                ]) {
+                    deploy.healthGatedDeploy(cfg)
+                }
+                // Record this build as the known-good image, available for future rollbacks.
+                withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                    deploy.tagLastGood(cfg)
+                }
+            }
+        }
     }
-    failure {
-      setBuildStatus('github_classic','iuga/jenkins/cicd/staging','failure','Pipeline failed.')
+
+    post {
+        success {
+            setBuildStatus('github_classic','iuga/jenkins/cicd/staging','success','Pipeline succeeded!')
+        }
+        failure {
+            setBuildStatus('github_classic','iuga/jenkins/cicd/staging','failure','Pipeline failed.')
+        }
     }
-  }
 }


### PR DESCRIPTION
## Summary

Fixes the Jenkins deploy so a failed or broken build keeps the **previous working build** serving instead of taking the site down.

**Before:** every jenkinsfile deployed with a kill-then-run pattern — `docker pull <mutable tag>` → `docker rm -f iuga-web-<env>` → `docker run`. The working container was destroyed *before* the new build started, and mutable image tags meant the previous working image was overwritten and unrecoverable.

**After:** every environment deploys through a health-gated candidate swap:

1. Build & push an **immutable** image tagged `:<BUILD_NUMBER>`
2. Start the new build as a **candidate on a temp port** (old container untouched, still serving)
3. Health-check `GET /api/v1/events` (up to 90s) — proves app **and** DB are up
4. Healthy → swap candidate onto the live port; failure → remove candidate, pipeline fails, **old container keeps serving**
5. Post-swap re-check on live port (up to 30s); failure → auto-rollback to the `:last-good` image
6. On success, tag & push `:last-good` so the fallback is always the last build that passed the health check

The duplicated build/push/deploy logic across the three jenkinsfiles is now extracted into a single shared `ci/deploy.groovy` (loaded via Jenkins' built-in `load`), so the pipelines cannot drift.

## Rationale

- **Deploy safety:** the previous `docker rm -f`-before-`docker run` pattern deployed *known-broken* builds and left the site down with no fallback. The health gate inverts the risk: the old container is only retired after the new one proves healthy.
- **Immutable tags:** `:<BUILD_NUMBER>` makes every build recoverable on Docker Hub; `:last-good` gives an always-known-good rollback target.
- **DRY:** the three jenkinsfiles were ~90% identical; a shared helper removes the class of bug where one env drifted (a real staging copy-paste bug mounting `uploads/prod` was found and fixed).
- **Zero infrastructure changes:** uses the built-in `load` step — no Jenkins shared-library repo or server config needed.

## Tests

The refactored deploy logic was **simulated against real Docker** using the actual `ci/deploy.groovy` source (rendered faithfully via a Groovy-GString emulation harness, verified with `bash -n`). Three scenarios, all passing:

| Scenario | Setup | Result |
|---|---|---|
| **Happy path** | Candidate started on temp port with a healthy image (app + local MongoDB) | Candidate health check 200 → old container retired → new image promoted on live port → HTTP 200 ✅ |
| **Broken build rejected** | Candidate started with unreachable DB (bad port) | Health gate fails (no 200 within 90s) → candidate removed → pipeline exits 1 → **old container untouched, live port still HTTP 200** ✅ |
| **Post-swap rollback** | Live container killed after promotion (simulated post-swap death) | 30s verification fails → auto-rollback to `:last-good` image → live port HTTP 200, pipeline exits 1 ✅ |

All sim containers cleaned up afterward.

**Docs:** `docs/DEPLOYMENT.md` (health-gated deploy flow, try-and-fall-back ASCII diagram, corrected branch triggers, corrected credentials `devDBUri`/`SESSION_SECRET`, removed the real Atlas hostname) and `docs/MAINTAINERS.md` (credential table, §1.7 branch note).