### PR TITLE
fix(jenkins): make the deploy health check reach the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 # local agent state
 .omo/
 /node_modules
+
+
+# Personal agent guidance
+/AGENTS.md

--- a/ci/deploy.groovy
+++ b/ci/deploy.groovy
@@ -35,25 +35,33 @@ void healthGatedDeploy(Map cfg) {
     sh """
     CANDIDATE="${cfg.container}-candidate"
     CONTAINER="${cfg.container}"
-    HEALTH_URL="http://127.0.0.1:${cfg.tempPort}/readyz"
     DEPLOY_START=\$(date +%s)
+
+    # Exit 0 when the app inside the container answers /readyz on its own port.
+    health_check() {
+      docker exec "\$1" node -e 'fetch("http://127.0.0.1:7777/readyz").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'
+    }
+
+    # Start an app container on a loopback-only host port.
+    run_app() {
+      docker run -d --name "\$1" -p "127.0.0.1:\$2:7777" \\
+        -e DEPLOY_ENV=${cfg.deployEnv} \\
+        -e DB_URI="\$DB_URI" \\
+        -e SESSION_SECRET="\$SESSION_SECRET" \\
+        -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
+        ${netFlag}\\
+        "\$3"
+    }
 
     docker pull "${newImage}"
     docker rm -f "\${CANDIDATE}" || true
-    docker run -d --name "\${CANDIDATE}" \\
-      -p "127.0.0.1:${cfg.tempPort}:7777" \\
-      -e DEPLOY_ENV=${cfg.deployEnv} \\
-      -e DB_URI="\$DB_URI" \\
-      -e SESSION_SECRET="\$SESSION_SECRET" \\
-      -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
-      ${netFlag}\\
-      "${newImage}"
+    run_app "\${CANDIDATE}" ${cfg.tempPort} "${newImage}"
     echo "[timing] candidate container started"
 
     # Wait up to 180s for the candidate to pass a health check (app + DB).
     HEALTHY=0
     for i in \$(seq 1 60); do
-      if curl -fsS -o /dev/null "\${HEALTH_URL}"; then
+      if health_check "\${CANDIDATE}"; then
         HEALTHY=1
         break
       fi
@@ -72,19 +80,13 @@ void healthGatedDeploy(Map cfg) {
     # Healthy: swap the candidate onto the real port and retire the old container.
     docker rm -f "\${CONTAINER}" || true
     docker rm -f "\${CANDIDATE}"
-    docker run -d -p "127.0.0.1:${cfg.realPort}:7777" --name "\${CONTAINER}" \\
-      -e DEPLOY_ENV=${cfg.deployEnv} \\
-      -e DB_URI="\$DB_URI" \\
-      -e SESSION_SECRET="\$SESSION_SECRET" \\
-      -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
-      ${netFlag}\\
-      "${newImage}"
+    run_app "\${CONTAINER}" ${cfg.realPort} "${newImage}"
     echo "[timing] live container swapped to port ${cfg.realPort}"
 
-    # Verify the promoted container on the real port; roll back if it fails.
+    # Verify the promoted container; roll back to last-good if it fails.
     PROMOTED_OK=0
     for i in \$(seq 1 10); do
-      if curl -fsS -o /dev/null "http://127.0.0.1:${cfg.realPort}/readyz"; then
+      if health_check "\${CONTAINER}"; then
         PROMOTED_OK=1
         break
       fi
@@ -95,13 +97,7 @@ void healthGatedDeploy(Map cfg) {
       echo "Promoted build failed verification. Rolling back to last-good."
       docker rm -f "\${CONTAINER}" || true
       docker pull "${lastGoodImage}" || true
-      docker run -d -p "127.0.0.1:${cfg.realPort}:7777" --name "\${CONTAINER}" \\
-        -e DEPLOY_ENV=${cfg.deployEnv} \\
-        -e DB_URI="\$DB_URI" \\
-        -e SESSION_SECRET="\$SESSION_SECRET" \\
-        -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
-        ${netFlag}\\
-        "${lastGoodImage}"
+      run_app "\${CONTAINER}" ${cfg.realPort} "${lastGoodImage}"
       exit 1
     fi
     echo "[timing] promoted container verified; total deploy time \$(( \$(date +%s) - DEPLOY_START ))s"

--- a/ci/test/deploy-groovy.test.js
+++ b/ci/test/deploy-groovy.test.js
@@ -1,0 +1,134 @@
+// Regression test for the health-gated deploy logic in ci/deploy.groovy.
+//
+// Seam: the `sh """` block inside healthGatedDeploy() — the exact shell
+// Jenkins executes. Observable behavior: the sequence of `docker` invocations
+// and the script's exit code, with `docker` stubbed so no daemon is needed.
+//
+// Run: node --test ci/test
+// (point DEPLOY_GROOVY at another file to test a different version, e.g. git show HEAD:ci/deploy.groovy)
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const groovyPath = process.env.DEPLOY_GROOVY || path.join(__dirname, '..', 'deploy.groovy')
+
+// Translate the Groovy shell block into bash: drop the `sh """` markers,
+// unescape `\\` -> `\` and `\$` -> `$`, then substitute concrete values for
+// the Groovy-interpolated variables. `sleep 3` becomes `sleep 0` so failing
+// paths don't wait out the real 180s window.
+function extractShell() {
+    const src = readFileSync(groovyPath, 'utf8')
+    const start = src.indexOf('sh """')
+    const end = src.indexOf('    """', start)
+    assert.ok(start !== -1 && end !== -1, 'deploy.groovy must contain a sh """ block')
+    let shell = src.slice(start + 6, end)
+    shell = shell.replace(/\\\\/g, '\\').replace(/\\\$/g, '$').replace(/sleep 3/g, 'sleep 0')
+    const vars = {
+        '${cfg.container}': 'iuga-test',
+        '${cfg.tempPort}': '16667',
+        '${cfg.realPort}': '16666',
+        '${cfg.deployEnv}': 'development',
+        '${cfg.uploadsDir}': '/tmp/iuga-test-uploads',
+        '${netFlag}': '',
+        '${newImage}': 'iuga/test-app:123',
+        '${lastGoodImage}': 'iuga/test-app:last-good',
+    }
+    for (const [k, v] of Object.entries(vars)) shell = shell.split(k).join(v)
+    return shell
+}
+
+const STUB_OK = '#!/bin/sh\necho "docker $*" >> "$STUB_LOG"\nexit 0\n'
+// Fail every docker exec except the first (candidate check passes, promotion fails).
+const STUB_ROLLBACK = '#!/bin/sh\necho "docker $*" >> "$STUB_LOG"\n' +
+    'if [ "$1" = "exec" ]; then\n' +
+    '  if [ -f "$COUNTER_FILE" ]; then n=$(cat "$COUNTER_FILE"); else n=0; fi\n' +
+    '  n=$((n+1)); echo $n > "$COUNTER_FILE"\n' +
+    '  [ "$n" = "1" ]\n' +
+    'else\n  exit 0\nfi\n'
+// Fail every docker exec (candidate never becomes healthy).
+const STUB_DEAD = '#!/bin/sh\necho "docker $*" >> "$STUB_LOG"\n[ "$1" != "exec" ]\n'
+
+function runDeploy(stubScript) {
+    const dir = mkdtempSync(path.join(tmpdir(), 'deploy-groovy-'))
+    const stubDir = path.join(dir, 'bin')
+    mkdirSync(stubDir)
+    writeFileSync(path.join(stubDir, 'docker'), stubScript)
+    chmodSync(path.join(stubDir, 'docker'), 0o755)
+    const logFile = path.join(dir, 'calls.log')
+    const scriptFile = path.join(dir, 'deploy.sh')
+    writeFileSync(scriptFile, extractShell())
+    const env = {
+        ...process.env,
+        PATH: `${stubDir}:${process.env.PATH}`,
+        STUB_LOG: logFile,
+        COUNTER_FILE: path.join(dir, 'count'),
+        DB_URI: 'mongodb://test-db',
+        SESSION_SECRET: 'test-secret',
+    }
+    let status = 0
+    try {
+        execFileSync('bash', [scriptFile], { env, stdio: 'pipe' })
+    } catch (err) {
+        status = err.status
+    }
+    const calls = readFileSync(logFile, 'utf8').trim().split('\n').filter(Boolean)
+    return { status, calls }
+}
+
+function runCalls(calls, needle) {
+    return calls.filter((c) => c.includes(needle))
+}
+
+test('healthy candidate is promoted to the live port; last-good untouched', () => {
+    const { status, calls } = runDeploy(STUB_OK)
+
+    assert.equal(status, 0)
+    assert.deepEqual(runCalls(calls, 'docker pull'), ['docker pull iuga/test-app:123'])
+    // Candidate starts on the temp port, container name suffixed -candidate.
+    const candidateRun = runCalls(calls, 'docker run -d')
+    assert.equal(candidateRun.length, 2)
+    assert.ok(candidateRun[0].includes('--name iuga-test-candidate') && candidateRun[0].includes('127.0.0.1:16667:7777'))
+    assert.ok(candidateRun[1].includes('--name iuga-test') && candidateRun[1].includes('127.0.0.1:16666:7777'))
+    // Health checks run inside the container against the app's own port.
+    const probes = runCalls(calls, 'fetch("http://127.0.0.1:7777/readyz")')
+    assert.equal(probes.length, 2)
+    assert.ok(probes.every((p) => p.includes('docker exec iuga-test')))
+    // Old live container is retired only after the candidate passed.
+    assert.ok(runCalls(calls, 'docker rm -f iuga-test').length >= 2)
+    assert.equal(runCalls(calls, 'last-good').length, 0)
+})
+
+test('dead candidate aborts the deploy and keeps the old container', () => {
+    const { status, calls } = runDeploy(STUB_DEAD)
+
+    assert.equal(status, 1)
+    // 60 probe attempts, none of them successful.
+    assert.equal(runCalls(calls, 'docker exec iuga-test-candidate').length, 60)
+    // Logs are dumped, candidate removed.
+    assert.ok(runCalls(calls, 'docker logs --tail 100 iuga-test-candidate').length === 1)
+    assert.ok(runCalls(calls, 'docker rm -f iuga-test-candidate').length >= 1)
+    // The live container was never stopped or replaced.
+    assert.equal(calls.filter((c) => c === 'docker rm -f iuga-test').length, 0)
+    assert.equal(runCalls(calls, '127.0.0.1:16666:7777').length, 0)
+})
+
+test('failed promotion verification rolls back to last-good', () => {
+    const { status, calls } = runDeploy(STUB_ROLLBACK)
+
+    assert.equal(status, 1)
+    // Candidate check passed (1st exec), then 10 failed promotion checks.
+    assert.equal(runCalls(calls, 'docker exec iuga-test-candidate').length, 1)
+    assert.equal(runCalls(calls, 'docker exec iuga-test ').length, 10)
+    // Rollback: pull last-good and restart the live container from it.
+    const pulls = runCalls(calls, 'docker pull')
+    assert.equal(pulls.length, 2)
+    assert.equal(pulls.at(-1), 'docker pull iuga/test-app:last-good')
+    const lastRun = runCalls(calls, 'docker run -d').at(-1)
+    assert.ok(lastRun.includes('--name iuga-test') && lastRun.includes('iuga/test-app:last-good'))
+})

