### PR TITLE
fix(jenkins): wrap shared deploy calls in script blocks

### DIFF
--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
         stage('Build') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/dev", "pending", "Building application...");
-                deploy.buildImage(cfg)
+                script { deploy.buildImage(cfg) }
             }
         }
         stage('Push to Registry') {
@@ -77,7 +77,7 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'docker login -u $USERNAME -p $PASSWORD'
                 }
-                deploy.pushImage(cfg)
+                script { deploy.pushImage(cfg) }
             }
         }
         stage('Deploy') {
@@ -87,11 +87,11 @@ pipeline {
                     string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
-                    deploy.healthGatedDeploy(cfg)
+                    script { deploy.healthGatedDeploy(cfg) }
                 }
                 // Record this build as the known-good image, available for future rollbacks.
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    deploy.tagLastGood(cfg)
+                    script { deploy.tagLastGood(cfg) }
                 }
             }
         }

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
         stage('Build') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/prod", "pending", "Building application...");
-                deploy.buildImage(cfg)
+                script { deploy.buildImage(cfg) }
             }
         }
         stage('Push to Registry') {
@@ -78,7 +78,7 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'docker login -u $USERNAME -p $PASSWORD'
                 }
-                deploy.pushImage(cfg)
+                script { deploy.pushImage(cfg) }
             }
         }
         stage('Deploy') {
@@ -88,11 +88,11 @@ pipeline {
                     string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
-                    deploy.healthGatedDeploy(cfg)
+                    script { deploy.healthGatedDeploy(cfg) }
                 }
                 // Record this build as the known-good image, available for future rollbacks.
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    deploy.tagLastGood(cfg)
+                    script { deploy.tagLastGood(cfg) }
                 }
             }
         }

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         stage('Build') {
             steps {
                 setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Building application...')
-                deploy.buildImage(cfg)
+                script { deploy.buildImage(cfg) }
             }
         }
 
@@ -66,7 +66,7 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'docker login -u $USERNAME -p $PASSWORD'
                 }
-                deploy.pushImage(cfg)
+                script { deploy.pushImage(cfg) }
             }
         }
 
@@ -77,11 +77,11 @@ pipeline {
                   string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                   string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
-                    deploy.healthGatedDeploy(cfg)
+                    script { deploy.healthGatedDeploy(cfg) }
                 }
                 // Record this build as the known-good image, available for future rollbacks.
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    deploy.tagLastGood(cfg)
+                    script { deploy.tagLastGood(cfg) }
                 }
             }
         }


### PR DESCRIPTION
## Summary

The health-gated deploy refactor (#28) caused every pipeline build to fail at compile time. Build #475 on the `dev` job failed in 1 second with:

```
WorkflowScript: 90: Method calls on objects not allowed outside "script" blocks.
    deploy.healthGatedDeploy(cfg)
```

Jenkins declarative pipelines reject method calls on a `load`ed object directly inside `steps {}` — a Groovy sandbox rule. Each `deploy.*()` call must be wrapped in `script { }`.

This PR wraps all four shared helper calls (`buildImage`, `pushImage`, `healthGatedDeploy`, `tagLastGood`) in `script { }` blocks across all three Jenkinsfiles.

## Rationale

- Without this fix, **every** push to dev/staging/main fails at compile time — the pipeline never reaches the Docker stages.
- The previous build's container keeps serving (safe outcome) but for the wrong reason: the pipeline died before the health gate could run.
- The `script { }` wrapper is the canonical fix for this exact Jenkins sandbox error and changes no pipeline behavior.

## Tests / Verification

1. **Jenkins-side validation** (`pipeline-model-converter/validate` — the same parser that failed build #475):
   - Broken version (origin/dev): reproduced the exact build #475 error — `WorkflowScript: 90: Method calls on objects not allowed outside "script" blocks.` ❌
   - Fixed version (all 3 files): `Jenkinsfile successfully validated.` ✅

2. **Structural check**: all 12 `deploy.*()` calls (4 per file × 3 files) confirmed inside `script { }` blocks.

3. **Deploy behavior** (from #28's Docker simulation — unchanged by this fix): happy-path swap, broken-build rejection keeping the old container, and post-swap rollback to `:last-good` all verified against the rendered `ci/deploy.groovy` payload.

## Files Changed

- `dev.jenkinsfile` (+4/-4)
- `staging.jenkinsfile` (+4/-4)
- `prod.jenkinsfile` (+4/-4)