### PR TITLE
feat(auth): gate routes with requireAuth/requireAdmin

### DIFF
--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -10,6 +10,7 @@ import express from "express";
 import mongoose from "mongoose";
 import { sendError } from "../helpers/sendError.js";
 import { sendSuccess } from "../helpers/sendSuccess.js";
+import { requireAuth } from "../utils/auth.js";
 
 var router = express.Router();
 //-------------------------------Event Endpoints----------------------------------------------
@@ -247,56 +248,52 @@ Expected Response Information:
     status: "success"
   }
 */
-router.post("/rsvp", async function (req, res) {
+router.post("/rsvp", requireAuth, async function (req, res) {
   //Using the given event id and user id parameters, create a participant profile for the user and this pId into the event's participant list
   try {
-    if (req.session.isAuthenticated) {
-      const { eId, rsvpAnswers } = req.body;
-      const event = await req.models.Events.findById(eId)
-        .populate("eParticipants")
-        .exec();
-      const userObjectId = mongoose.Types.ObjectId(req.session.userId);
+    const { eId, rsvpAnswers } = req.body;
+    const event = await req.models.Events.findById(eId)
+      .populate("eParticipants")
+      .exec();
+    const userObjectId = mongoose.Types.ObjectId(req.session.userId);
 
-      if (!event) {
-        return sendError(res, 404, "Event not found");
-      }
-
-      // Check if RSVP is enabled for this event
-      if (!event.eRsvpEnabled) {
-        return sendError(res, 400, "RSVP is not enabled for this event");
-      }
-
-      // Check if today's date is past the start date
-      const today = new Date();
-      const eventStartDate = new Date(event.eStartDate);
-      if (today > eventStartDate) {
-        return sendError(res, 400, "The event has already started or passed.");
-      }
-
-      // Check if the user is already a participant
-      const userIsParticipant = event.eParticipants.some((participant) =>
-        participant.pUID.equals(userObjectId),
-      );
-      if (userIsParticipant) {
-        return sendError(res, 400, "You already RSVPd!");
-      }
-
-      const newParticipant = new req.models.Participants({
-        pUID: userObjectId,
-        eID: eId,
-        rsvpAnswers: rsvpAnswers,
-      });
-
-      const savedParticipant = await newParticipant.save();
-
-      event.eParticipants.push(savedParticipant);
-
-      await event.save();
-
-      return sendSuccess(res, { message: "RSVP successful!" });
-    } else {
-      return sendError(res, 401, "User is not logged in");
+    if (!event) {
+      return sendError(res, 404, "Event not found");
     }
+
+    // Check if RSVP is enabled for this event
+    if (!event.eRsvpEnabled) {
+      return sendError(res, 400, "RSVP is not enabled for this event");
+    }
+
+    // Check if today's date is past the start date
+    const today = new Date();
+    const eventStartDate = new Date(event.eStartDate);
+    if (today > eventStartDate) {
+      return sendError(res, 400, "The event has already started or passed.");
+    }
+
+    // Check if the user is already a participant
+    const userIsParticipant = event.eParticipants.some((participant) =>
+      participant.pUID.equals(userObjectId),
+    );
+    if (userIsParticipant) {
+      return sendError(res, 400, "You already RSVPd!");
+    }
+
+    const newParticipant = new req.models.Participants({
+      pUID: userObjectId,
+      eID: eId,
+      rsvpAnswers: rsvpAnswers,
+    });
+
+    const savedParticipant = await newParticipant.save();
+
+    event.eParticipants.push(savedParticipant);
+
+    await event.save();
+
+    return sendSuccess(res, { message: "RSVP successful!" });
   } catch (error) {
     console.log(error);
     return sendError(res, 500);
@@ -317,27 +314,23 @@ Expected Response Information:
     status: "success"
   }
 */
-router.delete("/withdraw/:eId/:pId", async function (req, res) {
+router.delete("/withdraw/:eId/:pId", requireAuth, async function (req, res) {
   try {
-    if (req.session.isAuthenticated) {
-      const pId = req.params.pId;
-      const eId = req.params.eId;
-      const event = await req.models.Events.findById(eId);
+    const pId = req.params.pId;
+    const eId = req.params.eId;
+    const event = await req.models.Events.findById(eId);
 
-      let newParticipants = [];
-      event.eParticipants.forEach((participant) => {
-        if (participant.toString() !== pId) {
-          newParticipants.push(participant);
-        }
-      });
+    let newParticipants = [];
+    event.eParticipants.forEach((participant) => {
+      if (participant.toString() !== pId) {
+        newParticipants.push(participant);
+      }
+    });
 
-      event.eParticipants = newParticipants;
-      await event.save();
+    event.eParticipants = newParticipants;
+    await event.save();
 
-      return sendSuccess(res);
-    } else {
-      return sendError(res, 401, "User is not logged in");
-    }
+    return sendSuccess(res);
   } catch (error) {
     console.log(error);
     return sendError(res, 500);

--- a/backend/routes/api/v1/controllers/feedback.js
+++ b/backend/routes/api/v1/controllers/feedback.js
@@ -8,6 +8,7 @@ Schema addressed in feedback.js:
 import express from "express";
 import { sendError } from "../helpers/sendError.js";
 import { sendSuccess } from "../helpers/sendSuccess.js";
+import { requireAuth, requireAdmin } from "../utils/auth.js";
 import mongoose from "mongoose";
 
 var router = express.Router();
@@ -21,7 +22,7 @@ Needed Info:
 Assumed req variables (Will need to check back with frontend for what is sent in):
 - "fID", this is the feedback form ID requested from the database.
 */
-router.get("/", async (req, res) => {
+router.get("/", requireAuth, async (req, res) => {
   try {
     const fID = req.query.fID;
     if (!fID || !mongoose.isValidObjectId(fID)) {
@@ -63,10 +64,7 @@ Assumed req variables (Will need to check back with frontend for what is sent in
 - fTopic
 - fDescription
 */
-router.post("/", async (req, res) => {
-  if (!req.session.isAuthenticated) {
-    return sendError(res, 401, "User is not authenticated");
-  }
+router.post("/", requireAuth, async (req, res) => {
   try {
     //Fit the new feedback data into a new Feedback Schema Object
     const newFeedback = new req.models.Feedback({
@@ -97,7 +95,7 @@ Needed info:
 Assumed req variables (Will need to check back with frontend for what is sent in):
 - fID
 */
-router.delete("/", async (req, res) => {
+router.delete("/", requireAdmin, async (req, res) => {
   const fID = req.query.fID;
   try {
     //Delete the given feedback form

--- a/backend/routes/api/v1/controllers/user.js
+++ b/backend/routes/api/v1/controllers/user.js
@@ -9,6 +9,7 @@ import express from "express";
 import fetch from "node-fetch";
 import { sendError } from "../helpers/sendError.js";
 import { sendSuccess } from "../helpers/sendSuccess.js";
+import { requireAuth } from "../utils/auth.js";
 
 var router = express.Router();
 
@@ -68,75 +69,58 @@ router.post("/login", async function (req, res) {
     @method: POST
     @description: destroy user session.
 */
-router.post("/logout", function (req, res, next) {
-  if (req.session.isAuthenticated) {
-    req.session.destroy();
-
-    return sendSuccess(res);
-  } else {
-    return sendError(res, 401, "User is not logged in");
-  }
+router.post("/logout", requireAuth, function (req, res, next) {
+  req.session.destroy();
+  return sendSuccess(res);
 });
 
 //Get the user's specific information from the user's perspective, from an outsider perspective, and from the admin perspective
-router.get("/", async function (req, res) {
-  if (req.session.isAuthenticated) {
-    res.status(200).json({
-      firstName: req.session.firstName,
-      lastName: req.session.lastName,
-      displayName: req.session.displayName,
-      email: req.session.email,
-      memberType: req.session.memberType,
-    });
-  } else {
-    return sendError(res, 401, "User is not logged in");
-  }
+router.get("/", requireAuth, async function (req, res) {
+  res.status(200).json({
+    firstName: req.session.firstName,
+    lastName: req.session.lastName,
+    displayName: req.session.displayName,
+    email: req.session.email,
+    memberType: req.session.memberType,
+  });
 });
 
 //Get the user's specific information from the user's perspective, from an outsider perspective, and from the admin perspective
-router.get("/:uId", async function (req, res) {
-  if (req.session.isAuthenticated) {
-    try {
-      const uId = req.params.uId;
-      const currId = req.session.id;
-      const currUser = await req.models.Users.findById({ currId });
+router.get("/:uId", requireAuth, async function (req, res) {
+  try {
+    const uId = req.params.uId;
+    const currId = req.session.id;
+    const currUser = await req.models.Users.findById({ currId });
 
-      if (currId == uId) {
-        //Current user is viewing their own account (account owner view)
-      } else if (currId != uId && currUser.uType === "Admin") {
-        //An admin is viewing a users account (admin view)
-      } else {
-        //An outside user is viewing another user's account (Outside user view)
-      }
-    } catch (error) {
-      console.log(error);
-      return sendError(res, 500);
+    if (currId == uId) {
+      //Current user is viewing their own account (account owner view)
+    } else if (currId != uId && currUser.uType === "Admin") {
+      //An admin is viewing a users account (admin view)
+    } else {
+      //An outside user is viewing another user's account (Outside user view)
     }
-  } else {
-    return sendError(res, 401, "User is not logged in");
+  } catch (error) {
+    console.log(error);
+    return sendError(res, 500);
   }
 });
 
 //User wants to update their own profile information, or an admin is trying to change a user's information.
-router.post("/:uId", async function (req, res) {
-  if (req.session.isAuthenticated) {
-    try {
-      const uId = req.params.uId;
-      const currId = req.session.id;
-      const currUser = await req.models.Users.findById({ currId });
-      if (currId == uId) {
-        //If current user edits their own account
-      } else if (currId != uId && currUser.uType === "Admin") {
-        //if admin edits user account
-      } else {
-        return sendError(res, 403, "Access denied");
-      }
-    } catch (error) {
-      console.log(error);
-      return sendError(res, 500);
+router.post("/:uId", requireAuth, async function (req, res) {
+  try {
+    const uId = req.params.uId;
+    const currId = req.session.id;
+    const currUser = await req.models.Users.findById({ currId });
+    if (currId == uId) {
+      //If current user edits their own account
+    } else if (currId != uId && currUser.uType === "Admin") {
+      //if admin edits user account
+    } else {
+      return sendError(res, 403, "Access denied");
     }
-  } else {
-    return sendError(res, 401, "User is not logged in");
+  } catch (error) {
+    console.log(error);
+    return sendError(res, 500);
   }
 });
 


### PR DESCRIPTION
## Summary

Applies the auth middleware from #33 to every route that should be gated, replacing inline session checks:

**`feedback.js`**
- `GET /` → `requireAuth` (was public — anyone could read any feedback form)
- `POST /` → `requireAuth` (replaces the inline `isAuthenticated` check)
- `DELETE /` → `requireAdmin` (was public — deletion is now officer-only per plan §4.1)

**`events.js`**
- `POST /rsvp` → `requireAuth`
- `DELETE /withdraw/:eId/:pId` → `requireAuth`
- `GET /` and `GET /id/:eId` → **intentionally left public** — their `isAuthenticated` use is optional enrichment (`hasRSVPd`), not a gate; blocking them would break anonymous browsing

**`user.js`**
- `POST /logout`, `GET /`, `GET /:uId`, `POST /:uId` → `requireAuth`

## Rationale

- Before this PR, auth enforcement was copy-pasted inline (`if (req.session.isAuthenticated)`) across controllers — 8+ copies, easy to forget, no admin gate anywhere. `isAdmin` was set at login but never enforced.
- With the middleware in place (#33), each route declares its gate in the route line: `router.post("/", requireAuth, handler)`. One line per route, no drift.
- `feedback DELETE` becomes `requireAdmin` per the plan's route map (§4.1) — deleting feedback is moderation, not a member action.
- De-nested both `events.js` handlers: the inline wrapper was replaced by the middleware, so the try/catch no longer wraps an `if/else` (behavior unchanged, just the check moved out).

## Tests

- `node --input-type=module --check` on all 3 modified controllers — syntax OK
- `node --test 'test/*.test.js'` — 10/10 pass (5 auth middleware tests + 5 existing helper tests)
- `git diff --check` — no whitespace errors