### PR TITLE
feat(auth): add permission-based role checks

### DIFF
--- a/backend/models.js
+++ b/backend/models.js
@@ -4,6 +4,8 @@ import {
   participantsSchema,
   usersSchema,
   feedbackSchema,
+  rolesSchema,
+  roleAssignmentsSchema,
 } from "./schemas/schemas.js";
 
 let models = {};
@@ -20,6 +22,8 @@ async function connectToDatabase(){
   models.Participants = mongoose.model("Participants", participantsSchema);
   models.Users = mongoose.model("Users", usersSchema);
   models.Feedback = mongoose.model("Feedback", feedbackSchema);
+  models.Roles = mongoose.model("Roles", rolesSchema);
+  models.RoleAssignments = mongoose.model("RoleAssignments", roleAssignmentsSchema);
 
   console.log(`[startup] mongoose models created after ${Date.now() - connectionStartedAt}ms`);
 }

--- a/backend/routes/api/v1/utils/auth.js
+++ b/backend/routes/api/v1/utils/auth.js
@@ -58,3 +58,42 @@ export function requireAdmin(req, res, next) {
   }
   next();
 }
+
+/*
+    @middleware: requirePermission
+    @method: N/A (Express middleware factory)
+    @description: Checks that an authenticated admin has a specific
+                  permission through an active role assignment.
+
+    Example: router.post("/roles", requirePermission("users.roles.manage"), handler)
+*/
+export function requirePermission(permission) {
+  return async function (req, res, next) {
+    if (!req.session.isAuthenticated) {
+      return sendError(res, 401, "Not authenticated");
+    }
+    if (!req.session.isAdmin) {
+      return sendError(res, 403, "Not authorized");
+    }
+
+    try {
+      const assignments = await req.models.RoleAssignments.find({
+        userId: req.session.userId,
+        isActive: true,
+      }).populate("roleId");
+
+      const hasPermission = assignments.some((assignment) =>
+        assignment.roleId?.isActive &&
+        assignment.roleId.permissions.includes(permission),
+      );
+
+      if (!hasPermission) {
+        return sendError(res, 403, "Not authorized");
+      }
+      next();
+    } catch (error) {
+      console.error(error);
+      return sendError(res, 500);
+    }
+  };
+}

--- a/backend/test/auth.test.js
+++ b/backend/test/auth.test.js
@@ -1,6 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { requireAuth, requireAdmin } from "../routes/api/v1/utils/auth.js";
+import {
+  requireAuth,
+  requireAdmin,
+  requirePermission,
+} from "../routes/api/v1/utils/auth.js";
 import { makeFakeRes } from "./makeFakeRes.js";
 
 describe("requireAuth", () => {
@@ -75,5 +79,51 @@ describe("requireAdmin", () => {
 
     assert.strictEqual(res.statusCode, null);
     assert.strictEqual(nextCalled, true);
+  });
+});
+
+describe("requirePermission", () => {
+  function requestWithAssignments(assignments) {
+    return {
+      session: { isAuthenticated: true, isAdmin: true, userId: "user-1" },
+      models: {
+        RoleAssignments: {
+          find() {
+            return {
+              async populate() {
+                return assignments;
+              },
+            };
+          },
+        },
+      },
+    };
+  }
+
+  it("passes when an active role grants the permission", async () => {
+    const req = requestWithAssignments([
+      { roleId: { isActive: true, permissions: ["users.roles.manage"] } },
+    ]);
+    const res = makeFakeRes();
+    let nextCalled = false;
+
+    await requirePermission("users.roles.manage")(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.strictEqual(res.statusCode, null);
+    assert.strictEqual(nextCalled, true);
+  });
+
+  it("rejects an admin without the permission", async () => {
+    const req = requestWithAssignments([
+      { roleId: { isActive: true, permissions: ["events.view"] } },
+    ]);
+    const res = makeFakeRes();
+
+    await requirePermission("users.roles.manage")(req, res, () => {});
+
+    assert.strictEqual(res.statusCode, 403);
+    assert.strictEqual(res.body.message, "Not authorized");
   });
 });


### PR DESCRIPTION
## Summary

Connects the dynamic role schemas to the backend and adds permission-based authorization.

Changes:

- Registers `Roles` and `RoleAssignments` in `models.js`
- Adds `requirePermission(permission)` middleware
- Checks active role assignments and active role permissions
- Adds permission allow/deny tests

Example usage:

```js
requirePermission("users.roles.manage")
```

## Rationale

The application already has broad `Member` and `Admin` access checks, but event administration needs more specific permissions.

This middleware allows roles such as President, Vice-President, Finance Director, and Director of IT to receive different capabilities without hardcoding one officer role directly onto the user.

The backend remains the authorization boundary. A user must be authenticated, an admin, and assigned an active role containing the requested permission.

## Tests

- `node --input-type=module --check` passed for all modified files
- `node --test 'test/*.test.js'` — 12 tests passed
- `git diff --check` passed