--- a/ci/test/e2e-deploy.sh
+++ b/ci/test/e2e-deploy.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# ============================================================================
+# e2e-deploy.sh — local end-to-end proof of the health-gated deploy pipeline
+# ============================================================================
+# What this does
+#   Builds the real app image (DEPLOY_ENV=development), pushes it to a
+#   throwaway local registry, and runs the EXACT shell block Jenkins executes
+#   (healthGatedDeploy in ci/deploy.groovy) against a real Docker daemon with
+#   a disposable Mongo 7 container. If the deploy sequence (candidate start
+#   -> /readyz health gate -> live swap -> verification) passes here, the
+#   same logic will work in Jenkins. Only the Jenkins-context parts (webhook
+#   trigger, credential injection, GitHub status reporting) still need a real
+#   Jenkins build to verify.
+#
+# Why a real harness when the unit tests already exist
+#   ci/test/deploy-groovy.test.js stubs docker and proves the deploy LOGIC.
+#   This script proves the INTEGRATION: the image really builds, node really
+#   exists inside it, Mongo really connects, /readyz really answers.
+#
+# Safety
+#   - Uses only loopback host ports: 16766 (live), 16767 (candidate),
+#     5011 (registry). Never touches live ports 6666/6667/7777/8888.
+#   - Every resource is prefixed iuga-e2e-* and removed on exit via trap.
+#   - Test-only DB_URI/SESSION_SECRET; never touches real databases.
+#
+# Requirements
+#   - A running Docker daemon (e.g. Docker Desktop)
+#   - Ports 16766, 16767, 5011 free on the host loopback
+#
+# Usage
+#   bash ci/test/e2e-deploy.sh        # from anywhere in the repository
+# ============================================================================
+
+set -euo pipefail
+
+# --- Configuration ----------------------------------------------------------
+# Everything is unique to this harness so it can never collide with a live
+# deployment (live dev uses ports 6666/6667 and the iuga-web-dev container).
+REGISTRY_PORT=5011
+LIVE_PORT=16766        # the "real" host port after promotion
+CANDIDATE_PORT=16767   # the temp host port while health-checking
+IMAGE_NAME="iuga-web-app-e2e"
+REGISTRY="127.0.0.1:${REGISTRY_PORT}"
+NETWORK="iuga-e2e-net"
+UPLOADS_DIR="/tmp/iuga-e2e-uploads"
+CONTAINER="iuga-e2e-dev"
+
+# Locate the repository root from this script's own path, so it can be run
+# from any working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# --- Cleanup ----------------------------------------------------------------
+# Every container, network, image, and temp file this harness creates is
+# removed on exit (success or failure), so repeated runs never accumulate
+# state or collide with each other.
+cleanup() {
+    echo
+    echo "=== cleanup ==="
+    docker rm -f "${CONTAINER}" "${CONTAINER}-candidate" iuga-e2e-mongo iuga-e2e-registry 2>/dev/null || true
+    docker network rm "${NETWORK}" 2>/dev/null || true
+    docker rmi -f "${IMAGE_NAME}:local" "${REGISTRY}/${IMAGE_NAME}:local" "${REGISTRY}/${IMAGE_NAME}:last-good" 2>/dev/null || true
+    rm -rf "${UPLOADS_DIR}" /tmp/iuga-e2e-deploy.sh
+}
+trap cleanup EXIT
+
+# --- Preconditions ----------------------------------------------------------
+# Fail fast with a helpful message instead of a wall of docker errors.
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry." >&2
+    exit 1
+fi
+
+# Refuse to run if any harness port is already taken (e.g. another e2e run).
+for port in "${REGISTRY_PORT}" "${LIVE_PORT}" "${CANDIDATE_PORT}"; do
+    if lsof -nP -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1; then
+        echo "ERROR: port ${port} is already in use. Stop the other process and retry." >&2
+        exit 1
+    fi
+done
+
+# Wait for a dependency to become ready, with a clear failure instead of a
+# confusing downstream error. The check string is an internal constant, not
+# user input, so eval is safe here.
+wait_for() {
+    local description="$1" timeout_seconds="$2" check="$3"
+    for _ in $(seq 1 "${timeout_seconds}"); do
+        if eval "${check}" >/dev/null 2>&1; then
+            echo "ok: ${description}"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "ERROR: timed out waiting for ${description}." >&2
+    exit 1
+}
+
+# --- Infrastructure: disposable registry + Mongo ----------------------------
+# The deploy script pulls the image before running it, so a real registry is
+# required for that pull to succeed — exactly like the Docker Hub flow.
+# Mongo sits on a dedicated network so the app container can reach it by
+# name instead of a host address.
+mkdir -p "${UPLOADS_DIR}"
+docker network create "${NETWORK}"
+docker run -d --name iuga-e2e-registry --network "${NETWORK}" -p "127.0.0.1:${REGISTRY_PORT}:5000" registry:2
+wait_for "local registry" 30 "curl -sf http://${REGISTRY}/v2/"
+docker run -d --name iuga-e2e-mongo --network "${NETWORK}" mongo:7
+wait_for "mongodb" 30 "docker exec iuga-e2e-mongo mongosh --quiet --eval 'db.runCommand({ping:1}).ok' | grep -q '^1'"
+
+# --- Build and push the real image ------------------------------------------
+# Same build shape as CI: DEPLOY_ENV=development. Pushed to the local
+# registry, plus a :last-good tag to mirror tagLastGood().
+cd "${REPO_ROOT}"
+docker build --build-arg DEPLOY_ENV=development -t "${IMAGE_NAME}:local" .
+docker tag "${IMAGE_NAME}:local" "${REGISTRY}/${IMAGE_NAME}:local"
+docker push "${REGISTRY}/${IMAGE_NAME}:local"
+docker tag "${IMAGE_NAME}:local" "${REGISTRY}/${IMAGE_NAME}:last-good"
+docker push "${REGISTRY}/${IMAGE_NAME}:last-good"
+
+# --- Extract the real deploy logic from ci/deploy.groovy --------------------
+# Pull the `sh """` block out of healthGatedDeploy(), translate the Groovy
+# escapes (\\ -> \, \$ -> $), and substitute concrete values for the
+# Groovy-interpolated variables. The result is exactly what Jenkins runs,
+# pointed at this harness's containers, ports, and registry.
+extract_deploy_script() {
+    awk '/sh """/{found=1} found{print} found && /^    """$/{exit}' ci/deploy.groovy \
+        | sed '1d;$d' \
+        | sed 's/\\\\/\\/g; s/\\\$/\$/g' \
+        | sed \
+            -e 's/\${cfg\.container}/'"${CONTAINER}"'/g' \
+            -e 's/\${cfg\.tempPort}/'"${CANDIDATE_PORT}"'/g' \
+            -e 's/\${cfg\.realPort}/'"${LIVE_PORT}"'/g' \
+            -e 's/\${cfg\.deployEnv}/development/g' \
+            -e 's#\${cfg\.uploadsDir}#'"${UPLOADS_DIR}"'#g' \
+            -e 's/\${netFlag}/--network '"${NETWORK}"'/g' \
+            -e 's#\${newImage}#'"${REGISTRY}/${IMAGE_NAME}:local"'#g' \
+            -e 's#\${lastGoodImage}#'"${REGISTRY}/${IMAGE_NAME}:last-good"'#g'
+}
+
+extract_deploy_script > /tmp/iuga-e2e-deploy.sh
+bash -n /tmp/iuga-e2e-deploy.sh  # the extracted script must parse
+
+echo
+echo "=== running the real deploy sequence ==="
+DB_URI="mongodb://iuga-e2e-mongo:27017/iuga_e2e" \
+SESSION_SECRET="e2e-secret" \
+    bash /tmp/iuga-e2e-deploy.sh
+
+# --- Verification -----------------------------------------------------------
+echo
+echo "=== verification ==="
+# 1. The app answers /readyz from inside the live container — the same probe
+#    the pipeline itself uses.
+docker exec "${CONTAINER}" node -e 'fetch("http://127.0.0.1:7777/readyz").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))' \
+    && echo "PASS: /readyz answers inside the live container"
+
+# 2. The app answers /readyz on the host loopback through the live port.
+curl -fsS "http://127.0.0.1:${LIVE_PORT}/readyz" \
+    && echo "PASS: /readyz answers on host loopback port ${LIVE_PORT}"
+
+# 3. The candidate container was retired; only the live container remains.
+docker ps --filter name="${CONTAINER}" --format '{{.Names}} | {{.Status}}'
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER}-candidate$"; then
+    echo "FAIL: candidate container still exists after deploy." >&2
+    exit 1
+fi
+echo "PASS: candidate retired, live container promoted"
+
+echo
+echo "ALL E2E CHECKS PASSED"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -169,15 +169,39 @@ git submodule update --remote
 
 ## Testing
 
