### PR TITLE
fix(jenkins): load shared deploy helpers inside checkout stage

### DIFF
--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
         stage('Build') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/dev", "pending", "Building application...");
-                deploy.buildImage(cfg)
+                script { deploy.buildImage(cfg) }
             }
         }
         stage('Push to Registry') {
@@ -77,7 +77,7 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'docker login -u $USERNAME -p $PASSWORD'
                 }
-                deploy.pushImage(cfg)
+                script { deploy.pushImage(cfg) }
             }
         }
         stage('Deploy') {
@@ -87,11 +87,11 @@ pipeline {
                     string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
-                    deploy.healthGatedDeploy(cfg)
+                    script { deploy.healthGatedDeploy(cfg) }
                 }
                 // Record this build as the known-good image, available for future rollbacks.
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    deploy.tagLastGood(cfg)
+                    script { deploy.tagLastGood(cfg) }
                 }
             }
         }

--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -17,7 +17,9 @@ Expected Response Information:
 */
 
 // Shared Docker build/push/deploy helpers, defined once in ci/deploy.groovy.
-def deploy = load 'ci/deploy.groovy'
+// Loaded inside the Checkout stage below: `load` needs a workspace context, which
+// only exists inside a stage (top-level load fails with MissingContextVariableException).
+def deploy = null
 
 // Per-environment config consumed by the shared helpers in ci/deploy.groovy.
 def cfg = [
@@ -59,6 +61,8 @@ pipeline {
                         url: 'https://github.com/UW-IUGA/iuga-web-app.git'
                     ]]
                 ])
+                // load needs a workspace; the file is only present after checkout
+                script { deploy = load 'ci/deploy.groovy' }
             }
         }
         stage('Initialize Submodules') {

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
         stage('Build') {
             steps {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/prod", "pending", "Building application...");
-                deploy.buildImage(cfg)
+                script { deploy.buildImage(cfg) }
             }
         }
         stage('Push to Registry') {
@@ -78,7 +78,7 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'docker login -u $USERNAME -p $PASSWORD'
                 }
-                deploy.pushImage(cfg)
+                script { deploy.pushImage(cfg) }
             }
         }
         stage('Deploy') {
@@ -88,11 +88,11 @@ pipeline {
                     string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                     string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
-                    deploy.healthGatedDeploy(cfg)
+                    script { deploy.healthGatedDeploy(cfg) }
                 }
                 // Record this build as the known-good image, available for future rollbacks.
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    deploy.tagLastGood(cfg)
+                    script { deploy.tagLastGood(cfg) }
                 }
             }
         }

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -17,7 +17,9 @@ Expected Response Information:
 */
 
 // Shared Docker build/push/deploy helpers, defined once in ci/deploy.groovy.
-def deploy = load 'ci/deploy.groovy'
+// Loaded inside the Checkout stage below: `load` needs a workspace context, which
+// only exists inside a stage (top-level load fails with MissingContextVariableException).
+def deploy = null
 
 // Per-environment config consumed by the shared helpers in ci/deploy.groovy.
 def cfg = [
@@ -60,6 +62,8 @@ pipeline {
                         url: 'https://github.com/UW-IUGA/iuga-web-app.git'
                     ]]
                 ])
+                // load needs a workspace; the file is only present after checkout
+                script { deploy = load 'ci/deploy.groovy' }
             }
         }
         stage('Initialize Submodules') {

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -18,7 +18,9 @@ Expected Response Information:
 */
 
 // Shared Docker build/push/deploy helpers, defined once in ci/deploy.groovy.
-def deploy = load 'ci/deploy.groovy'
+// Loaded inside the Checkout stage below: `load` needs a workspace context, which
+// only exists inside a stage (top-level load fails with MissingContextVariableException).
+def deploy = null
 
 // Per-environment config consumed by the shared helpers in ci/deploy.groovy.
 def cfg = [
@@ -51,6 +53,8 @@ pipeline {
                 setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Checking out repository...')
                 checkout scm
                 sh 'git submodule update --init --recursive'
+                // load needs a workspace; the file is only present after checkout
+                script { deploy = load 'ci/deploy.groovy' }
             }
         }
 

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         stage('Build') {
             steps {
                 setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Building application...')
-                deploy.buildImage(cfg)
+                script { deploy.buildImage(cfg) }
             }
         }
 
@@ -66,7 +66,7 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'docker login -u $USERNAME -p $PASSWORD'
                 }
-                deploy.pushImage(cfg)
+                script { deploy.pushImage(cfg) }
             }
         }
 
@@ -77,11 +77,11 @@ pipeline {
                   string(credentialsId: 'devDBUri', variable: 'DB_URI'),
                   string(credentialsId: 'SESSION_SECRET', variable: 'SESSION_SECRET'),
                 ]) {
-                    deploy.healthGatedDeploy(cfg)
+                    script { deploy.healthGatedDeploy(cfg) }
                 }
                 // Record this build as the known-good image, available for future rollbacks.
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    deploy.tagLastGood(cfg)
+                    script { deploy.tagLastGood(cfg) }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes the dev/staging/prod Jenkins pipelines failing with `MissingContextVariableException` immediately after the CI refactor (PR #28) and the `script{}` wrapper fix (PR #29).

**Root cause:** `def deploy = load 'ci/deploy.groovy'` was declared at the top level of each Jenkinsfile. The `load` step reads the file from the workspace, but at script top level there is **no workspace (FilePath) context** — that only exists inside a stage. Result: every build died in ~1s at `WorkflowScript:20` before touching Docker.

**Fix:** declare `def deploy = null` at top level, and assign `deploy = load 'ci/deploy.groovy'` inside the Checkout stage (after checkout, when the file is present and the workspace context exists).

## Rationale
- The deploy itself never runs in the failed builds — the pipeline crashes at load time. This fix unblocks the health-gated deploy (candidate on temp port → health check → swap → `:last-good` rollback) so a broken build can never take the site down.
- The check-out-then-load ordering matters: `load` requires the file to exist in the workspace, which is only guaranteed after checkout.

## Tests
- **Local Jenkins in Docker (real Jenkins engine, real `ci/deploy.groovy`):**
  - `runA-broken` (top-level `load`, the broken pattern): reproduced the exact error from builds #476–478 — `Required context class hudson.FilePath is missing`, `Finished: FAILURE`.
  - `runB-fixed` (null + load inside Checkout stage, this fix): `deploy loaded: true` → `RUN B PASSED: load inside stage works, deploy helper callable`, `Finished: SUCCESS`.
- Jenkins pipeline-model validator: all 3 files validate (compile-time check; the top-level load error is runtime-only, which is why the previous validator check passed).