### PR TITLE
perf: optimize pipeline build and deploy health gate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.omo
+.agents
+node_modules
+**/node_modules
+frontend/build
+backend/env
+*.log
+.DS_Store
+docs
+.github
+ci
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM node:22-alpine AS build
 ARG DEPLOY_ENV
@@ -6,7 +7,7 @@ ENV PORT=7777
 
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
-RUN npm install
+RUN --mount=type=cache,target=/root/.npm npm ci
 COPY frontend/ ./
 
 RUN if [ "$DEPLOY_ENV" = "production" ] ; then sed -i 's#http://localhost:7777/#https://iuga.info/#' src/authConfig.js ; fi
@@ -17,12 +18,11 @@ RUN npm run build
 
 # Production stage
 FROM node:22-alpine
-RUN apk add --no-cache tzdata
 RUN apk add --no-cache tzdata git
 ENV TZ=America/Los_Angeles
 WORKDIR /app/backend
 COPY backend/package*.json ./
-RUN npm install --production
+RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
 
 COPY backend/ ./
 COPY --from=build /app/frontend/build /app/frontend/build

--- a/backend/app.js
+++ b/backend/app.js
@@ -17,6 +17,10 @@ const __dirname = dirname(__filename);
 await connectToDatabase();
 const app = express();
 
+// Readiness probe for the pipeline health gate. The listener only starts
+// after the DB connects, so 200 implies the database is reachable.
+app.get('/readyz', (req, res) => res.json({ status: 'ok' }));
+
 if (!process.env.DEPLOY) {
     app.use(cors());
 }

--- a/backend/bin/www.cjs
+++ b/backend/bin/www.cjs
@@ -7,6 +7,7 @@ var debug = require('debug')('vulnalert:server');
 var http = require('http');
 
 const DEFAULT_PORT = '7777';