-The project currently has **limited test infrastructure**:
+The repository has a small but real test surface, although coverage is incomplete:
 
-- Frontend includes `@testing-library/react` (installed) but no test files were found during documentation authoring.
-- Backend has no test runner or test files.
+- **Frontend:** Jest and React Testing Library tests under `frontend/src/` (currently eight test files). Run them with:
+  ```bash
+  cd frontend
+  CI=true npm test -- --watchAll=false
+  ```
+- **Backend:** two Node built-in test suites under `backend/test/` (`sendError` and `sendSuccess`), plus their test fixture. Run them with:
+  ```bash
+  cd backend
+  node --test
+  ```
+- **CI deploy helper:** regression tests for the health-gated deploy sequence in `ci/deploy.groovy`, under `ci/test/`. They stub `docker` and assert the invoke/rollback behavior, so no daemon is needed. Run them with:
+  ```bash
+  node --test 'ci/test/*.test.js'
+  ```
+- **CI deploy end-to-end test:** `ci/test/e2e-deploy.sh` runs the same sequence against a real Docker daemon. It builds the actual app image, pushes it to a temporary local registry, starts a disposable Mongo 7 container, then runs the exact deploy commands from `ci/deploy.groovy` with test-only credentials. It only uses loopback ports (16766/16767/5011), never touches the live deployment, and cleans up after itself. Requires Docker; run it with:
+  ```bash
+  bash ci/test/e2e-deploy.sh
+  ```
+- **Root:** `npm test` is still a placeholder that exits with `Error: no test specified`; it is not a meaningful project test command.
 
