### PR TITLE
feat(api): complete role assignment mutations

### DIFF
--- a/backend/routes/api/v1/controllers/roles.js
+++ b/backend/routes/api/v1/controllers/roles.js
@@ -33,36 +33,65 @@ function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function isProvided(value) {
+  return value !== undefined && value !== null;
+}
+
 function readRoleFields(body = {}, partial = false) {
   body = body ?? {};
   const fields = {};
-  const roleName = typeof body.roleName === "string" ? body.roleName.trim() : undefined;
-  const roleKey = typeof body.roleKey === "string" ? body.roleKey.trim().toLowerCase() : undefined;
-  const roleDescription = typeof body.roleDescription === "string" ? body.roleDescription.trim() : undefined;
+  const roleName =
+    typeof body.roleName === "string" ? body.roleName.trim() : undefined;
+  const roleKey =
+    typeof body.roleKey === "string"
+      ? body.roleKey.trim().toLowerCase()
+      : undefined;
+  const roleDescription =
+    typeof body.roleDescription === "string"
+      ? body.roleDescription.trim()
+      : undefined;
 
   if (!partial || roleName !== undefined) fields.roleName = roleName;
   if (!partial || roleKey !== undefined) fields.roleKey = roleKey;
-  if (!partial || roleDescription !== undefined) fields.roleDescription = roleDescription ?? "";
-  if (!partial || body.permissions !== undefined) fields.permissions = body.permissions;
+  if (!partial || roleDescription !== undefined)
+    fields.roleDescription = roleDescription ?? "";
+  if (!partial || body.permissions !== undefined)
+    fields.permissions = body.permissions;
   if (body.isActive !== undefined) fields.isActive = body.isActive;
 
   if (!partial && (!fields.roleName || !fields.roleKey)) {
     return { error: "roleName and roleKey are required" };
   }
   if (fields.roleName && fields.roleName.length > ROLE_NAME_MAX_LENGTH) {
-    return { error: `roleName must be ${ROLE_NAME_MAX_LENGTH} characters or fewer` };
+    return {
+      error: `roleName must be ${ROLE_NAME_MAX_LENGTH} characters or fewer`,
+    };
   }
   if (fields.roleKey && fields.roleKey.length > ROLE_KEY_MAX_LENGTH) {
-    return { error: `roleKey must be ${ROLE_KEY_MAX_LENGTH} characters or fewer` };
+    return {
+      error: `roleKey must be ${ROLE_KEY_MAX_LENGTH} characters or fewer`,
+    };
   }
-  if (fields.roleDescription && fields.roleDescription.length > ROLE_DESCRIPTION_MAX_LENGTH) {
-    return { error: `roleDescription must be ${ROLE_DESCRIPTION_MAX_LENGTH} characters or fewer` };
+  if (
+    fields.roleDescription &&
+    fields.roleDescription.length > ROLE_DESCRIPTION_MAX_LENGTH
+  ) {
+    return {
+      error: `roleDescription must be ${ROLE_DESCRIPTION_MAX_LENGTH} characters or fewer`,
+    };
   }
   if (fields.roleKey && !/^[a-z][a-z0-9_]*$/.test(fields.roleKey)) {
-    return { error: "roleKey must use lowercase letters, numbers, and underscores" };
+    return {
+      error: "roleKey must use lowercase letters, numbers, and underscores",
+    };
   }
-  if (fields.permissions !== undefined && (!Array.isArray(fields.permissions) ||
-      fields.permissions.some((permission) => !knownPermissions.has(permission)))) {
+  if (
+    fields.permissions !== undefined &&
+    (!Array.isArray(fields.permissions) ||
+      fields.permissions.some(
+        (permission) => !knownPermissions.has(permission),
+      ))
+  ) {
     return { error: "permissions contains an unknown permission" };
   }
   if (fields.isActive !== undefined && typeof fields.isActive !== "boolean") {
@@ -112,82 +141,235 @@ router.post("/", requirePermission("users.roles.manage"), async (req, res) => {
 Purpose: Update a role definition without changing its stable roleKey.
 Authentication/Authorization Requirements: users.roles.manage
 */
-router.patch("/:id", requirePermission("users.roles.manage"), async (req, res) => {
-  if (!mongoose.isValidObjectId(req.params.id)) {
-    return sendError(res, 400, "Invalid role ID");
-  }
+router.patch(
+  "/:id",
+  requirePermission("users.roles.manage"),
+  async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return sendError(res, 400, "Invalid role ID");
+    }
 
-  const { fields, error } = readRoleFields(req.body, true);
-  if (error) return sendError(res, 400, error);
-  delete fields.roleKey;
-  fields.updatedBy = req.session.userId;
+    const { fields, error } = readRoleFields(req.body, true);
+    if (error) return sendError(res, 400, error);
+    delete fields.roleKey;
+    fields.updatedBy = req.session.userId;
 
-  try {
-    const role = await req.models.Roles.findByIdAndUpdate(
-      req.params.id,
-      { $set: fields },
-      { new: true, runValidators: true },
-    );
-    if (!role) return sendError(res, 404, "Role not found");
-    return sendSuccess(res, { role });
-  } catch (err) {
-    console.error(err);
-    return sendError(res, 500);
-  }
-});
+    try {
+      const role = await req.models.Roles.findByIdAndUpdate(
+        req.params.id,
+        { $set: fields },
+        { new: true, runValidators: true },
+      );
+      if (!role) return sendError(res, 404, "Role not found");
+      return sendSuccess(res, { role });
+    } catch (err) {
+      console.error(err);
+      return sendError(res, 500);
+    }
+  },
+);
 
 /*
 Purpose: Search users for the role-management interface without returning secrets.
 Authentication/Authorization Requirements: users.roles.manage
 */
-router.get("/users", requirePermission("users.roles.manage"), async (req, res) => {
-  const search = typeof req.query.search === "string" ? req.query.search.trim() : "";
-  if (search.length < 2) return sendError(res, 400, "search must be at least 2 characters");
+router.get(
+  "/users",
+  requirePermission("users.roles.manage"),
+  async (req, res) => {
+    const search =
+      typeof req.query.search === "string" ? req.query.search.trim() : "";
+    if (search.length < 2)
+      return sendError(res, 400, "search must be at least 2 characters");
 
-  try {
-    const pattern = new RegExp(escapeRegex(search), "i");
-    const users = await req.models.Users.find({
-      $or: [
-        { uDisplayName: pattern },
-        { uEmail: pattern },
-        { uNetId: pattern },
-      ],
-    })
-      .select("_id uFirstName uLastName uDisplayName uEmail uNetId uType")
-      .limit(25)
-      .lean();
+    try {
+      const pattern = new RegExp(escapeRegex(search), "i");
+      const users = await req.models.Users.find({
+        $or: [
+          { uDisplayName: pattern },
+          { uEmail: pattern },
+          { uNetId: pattern },
+        ],
+      })
+        .select("_id uFirstName uLastName uDisplayName uEmail uNetId uType")
+        .limit(25)
+        .lean();
 
-    return sendSuccess(res, { users });
-  } catch (error) {
-    console.error(error);
-    return sendError(res, 500);
-  }
-});
+      return sendSuccess(res, { users });
+    } catch (error) {
+      console.error(error);
+      return sendError(res, 500);
+    }
+  },
+);
 
 /*
 Purpose: Read a user's active assignments before implementing assignment mutations.
 Authentication/Authorization Requirements: users.roles.manage
 */
-router.get("/users/:id/assignments", requirePermission("users.roles.manage"), async (req, res) => {
-  if (!mongoose.isValidObjectId(req.params.id)) {
-    return sendError(res, 400, "Invalid user ID");
-  }
+router.get(
+  "/users/:id/assignments",
+  requirePermission("users.roles.manage"),
+  async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return sendError(res, 400, "Invalid user ID");
+    }
 
-  try {
-    const assignments = await req.models.RoleAssignments.find({
-      userId: req.params.id,
-      isActive: true,
-    })
-      .populate("roleId")
-      .populate("committeeId")
-      .populate("reportsToUserId", "uDisplayName uEmail")
-      .lean();
+    try {
+      const assignments = await req.models.RoleAssignments.find({
+        userId: req.params.id,
+        isActive: true,
+      })
+        .populate("roleId")
+        .populate("committeeId")
+        .populate("reportsToUserId", "uDisplayName uEmail")
+        .lean();
 
-    return sendSuccess(res, { assignments });
-  } catch (error) {
-    console.error(error);
-    return sendError(res, 500);
-  }
-});
+      return sendSuccess(res, { assignments });
+    } catch (error) {
+      console.error(error);
+      return sendError(res, 500);
+    }
+  },
+);
+
+/*
+Purpose: Assign a role to a user.
+Authentication/Authorization Requirements: users.roles.manage
+*/
+router.post(
+  "/users/:id/assignments",
+  requirePermission("users.roles.manage"),
+  async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return sendError(res, 400, "Invalid user ID");
+    }
+
+    const { roleId, committeeId, reportsToUserId, expiresAt } = req.body ?? {};
+
+    if (!roleId || !mongoose.isValidObjectId(roleId)) {
+      return sendError(res, 400, "Invalid role ID");
+    }
+
+    if (isProvided(committeeId) && !mongoose.isValidObjectId(committeeId)) {
+      return sendError(res, 400, "Invalid committee ID");
+    }
+
+    if (
+      isProvided(reportsToUserId) &&
+      !mongoose.isValidObjectId(reportsToUserId)
+    ) {
+      return sendError(res, 400, "Invalid reporting user ID");
+    }
+
+    let expiration = null;
+    if (isProvided(expiresAt)) {
+      expiration = new Date(expiresAt);
+      if (Number.isNaN(expiration.getTime())) {
+        return sendError(res, 400, "Invalid expiration date");
+      }
+    }
+
+    try {
+      const user = await req.models.Users.findById(req.params.id);
+      if (!user) {
+        return sendError(res, 404, "User not found");
+      }
+
+      const role = await req.models.Roles.findById(roleId);
+      if (!role) {
+        return sendError(res, 404, "Role not found");
+      }
+      if (!role.isActive) {
+        return sendError(res, 409, "Role is inactive");
+      }
+
+      if (isProvided(committeeId)) {
+        const committee = await req.models.Committees.findById(committeeId);
+        if (!committee) {
+          return sendError(res, 404, "Committee not found");
+        }
+      }
+
+      if (isProvided(reportsToUserId)) {
+        if (reportsToUserId === req.params.id) {
+          return sendError(res, 400, "User cannot report to themselves");
+        }
+        const reportingUser = await req.models.Users.findById(reportsToUserId);
+        if (!reportingUser) {
+          return sendError(res, 404, "Reporting user not found");
+        }
+      }
+
+      const existingAssignment = await req.models.RoleAssignments.findOne({
+        userId: req.params.id,
+        roleId,
+        isActive: true,
+      });
+      if (existingAssignment) {
+        return sendError(res, 409, "Role already assigned");
+      }
+
+      const assignment = await req.models.RoleAssignments.create({
+        userId: req.params.id,
+        roleId,
+        committeeId: committeeId ?? null,
+        reportsToUserId: reportsToUserId ?? null,
+        assignedBy: req.session.userId,
+        assignedAt: new Date(),
+        expiresAt: expiration,
+        isActive: true,
+      });
+
+      return res.status(201).json({ status: "success", assignment });
+    } catch (error) {
+      console.error(error);
+      return sendError(res, 500);
+    }
+  },
+);
+
+/*
+Purpose: Deactivate a user's role assignment without deleting its history.
+Authentication/Authorization Requirements: users.roles.manage
+*/
+router.delete(
+  "/users/:id/assignments/:assignmentId",
+  requirePermission("users.roles.manage"),
+  async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return sendError(res, 400, "Invalid user ID");
+    }
+    if (!mongoose.isValidObjectId(req.params.assignmentId)) {
+      return sendError(res, 400, "Invalid assignment ID");
+    }
+
+    try {
+      const assignment = await req.models.RoleAssignments.findOneAndUpdate(
+        {
+          _id: req.params.assignmentId,
+          userId: req.params.id,
+          isActive: true,
+        },
+        {
+          $set: {
+            isActive: false,
+            deactivatedBy: req.session.userId,
+            deactivatedAt: new Date(),
+          },
+        },
+        { new: true, runValidators: true },
+      );
+
+      if (!assignment) {
+        return sendError(res, 404, "Active assignment not found");
+      }
+      return sendSuccess(res, { assignment });
+    } catch (error) {
+      console.error(error);
+      return sendError(res, 500);
+    }
+  },
+);
 
 export default router;