+const startupStartedAt = Date.now();
 
 (async () => {
   const app = await (await import('../app.js')).default;
@@ -91,7 +92,7 @@ const DEFAULT_PORT = '7777';
     let port = process.env.PORT ? process.env.PORT : DEFAULT_PORT;
 
     if (!process.env.DEBUG) {
-      console.log('Listening at ' + host + ":" + port);
+      console.log(`[startup] Listening at ${host}:${port} after ${Date.now() - startupStartedAt}ms`);
     } else {
       debug('Listening at ' + host + ":" + port);
     }

--- a/backend/models.js
+++ b/backend/models.js
@@ -11,16 +11,17 @@ let models = {};
 async function connectToDatabase(){
     const db_uri = process.env.DB_URI;
     if (!db_uri) throw new Error('DB_URI is not set (set it in backend/env/.env.dev or inject via pipeline)');
-    console.log('connecting to mongodb')
+    const connectionStartedAt = Date.now();
+    console.log(`[startup] connecting to mongodb at ${new Date(connectionStartedAt).toISOString()}`)
     await mongoose.connect(db_uri);
-    console.log("successfully connected to mongodb")
+    console.log(`[startup] successfully connected to mongodb after ${Date.now() - connectionStartedAt}ms`)
 
   models.Events = mongoose.model("Events", eventsSchema);
   models.Participants = mongoose.model("Participants", participantsSchema);
   models.Users = mongoose.model("Users", usersSchema);
   models.Feedback = mongoose.model("Feedback", feedbackSchema);
 
-  console.log("mongoose models created");
+  console.log(`[startup] mongoose models created after ${Date.now() - connectionStartedAt}ms`);
 }
 
 //Ship the models variable with all the schemas in it to be used externally.

--- a/ci/deploy.groovy
+++ b/ci/deploy.groovy
@@ -35,7 +35,8 @@ void healthGatedDeploy(Map cfg) {
     sh """
     CANDIDATE="${cfg.container}-candidate"
     CONTAINER="${cfg.container}"
-    HEALTH_URL="http://127.0.0.1:${cfg.tempPort}/api/v1/events"
+    HEALTH_URL="http://127.0.0.1:${cfg.tempPort}/readyz"
+    DEPLOY_START=\$(date +%s)
 
     docker pull "${newImage}"
     docker rm -f "\${CANDIDATE}" || true
@@ -47,10 +48,11 @@ void healthGatedDeploy(Map cfg) {
       -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
       ${netFlag}\\
       "${newImage}"
+    echo "[timing] candidate container started"
 
-    # Wait up to 90s for the candidate to pass a health check (app + DB).
+    # Wait up to 180s for the candidate to pass a health check (app + DB).
     HEALTHY=0
-    for i in \$(seq 1 30); do
+    for i in \$(seq 1 60); do
       if curl -fsS -o /dev/null "\${HEALTH_URL}"; then
         HEALTHY=1
         break
@@ -65,6 +67,7 @@ void healthGatedDeploy(Map cfg) {
       docker rm -f "\${CANDIDATE}" || true
       exit 1
     fi
+    echo "[timing] candidate passed health check after \$(( \$(date +%s) - DEPLOY_START ))s"
 
     # Healthy: swap the candidate onto the real port and retire the old container.
     docker rm -f "\${CONTAINER}" || true
@@ -76,11 +79,12 @@ void healthGatedDeploy(Map cfg) {
       -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
       ${netFlag}\\
       "${newImage}"
+    echo "[timing] live container swapped to port ${cfg.realPort}"
 
     # Verify the promoted container on the real port; roll back if it fails.
     PROMOTED_OK=0
     for i in \$(seq 1 10); do
-      if curl -fsS -o /dev/null "http://127.0.0.1:${cfg.realPort}/api/v1/events"; then
+      if curl -fsS -o /dev/null "http://127.0.0.1:${cfg.realPort}/readyz"; then
         PROMOTED_OK=1
         break
       fi
@@ -100,6 +104,7 @@ void healthGatedDeploy(Map cfg) {
         "${lastGoodImage}"
       exit 1
     fi
+    echo "[timing] promoted container verified; total deploy time \$(( \$(date +%s) - DEPLOY_START ))s"
     """
 }
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -15,7 +15,7 @@ Every environment (dev, staging, production) follows the same five-stage pipelin
 | Checkout | Jenkins clones `github.com/UW-IUGA/iuga-web-app` (dev & prod use explicit branches; staging uses `checkout scm`) with submodules using the `github_classic` credential. | Jenkins |
 | Build | `docker build` with `--build-arg DEPLOY_ENV` selects the target environment's API URL via sed transforms in the Dockerfile. | Jenkins |
 | Push to Registry | `docker push` to Docker Hub after authenticating with the `dockerhub` credential. | Docker Hub |
-| Deploy | `docker pull`, start the new build as a candidate on a temp port, health-check it (`/api/v1/events`), then swap onto the live port only if healthy. **A broken build never takes the site down** — the previous working container keeps serving and the pipeline fails. | Production host |
+| Deploy | `docker pull`, start the new build as a candidate on a temp port, health-check it (`/readyz`), then swap onto the live port only if healthy. **A broken build never takes the site down** — the previous working container keeps serving and the pipeline fails. | Production host |
 | Status report | Jenkins posts a commit status to GitHub (`iuga/jenkins/cicd/<env>`). | Jenkins |
 
 ### Trigger
@@ -145,7 +145,7 @@ Every deploy follows this flow per environment. The previous working container i
                        └───────────────────────────┬────────────────────────────┘
                                                    ▼
                        ┌────────────────────────────────────────────────────────┐
-                       │ 3. Health check  GET /api/v1/events  (up to 90s)      │
+                       │ 3. Health check  GET /readyz  (up to 180s)             │
                        └──────────┬─────────────────────────────┬───────────────┘
                                   │ healthy (200)               │ failure
                                   ▼                             ▼
@@ -206,7 +206,7 @@ Expected output: `STATUS Up <time>`, port mapping matches the table above.
 
 ```bash
 # From the host
-curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/api/v1/events
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/readyz
 # Dev: 6666, Staging: 7777, Prod: 8888
 ```
 
@@ -228,10 +228,10 @@ docker logs iuga-web-<env> --tail 50
 
 Expected: The last lines should show:
 ```
-Listening at 0.0.0.0:7777
-connecting to <prod|dev> database
-successfully connected to <prod|dev> mongodb
-mongoose models created
+[startup] connecting to mongodb at <ISO timestamp>
+[startup] successfully connected to mongodb after <N>ms
+[startup] mongoose models created after <N>ms
+[startup] Listening at 0.0.0.0:7777 after <N>ms
 ```
 
 ### 6. Check image was pushed to Docker Hub
@@ -244,7 +244,7 @@ Visit `https://hub.docker.com/r/iuga/iuga-web-app-<env>/tags` and confirm a tag 
 
 The pipeline now deploys with an **automated health gate**, so a broken build does not take the site down:
 
-1. **Before switchover:** the new build starts as a candidate on a temp port and is health-checked against `GET /api/v1/events` (up to 90s). If it fails, the candidate is removed, the old container keeps serving, and the pipeline fails — **no action needed**.
+1. **Before switchover:** the new build starts as a candidate on a temp port and is health-checked against `GET /readyz` (up to 180s). If it fails, the candidate is removed, the old container keeps serving, and the pipeline fails — **no action needed**.
 2. **After switchover:** the promoted container is re-checked on the live port (up to 30s). If it fails, the pipeline automatically rolls back to the `:last-good` image (the last build that passed the health check) and reports failure.
 3. **Immutable images:** every build is tagged with its Jenkins `BUILD_NUMBER`, so the previous working image is always available on Docker Hub.
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -49,7 +49,7 @@ Look for:
 ```bash
 for port in 6666 7777 8888; do
   echo -n "localhost:$port → "
-  curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$port/
+  curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$port/readyz
   echo
 done
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -233,7 +233,7 @@ If no ports are shown, the `-p` flag was omitted from `docker run`.
 ### Step 3 — Can you reach the application from the host?
 
 ```bash
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:<host-port>/
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:<host-port>/readyz
 ```
 
 - **200:** The app is healthy. The issue is in nginx configuration (TLS, proxy_pass URL, upstream definition). **Not managed by this repo.**


### PR DESCRIPTION
## Summary

Optimizes the Jenkins build/deploy pipeline: drastically shrinks the Docker build context, switches to deterministic `npm ci`, replaces the heavy `/api/v1/events` health probe with a lightweight `/readyz` readiness endpoint, widens the health-gate window to 180s, and adds `[startup]`/`[timing]` instrumentation so pipeline behavior is observable.

## Why

- The previous local build shipped a **1.61 GB build context** (no `.dockerignore`) — most of it `.git`, `node_modules`, and build output that Docker never needs.
- `npm install` resolves ranges and may drift from the lockfile; `npm ci` installs exactly the locked versions and is faster and deterministic.
- The pipeline health gate probed `/api/v1/events`, which runs a heavy Mongoose query on every attempt (up to 60 times per deploy). Since the app only listens after MongoDB connects, a 200 on `/readyz` proves DB readiness without any query.
- Dev build #482 showed the app connects to Mongo and listens only after the previous ~90s health window expired, causing a false rollback. The window is now 180s (60 × 3s).

## Approach

- Added `.dockerignore` excluding `.git`, `node_modules`, `frontend/build`, `backend/env`, docs, and CI files.
- `Dockerfile`: BuildKit syntax, `npm ci` with `/root/.npm` cache mounts (frontend + backend), merged duplicate `apk add tzdata` into one layer.
- Added `GET /readyz` in `backend/app.js` after the DB connect — returns `{"status":"ok"}` only once the listener can serve (listener binds only after `connectToDatabase()` resolves).
- `ci/deploy.groovy`: candidate and post-swap health probes now hit `/readyz`; candidate window `seq 1 30` → `seq 1 60` (180s); added `[timing]` phase logs (candidate started, passed health check, swapped, total deploy time).
- `backend/bin/www.cjs` + `backend/models.js`: `[startup]` timestamps for DB connect, model creation, and listener bind.
- Updated `docs/DEPLOYMENT.md`, `docs/MAINTAINERS.md`, `docs/TROUBLESHOOTING.md` to the new `/readyz` probe, 180s window, and `[startup]` log format.

## Architecture and Contracts

- **New API contract:** `GET /readyz` → `200 {"status":"ok"}`. Readiness = database reachable, because the HTTP listener only binds after `connectToDatabase()` resolves in `backend/app.js`.
- **Pipeline contract change:** health probes moved from `/api/v1/events` to `/readyz` (candidate temp port and post-swap real port). Rollback behavior, `/api/v1/events` API itself, and the 30s post-swap verification are unchanged.
- **Build contract change:** `npm ci` requires lockfiles (present at root, `frontend/`, `backend/`, `backend/schemas/`); build now fails if a lockfile is out of sync — intentional.

## Tests

- `docker build . -t iuga/iuga-web-app-development:local-test2 --build-arg DEPLOY_ENV=development` — passed; context transfer dropped from **1.61 GB / ~21s** to **57.79 kB / 1.4s** (~28,000×); both `npm ci` stages resolved from lockfiles; frontend `npm run build` succeeded (pre-existing warnings only).
- E2E against a real MongoDB container (`mongo:7` on `host.docker.internal:27017`):
  - `[startup] connecting to mongodb at 2026-08-10T04:03:09.936Z`
  - `[startup] successfully connected to mongodb after 27ms`
  - `[startup] mongoose models created after 31ms`
  - `[startup] Listening at 0.0.0.0:7777 after 247ms`
  - `GET /readyz` → `{"status":"ok"}`; `GET /api/v1/events` → `[]` (unchanged API).
- `node --check` on `app.js`, `bin/www.cjs`, `models.js` — passed.
- `bash -n` on the extracted `ci/deploy.groovy` shell block — passed (2 `/readyz` refs, 4 `[timing]` logs, `seq 1 60` candidate + `seq 1 10` post-swap intact).
- `git diff --check` — passed.

Not yet exercised: a real Jenkins run on this branch (pipeline timing logs, `/readyz` probe on the dev host, and build-context reduction on the Jenkins host). Health gate + candidate log dump contain any regression.