-To add tests, the project would benefit from:
+### Required verification workflow
 
-- **Frontend**: `react-scripts test` (Jest) — add tests alongside components in `__tests__/` directories
-- **Backend**: Jest or Mocha for controller integration tests with a test MongoDB
+For every code, CI, Docker, or runtime behavior change:
+
+1. Define the intended observable behavior and reproduce the current failure or boundary.
+2. Add or update a behavior-focused test or script. Ideally **before** implementation — it can be written either before or after, but before is the best way: it proves the test actually detects the issue and keeps the change honest.
+3. If no existing test surface covers the behavior, invent the smallest deterministic regression test at the public boundary.
+4. Run the test against the current state. It should fail or reproduce the current issue when applicable; if it already passes, confirm that it covers the intended behavior.
+5. Implement the smallest change, rerun the test until it passes, and complete the narrow integration/build smoke check before considering a Jenkins build — the local test suites listed in the Testing section above, plus (for deploy/pipeline changes) the full end-to-end test `ci/test/e2e-deploy.sh`.
+
+Tests must verify behavior through public interfaces, rendered output, HTTP responses, logs, or real integration boundaries. Do not replace a test with a source-text assertion. For MongoDB or backend changes, use a disposable Docker MongoDB setup when feasible. One-off scripts written to diagnose a single issue should stay out of the repository (for example in /tmp); only reusable tests belong in the codebase.
 
 ---
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -126,7 +126,7 @@ Verify that files are accessible and not accumulating unexpectedly.
 ### 2.4 Check MongoDB connectivity (from inside the container)
 
 ```bash
-docker exec iuga-web-<env> node -e "
+docker exec iuga-web-<env> node --input-type=commonjs -e "
   const mongoose = require('mongoose');
   mongoose.connect('mongodb://...').then(() => {
     console.log('OK');
@@ -138,7 +138,7 @@ docker exec iuga-web-<env> node -e "
 "
 ```
 