--- a/backend/test/role-assignments.test.js
+++ b/backend/test/role-assignments.test.js
@@ -1,0 +1,179 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import { once } from "node:events";
+import rolesRouter from "../routes/api/v1/controllers/roles.js";
+
+const userId = "507f1f77bcf86cd799439011";
+const roleId = "507f1f77bcf86cd799439012";
+const assignmentId = "507f1f77bcf86cd799439013";
+
+function makeModels({
+  existingAssignment = null,
+  roleActive = true,
+  updatedAssignment = null,
+} = {}) {
+  return {
+    Users: {
+      async findById(id) {
+        return id === userId ? { _id: userId } : null;
+      },
+    },
+    Roles: {
+      async findById(id) {
+        return id === roleId ? { _id: roleId, isActive: roleActive } : null;
+      },
+    },
+    Committees: {
+      async findById() {
+        return null;
+      },
+    },
+    RoleAssignments: {
+      find() {
+        return {
+          async populate() {
+            return [{ roleId: { isActive: true, permissions: ["users.roles.manage"] } }];
+          },
+        };
+      },
+      async findOne() {
+        return existingAssignment;
+      },
+      async create(fields) {
+        return { _id: assignmentId, ...fields };
+      },
+      async findOneAndUpdate() {
+        return updatedAssignment;
+      },
+    },
+  };
+}
+
+async function request(method, path, body, models = makeModels()) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.models = models;
+    req.session = {
+      isAuthenticated: true,
+      isAdmin: true,
+      userId: "507f1f77bcf86cd799439014",
+    };
+    next();
+  });
+  app.use("/api/v1/roles", rolesRouter);
+
+  const server = app.listen(0);
+  await once(server, "listening");
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method,
+      headers: { "content-type": "application/json" },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: response.status, body: await response.json() };
+  } finally {
+    server.close();
+  }
+}
+
+describe("role assignment API", () => {
+  it("creates an assignment for an existing user and active role", async () => {
+    const result = await request(
+      "POST",
+      `/api/v1/roles/users/${userId}/assignments`,
+      { roleId },
+    );
+
+    assert.equal(result.status, 201);
+    assert.equal(result.body.status, "success");
+    assert.equal(result.body.assignment.userId, userId);
+    assert.equal(result.body.assignment.roleId, roleId);
+    assert.equal(result.body.assignment.assignedBy, "507f1f77bcf86cd799439014");
+    assert.equal(result.body.assignment.isActive, true);
+  });
+
+  it("rejects a malformed target user ID", async () => {
+    const result = await request(
+      "POST",
+      "/api/v1/roles/users/not-an-object-id/assignments",
+      { roleId },
+    );
+
+    assert.equal(result.status, 400);
+    assert.equal(result.body.message, "Invalid user ID");
+  });
+
+  it("rejects an assignment without a role ID", async () => {
+    const result = await request(
+      "POST",
+      `/api/v1/roles/users/${userId}/assignments`,
+      {},
+    );
+
+    assert.equal(result.status, 400);
+    assert.equal(result.body.message, "Invalid role ID");
+  });
+
+  it("rejects a duplicate active role assignment", async () => {
+    const result = await request(
+      "POST",
+      `/api/v1/roles/users/${userId}/assignments`,
+      { roleId },
+      makeModels({ existingAssignment: { _id: assignmentId } }),
+    );
+
+    assert.equal(result.status, 409);
+    assert.equal(result.body.message, "Role already assigned");
+  });
+
+  it("rejects an inactive role", async () => {
+    const result = await request(
+      "POST",
+      `/api/v1/roles/users/${userId}/assignments`,
+      { roleId },
+      makeModels({ roleActive: false }),
+    );
+
+    assert.equal(result.status, 409);
+    assert.equal(result.body.message, "Role is inactive");
+  });
+
+  it("rejects a user reporting to themselves", async () => {
+    const result = await request(
+      "POST",
+      `/api/v1/roles/users/${userId}/assignments`,
+      { roleId, reportsToUserId: userId },
+    );
+
+    assert.equal(result.status, 400);
+    assert.equal(result.body.message, "User cannot report to themselves");
+  });
+
+  it("deactivates an assignment and records the revoking actor", async () => {
+    const revokedAt = "2026-08-12T00:00:00.000Z";
+    const result = await request(
+      "DELETE",
+      `/api/v1/roles/users/${userId}/assignments/${assignmentId}`,
+      undefined,
+      makeModels({
+        updatedAssignment: {
+          _id: assignmentId,
+          userId,
+          isActive: false,
+          deactivatedBy: "507f1f77bcf86cd799439014",
+          deactivatedAt: revokedAt,
+        },
+      }),
+    );
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.status, "success");
+    assert.equal(result.body.assignment.isActive, false);
+    assert.equal(result.body.assignment.deactivatedBy, "507f1f77bcf86cd799439014");
+    assert.equal(result.body.assignment.deactivatedAt, revokedAt);
+  });
+});


### PR DESCRIPTION
## Summary

Completes role assignment mutations for the dynamic IUGA role system.

Adds:

- `POST /api/v1/roles/users/:id/assignments`
- `DELETE /api/v1/roles/users/:id/assignments/:assignmentId`

The API validates users, roles, committees, reporting relationships, expiration dates, duplicate assignments, and inactive roles. Assignment creation records the authenticated actor, and deactivation preserves the assignment while recording the revoking actor and timestamp.

## Rationale

Role catalog and permission checks were added first. This PR completes the mutation layer needed to assign and revoke roles without directly editing user documents.

Assignments remain separate records so one user can hold multiple roles, belong to a committee, report to another officer, and retain assignment history after deactivation.

## Tests

- `node --input-type=module --check` passed for the API and schemas
- `node --test 'test/*.test.js'` — 19 tests passed
- Added seven HTTP-level role-assignment behavior tests
- `git diff --check` passed