-> **Note:** Replace the connection string with the actual URI (prod uses `mongo:27017`, dev uses Atlas). Run this only during incident response.
+> **Note:** The backend is ES modules, so the `--input-type=commonjs` flag is required to use `require()` in this snippet. Replace the connection string with the actual URI (prod uses `mongo:27017`, dev uses Atlas). Run this only during incident response.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the Jenkins deploy health check so dev/staging deploys stop failing, and adds local tests that prove the deploy pipeline works before pushing to Jenkins.

The health check previously ran `curl` against `127.0.0.1:<port>` from the Jenkins shell. Jenkins is itself containerized, so its loopback is not the Docker host's — the check could never reach the app. Every build burned the full 180s probe window, failed, and left the site on the old container. The check now runs **inside the app container** (`docker exec … node -e 'fetch("http://127.0.0.1:7777/readyz")'`), where the app actually listens, so a healthy candidate passes in seconds instead of timing out.

## Rationale

- **What was broken:** the namespace mismatch made the health gate impossible to pass — the candidate app was healthy (startup logs showed Mongo connected and listening), but the probe never reached it.
- **Why it matters now:** this is the gate that decides whether a broken build replaces the live site. A gate that always fails means *every* deploy fails; the fail-safe was doing its job, but nothing could ever get through it.
- **Local proof before remote builds:** previously a pipeline change could only be validated by pushing and watching Jenkins fail. The repo now has a stubbed-docker unit test (`ci/test/deploy-groovy.test.js`, 3 paths: promote / keep-old / rollback) and a real-Docker end-to-end harness (`ci/test/e2e-deploy.sh`) that builds the actual image, runs a disposable registry + Mongo 7, and executes the real deploy block — verified passing with a full deploy in ~7s.
- **Docs updated:** test inventory corrected in `docs/DEVELOPMENT.md` (it previously claimed no tests existed), a plain-language verification workflow added, and the broken CommonJS diagnostic in `docs/MAINTAINERS.md` fixed for the ESM backend.

## Tests

- `node --test 'ci/test/*.test.js'` — **3/3 pass** (all three fail against the old curl-based code)
- `bash ci/test/e2e-deploy.sh` — **ALL E2E CHECKS PASSED**: image built, pushed to local registry, candidate health-checked via `/readyz` (passed in 4s), promoted to the live port, verified from inside the container and host loopback, cleanup complete
- Deploy script extracted from `ci/deploy.groovy` passes `bash -n`; `git diff --check` clean
