### PR TITLE
feat(ui): add role-aware event operations

### DIFF
--- a/frontend/src/components/EventOperations.jsx
+++ b/frontend/src/components/EventOperations.jsx
@@ -1,0 +1,353 @@
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "react-toastify";
+
+const API_PATH = "/api/v1/event-requests";
+const CHECKPOINTS = [
+    ["proposal", "Proposal"],
+    ["meeting", "Meeting"],
+    ["finance", "Finance"],
+    ["room", "Room"],
+    ["marketing", "Marketing"],
+    ["purchases", "Purchases"],
+    ["completion", "Completion"],
+    ["review", "Review"],
+];
+const emptyForm = {
+    eventName: "",
+    requestingGroup: "",
+    description: "",
+    proposedStartDate: "",
+    proposedEndDate: "",
+    audience: "",
+};
+
+async function apiRequest(path, options = {}) {
+    const response = await fetch(`${API_PATH}${path}`, {
+        headers: { "Content-Type": "application/json" },
+        ...options,
+    });
+    const data = await response.json();
+    if (!response.ok || data.status === "error") {
+        throw new Error(data.message || "The request could not be completed.");
+    }
+    return data;
+}
+
+function currentStage(request) {
+    return request.checkpoints?.find((checkpoint) => checkpoint.status !== "completed")?.key || "complete";
+}
+
+function quarterOf(date) {
+    return `Q${Math.floor(date.getMonth() / 3) + 1}`;
+}
+
+function weekOfQuarter(date) {
+    const quarterStart = new Date(date.getFullYear(), Math.floor(date.getMonth() / 3) * 3, 1);
+    return Math.ceil((date - quarterStart + 1) / (7 * 24 * 60 * 60 * 1000));
+}
+
+function formatDate(value) {
+    if (!value) return "—";
+    return new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+}
+
+function dateTimeValue(value) {
+    return value ? new Date(value).toISOString().slice(0, 16) : "";
+}
+
+function dollarsToCents(value) {
+    if (value === "") return undefined;
+    const amount = Number(value);
+    return Number.isFinite(amount) && amount >= 0 ? Math.round(amount * 100) : null;
+}
+
+function centsToDollars(value) {
+    return value === undefined || value === null ? "" : (value / 100).toFixed(2);
+}
+
+function StatusBadge({ status }) {
+    const label = String(status || "unknown").replace(/_/g, " ");
+    return <span className={`event-ops-status event-ops-status-${status || "unknown"}`}>{label}</span>;
+}
+
+function EventRequestForm({ onCreated, onCancel }) {
+    const [form, setForm] = useState(emptyForm);
+    const [saving, setSaving] = useState(false);
+
+    const update = (event) => setForm({ ...form, [event.target.name]: event.target.value });
+
+    const submit = async (event) => {
+        event.preventDefault();
+        setSaving(true);
+        try {
+            const payload = { ...form };
+            if (!payload.audience) delete payload.audience;
+            if (!payload.proposedEndDate) delete payload.proposedEndDate;
+            const data = await apiRequest("/", {
+                method: "POST",
+                body: JSON.stringify(payload),
+            });
+            onCreated(data.eventRequest);
+            setForm(emptyForm);
+            toast.success("Event request submitted.");
+        } catch (error) {
+            toast.error(error.message);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <form className="event-ops-form editorial-card" onSubmit={submit}>
+            <div className="event-ops-form-heading">
+                <div>
+                    <span className="event-ops-kicker">New request</span>
+                    <h3>Plan an IUGA event</h3>
+                </div>
+                <button type="button" className="event-ops-close" onClick={onCancel}>Close</button>
+            </div>
+            <div className="event-ops-form-grid">
+                <label className="form-label">Event name<input className="form-input" name="eventName" value={form.eventName} onChange={update} required maxLength="120" /></label>
+                <label className="form-label">Requesting group<input className="form-input" name="requestingGroup" value={form.requestingGroup} onChange={update} required maxLength="120" /></label>
+                <label className="form-label">Proposed start<input className="form-input" type="datetime-local" name="proposedStartDate" value={form.proposedStartDate} onChange={update} required /></label>
+                <label className="form-label">Proposed end<input className="form-input" type="datetime-local" name="proposedEndDate" value={form.proposedEndDate} onChange={update} /></label>
+                <label className="form-label event-ops-full-width">Audience<input className="form-input" name="audience" value={form.audience} onChange={update} maxLength="500" placeholder="Who is this event for?" /></label>
+                <label className="form-label event-ops-full-width">Description<textarea className="form-input" name="description" value={form.description} onChange={update} required maxLength="2000" rows="4" /></label>
+            </div>
+            <div className="event-ops-form-actions">
+                <button type="submit" className="cta-secondary" disabled={saving}>{saving ? "Submitting…" : "Submit request"}</button>
+                <button type="button" className="cta-primary" onClick={onCancel}>Cancel</button>
+            </div>
+        </form>
+    );
+}
+
+function EventDetail({ request, onUpdate }) {
+    const [budget, setBudget] = useState({});
+    const [booking, setBooking] = useState({});
+    const [review, setReview] = useState({});
+
+    useEffect(() => {
+        setBudget({
+            allocated: centsToDollars(request.finance?.allocatedCents),
+            actual: centsToDollars(request.finance?.actualSpendCents),
+            notes: request.finance?.notes || "",
+        });
+        setBooking({
+            location: request.booking?.location || "",
+            startDate: dateTimeValue(request.booking?.startDate),
+            endDate: dateTimeValue(request.booking?.endDate),
+            notes: request.booking?.notes || "",
+        });
+        setReview({
+            reviewLink: request.reviewLink || "",
+            received: Boolean(request.reviewReceivedAt),
+        });
+    }, [request]);
+
+    const mutate = async (path, body) => {
+        try {
+            const data = await apiRequest(`/${request._id}${path}`, {
+                method: "PATCH",
+                body: JSON.stringify(body),
+            });
+            onUpdate(data.eventRequest);
+            toast.success("Event request updated.");
+        } catch (error) {
+            toast.error(error.message);
+        }
+    };
+
+    const reviewAction = async (action, reason) => {
+        try {
+            const data = await apiRequest(`/${request._id}/${action}`, {
+                method: "POST",
+                body: reason ? JSON.stringify({ reason }) : undefined,
+            });
+            onUpdate(data.eventRequest);
+            toast.success(`Request ${action.replace("-", " ")}.`);
+        } catch (error) {
+            toast.error(error.message);
+        }
+    };
+
+    const askForReason = (action, label) => {
+        const reason = window.prompt(label);
+        if (reason?.trim()) reviewAction(action, reason.trim());
+    };
+
+    const saveBudget = (event) => {
+        event.preventDefault();
+        const allocatedCents = dollarsToCents(budget.allocated);
+        const actualSpendCents = dollarsToCents(budget.actual);
+        if (allocatedCents === null || actualSpendCents === null) {
+            toast.error("Budget amounts must be valid dollar values.");
+            return;
+        }
+        mutate("/budget", { allocatedCents, actualSpendCents, notes: budget.notes });
+    };
+
+    const saveBooking = (event) => {
+        event.preventDefault();
+        mutate("/booking", {
+            ...(booking.location && { location: booking.location }),
+            ...(booking.startDate && { startDate: booking.startDate }),
+            ...(booking.endDate && { endDate: booking.endDate }),
+            notes: booking.notes,
+        });
+    };
+
+    return (
+        <aside className="event-ops-detail editorial-card" aria-label={`${request.eventName} details`}>
+            <div className="event-ops-detail-heading">
+                <div><span className="event-ops-kicker">Request detail</span><h3>{request.eventName}</h3></div>
+                <StatusBadge status={request.status} />
+            </div>
+            <p className="event-ops-detail-meta">{request.requestingGroup} · {formatDate(request.proposedStartDate)}</p>
+            <p>{request.description}</p>
+
+            {request.status === "submitted" || request.status === "changes_requested" ? (
+                <div className="event-ops-actions">
+                    <button className="cta-secondary" onClick={() => reviewAction("approve")}>Approve & publish</button>
+                    <button className="cta-primary" onClick={() => askForReason("request-changes", "What should the requester change?")}>Request changes</button>
+                    <button className="event-ops-danger" onClick={() => askForReason("deny", "Why is this request denied?")}>Deny</button>
+                </div>
+            ) : null}
+
+            <section className="event-ops-detail-section">
+                <h4>Checkpoint progress</h4>
+                <div className="event-ops-checkpoint-list">
+                    {CHECKPOINTS.map(([key, label]) => {
+                        const checkpoint = request.checkpoints?.find((item) => item.key === key) || { status: "pending" };
+                        return <label key={key} className="event-ops-checkpoint-edit">{label}
+                            <select value={checkpoint.status} onChange={(event) => mutate(`/checklist/${key}`, { status: event.target.value })}>
+                                <option value="pending">Pending</option>
+                                <option value="in_progress">In progress</option>
+                                <option value="completed">Completed</option>
+                            </select>
+                        </label>;
+                    })}
+                </div>
+            </section>
+
+            <form className="event-ops-detail-section" onSubmit={saveBudget}>
+                <h4>Finance</h4>
+                <div className="event-ops-inline-fields">
+                    <label className="form-label">Allocated ($)<input className="form-input" inputMode="decimal" value={budget.allocated || ""} onChange={(event) => setBudget({ ...budget, allocated: event.target.value })} /></label>
+                    <label className="form-label">Actual spend ($)<input className="form-input" inputMode="decimal" value={budget.actual || ""} onChange={(event) => setBudget({ ...budget, actual: event.target.value })} /></label>
+                </div>
+                <label className="form-label">Finance notes<textarea className="form-input" rows="2" value={budget.notes || ""} onChange={(event) => setBudget({ ...budget, notes: event.target.value })} /></label>
+                <button className="standard-button" type="submit">Save finance</button>
+            </form>
+
+            <form className="event-ops-detail-section" onSubmit={saveBooking}>
+                <h4>Room booking</h4>
+                <label className="form-label">Location<input className="form-input" value={booking.location || ""} onChange={(event) => setBooking({ ...booking, location: event.target.value })} /></label>
+                <div className="event-ops-inline-fields">
+                    <label className="form-label">Start<input className="form-input" type="datetime-local" value={booking.startDate || ""} onChange={(event) => setBooking({ ...booking, startDate: event.target.value })} /></label>
+                    <label className="form-label">End<input className="form-input" type="datetime-local" value={booking.endDate || ""} onChange={(event) => setBooking({ ...booking, endDate: event.target.value })} /></label>
+                </div>
+                <label className="form-label">Booking notes<textarea className="form-input" rows="2" value={booking.notes || ""} onChange={(event) => setBooking({ ...booking, notes: event.target.value })} /></label>
+                <button className="standard-button" type="submit">Save booking</button>
+            </form>
+
+            <section className="event-ops-detail-section">
+                <h4>Post-event review</h4>
+                <label className="form-label">OneDrive / Microsoft Forms link<input className="form-input" value={review.reviewLink || ""} onChange={(event) => setReview({ ...review, reviewLink: event.target.value })} /></label>
+                <label className="event-ops-checkbox"><input type="checkbox" checked={review.received || false} onChange={(event) => setReview({ ...review, received: event.target.checked })} /> Review received</label>
+                <button type="button" className="standard-button" onClick={() => mutate("/review-tracking", review)}>Save review tracking</button>
+            </section>
+        </aside>
+    );
+}
+
+function EventOperations({ isAdmin }) {
+    const [requests, setRequests] = useState([]);
+    const [selectedId, setSelectedId] = useState(null);
+    const [showForm, setShowForm] = useState(false);
+    const [filters, setFilters] = useState({ year: "", quarter: "", week: "", stage: "", requester: "", search: "" });
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        if (!isAdmin) return;
+        apiRequest("")
+            .then((data) => setRequests(data.eventRequests || []))
+            .catch((requestError) => setError(requestError.message));
+    }, [isAdmin]);
+
+    const years = useMemo(() => [...new Set(requests.map((request) => new Date(request.proposedStartDate).getFullYear()))].sort(), [requests]);
+    const requesters = useMemo(() => [...new Set(requests.map((request) => request.requestingGroup).filter(Boolean))].sort(), [requests]);
+    const filteredRequests = useMemo(() => requests.filter((request) => {
+        const date = new Date(request.proposedStartDate);
+        const stage = currentStage(request);
+        return (!filters.year || date.getFullYear().toString() === filters.year)
+            && (!filters.quarter || quarterOf(date) === filters.quarter)
+            && (!filters.week || weekOfQuarter(date).toString() === filters.week)
+            && (!filters.stage || stage === filters.stage)
+            && (!filters.requester || request.requestingGroup === filters.requester)
+            && (!filters.search || `${request.eventName} ${request.requestingGroup}`.toLowerCase().includes(filters.search.toLowerCase()));
+    }), [filters, requests]);
+    const selected = requests.find((request) => request._id === selectedId) || null;
+
+    const selectRequest = async (request) => {
+        setSelectedId(request._id);
+        try {
+            const data = await apiRequest(`/${request._id}`);
+            setRequests((current) => current.map((item) => item._id === request._id ? data.eventRequest : item));
+        } catch (requestError) {
+            setError(requestError.message);
+        }
+    };
+
+    const updateRequest = (updated) => setRequests((current) => current.map((request) => request._id === updated._id ? updated : request));
+    const addRequest = (created) => {
+        setRequests((current) => [...current, created]);
+        setSelectedId(created._id);
+        setShowForm(false);
+    };
+
+    if (!isAdmin) return null;
+
+    return (
+        <section className="event-operations" aria-labelledby="event-operations-heading">
+            <div className="event-ops-header">
+                <div><span className="event-ops-kicker">Officer workspace</span><h2 id="event-operations-heading">Event operations</h2><p>Track requests from proposal through post-event review.</p></div>
+                <button className="cta-secondary" onClick={() => setShowForm(!showForm)}>{showForm ? "Hide form" : "New event request"}</button>
+            </div>
+            {showForm && <EventRequestForm onCreated={addRequest} onCancel={() => setShowForm(false)} />}
+            <div className="event-ops-filters" role="group" aria-label="Event request filters">
+                <label>Year<select value={filters.year} onChange={(event) => setFilters({ ...filters, year: event.target.value })}><option value="">All years</option>{years.map((year) => <option key={year}>{year}</option>)}</select></label>
+                <label>Quarter<select value={filters.quarter} onChange={(event) => setFilters({ ...filters, quarter: event.target.value })}><option value="">All quarters</option>{["Q1", "Q2", "Q3", "Q4"].map((quarter) => <option key={quarter}>{quarter}</option>)}</select></label>
+                <label>Week<select value={filters.week} onChange={(event) => setFilters({ ...filters, week: event.target.value })}><option value="">All weeks</option>{Array.from({ length: 14 }, (_, index) => <option key={index + 1}>{index + 1}</option>)}</select></label>
+                <label>Current stage<select value={filters.stage} onChange={(event) => setFilters({ ...filters, stage: event.target.value })}><option value="">All stages</option>{CHECKPOINTS.map(([key, label]) => <option key={key} value={key}>{label}</option>)}<option value="complete">Complete</option></select></label>
+                <label>Group<select value={filters.requester} onChange={(event) => setFilters({ ...filters, requester: event.target.value })}><option value="">All groups</option>{requesters.map((requester) => <option key={requester}>{requester}</option>)}</select></label>
+                <label className="event-ops-search">Search<input value={filters.search} onChange={(event) => setFilters({ ...filters, search: event.target.value })} placeholder="Event or group" /></label>
+            </div>
+            {error && <p className="event-ops-error" role="alert">{error}</p>}
+            <div className="event-ops-layout">
+                <div className="event-ops-table-wrapper">
+                    <table className="event-ops-table">
+                        <caption className="sr-only">Event requests and checkpoint status</caption>
+                        <thead><tr><th scope="col">Event</th>{CHECKPOINTS.map(([, label]) => <th scope="col" key={label}>{label}</th>)}</tr></thead>
+                        <tbody>
+                            {filteredRequests.map((request) => {
+                                const stage = currentStage(request);
+                                return <tr key={request._id} className={selectedId === request._id ? "event-ops-row-selected" : ""}>
+                                    <th scope="row"><button className="event-ops-event-button" aria-pressed={selectedId === request._id} onClick={() => selectRequest(request)}><strong>{request.eventName}</strong><span>{formatDate(request.proposedStartDate)}</span><StatusBadge status={request.status} /></button></th>
+                                    {CHECKPOINTS.map(([key, label]) => {
+                                        const checkpoint = request.checkpoints?.find((item) => item.key === key) || { status: "pending" };
+                                        return <td key={key} className={stage === key ? "event-ops-current" : ""} data-label={label}><span className="event-ops-mobile-label">{label}</span><StatusBadge status={checkpoint.status} /></td>;
+                                    })}
+                                </tr>;
+                            })}
+                        </tbody>
+                    </table>
+                    {!filteredRequests.length && <p className="event-ops-empty">No event requests match these filters.</p>}
+                </div>
+                {selected && <EventDetail request={selected} onUpdate={updateRequest} />}
+            </div>
+        </section>
+    );
+}
+
+export default EventOperations;

--- a/frontend/src/components/EventOperations.test.jsx
+++ b/frontend/src/components/EventOperations.test.jsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import EventOperations from "./EventOperations";
+
+const request = {
+    _id: "request-1",
+    eventName: "Autumn Workshop",
+    requestingGroup: "Tech Committee",
+    description: "A workshop for students.",
+    proposedStartDate: "2026-10-15T18:00:00.000Z",
+    status: "submitted",
+    checkpoints: [
+        "proposal",
+        "meeting",
+        "finance",
+        "room",
+        "marketing",
+        "purchases",
+        "completion",
+        "review",
+    ].map((key) => ({ key, status: "pending" })),
+};
+
+const apiResponse = (eventRequest = request) => ({
+    ok: true,
+    json: async () => ({ status: "success", eventRequest, eventRequests: [eventRequest] }),
+});
+
+describe("EventOperations", () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    test("an officer can find a request, open its details, and update a checkpoint", async () => {
+        const updatedRequest = {
+            ...request,
+            checkpoints: request.checkpoints.map((checkpoint) =>
+                checkpoint.key === "meeting" ? { ...checkpoint, status: "completed" } : checkpoint,
+            ),
+        };
+        const fetchSpy = jest.spyOn(global, "fetch").mockImplementation((url, options = {}) => {
+            if (url.endsWith("/event-requests") || url.endsWith("/event-requests/")) return Promise.resolve(apiResponse());
+            if (url.endsWith("/event-requests/request-1")) return Promise.resolve(apiResponse());
+            if (url.endsWith("/event-requests/request-1/checklist/meeting")) return Promise.resolve(apiResponse(updatedRequest));
+            throw new Error(`Unexpected API request: ${url} ${options.method || "GET"}`);
+        });
+
+        render(<EventOperations isAdmin />);
+
+        const search = await screen.findByRole("textbox", { name: "Search" });
+        await screen.findByRole("button", { name: /autumn workshop/i });
+
+        fireEvent.change(search, { target: { value: "does not exist" } });
+        expect(screen.queryByRole("button", { name: /autumn workshop/i })).not.toBeInTheDocument();
+
+        fireEvent.change(search, { target: { value: "autumn" } });
+        fireEvent.click(await screen.findByRole("button", { name: /autumn workshop/i }));
+        expect(await screen.findByRole("button", { name: "Approve & publish" })).toBeInTheDocument();
+
+        fireEvent.change(screen.getByRole("combobox", { name: "Meeting" }), { target: { value: "completed" } });
+
+        await waitFor(() => expect(screen.getByRole("combobox", { name: "Meeting" })).toHaveValue("completed"));
+        expect(fetchSpy).toHaveBeenCalledWith(
+            "/api/v1/event-requests/request-1/checklist/meeting",
+            expect.objectContaining({
+                method: "PATCH",
+                body: JSON.stringify({ status: "completed" }),
+            }),
+        );
+    });
+
+    test("submits a request without sending blank optional fields", async () => {
+        const fetchSpy = jest.spyOn(global, "fetch").mockImplementation((url, options = {}) => {
+            if (url.endsWith("/event-requests") || url.endsWith("/event-requests/")) {
+                return Promise.resolve(apiResponse());
+            }
+            throw new Error(`Unexpected API request: ${url} ${options.method || "GET"}`);
+        });
+
+        render(<EventOperations isAdmin />);
+        fireEvent.click(await screen.findByRole("button", { name: /new event request/i }));
+        fireEvent.change(screen.getByRole("textbox", { name: "Event name" }), { target: { value: "Winter Social" } });
+        fireEvent.change(screen.getByRole("textbox", { name: "Requesting group" }), { target: { value: "Tech Committee" } });
+        fireEvent.change(screen.getByLabelText("Proposed start"), { target: { value: "2026-12-15T18:00" } });
+        fireEvent.change(screen.getByRole("textbox", { name: "Description" }), { target: { value: "A social event." } });
+        fireEvent.click(screen.getByRole("button", { name: "Submit request" }));
+
+        await waitFor(() => expect(fetchSpy).toHaveBeenLastCalledWith(
+            "/api/v1/event-requests/",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    eventName: "Winter Social",
+                    requestingGroup: "Tech Committee",
+                    description: "A social event.",
+                    proposedStartDate: "2026-12-15T18:00",
+                }),
+            }),
+        ));
+    });
+
+    test("students are not offered officer controls and do not load request data", () => {
+        const fetchSpy = jest.spyOn(global, "fetch");
+
+        render(<EventOperations isAdmin={false} />);
+
+        expect(screen.queryByRole("button", { name: /new event request/i })).not.toBeInTheDocument();
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -78,8 +78,10 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
+  const isAdmin = user?.uType === "Admin";
+
   return (
-    <AuthContext.Provider value={{ user, isAuthenticated, authLoading, authError, signIn, signOut }}>
+    <AuthContext.Provider value={{ user, isAuthenticated, isAdmin, authLoading, authError, signIn, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Events.jsx
+++ b/frontend/src/pages/Events.jsx
@@ -1,4 +1,5 @@
 import Calendar from "../components/Calendar";
+import EventOperations from "../components/EventOperations";
 import { useLocation } from 'react-router-dom';
 import { useState, useEffect } from "react";
 import { mockCalendarData } from "../assets/mock-data/MockCalendarData";
@@ -6,7 +7,7 @@ import { useAuthContext } from "../context/AuthContext";
 import MediaQuery from "react-responsive";
 
 function EventsPage() {
-    const { isAuthenticated } = useAuthContext();
+    const { isAuthenticated, isAdmin } = useAuthContext();
     const {state, pathname} = useLocation();
     const [calendarEvents, setCalendarEvents] = useState([])
 
@@ -53,6 +54,7 @@ function EventsPage() {
                     <img src="/assets/about-main.png" alt="group of iuga students" />
                 </div>
             </MediaQuery>
+            <EventOperations isAdmin={isAdmin} />
         </>
     );
 }

--- a/frontend/src/pages/Events.test.jsx
+++ b/frontend/src/pages/Events.test.jsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import EventsPage from "./Events";
+import { useAuthContext } from "../context/AuthContext";
+
+jest.mock("../context/AuthContext", () => ({
+    useAuthContext: jest.fn(),
+}));
+jest.mock("../components/Calendar", () => () => <div>Public events calendar</div>);
+jest.mock("react-responsive", () => ({ children }) => <>{children}</>);
+
+const request = {
+    _id: "request-1",
+    eventName: "Autumn Workshop",
+    requestingGroup: "Tech Committee",
+    description: "A workshop for students.",
+    proposedStartDate: "2026-10-15T18:00:00.000Z",
+    status: "submitted",
+    checkpoints: ["proposal", "meeting", "finance", "room", "marketing", "purchases", "completion", "review"]
+        .map((key) => ({ key, status: "pending" })),
+};
+
+describe("EventsPage", () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    test("keeps the public calendar and reveals operations to an officer", async () => {
+        useAuthContext.mockReturnValue({ isAuthenticated: true, isAdmin: true });
+        jest.spyOn(global, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => ({ status: "success", eventRequests: [request] }),
+        });
+        jest.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+        render(<MemoryRouter><EventsPage /></MemoryRouter>);
+
+        expect(screen.getByText("Public events calendar")).toBeInTheDocument();
+        expect(await screen.findByRole("heading", { name: "Event operations" })).toBeInTheDocument();
+        expect(await screen.findByText("Autumn Workshop")).toBeInTheDocument();
+    });
+
+    test("keeps officer operations out of the public Events page", async () => {
+        useAuthContext.mockReturnValue({ isAuthenticated: false, isAdmin: false });
+        const fetchSpy = jest.spyOn(global, "fetch");
+        jest.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+        render(<MemoryRouter><EventsPage /></MemoryRouter>);
+
+        await waitFor(() => expect(screen.getByText("Public events calendar")).toBeInTheDocument());
+        expect(screen.queryByRole("heading", { name: "Event operations" })).not.toBeInTheDocument();
+        expect(fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining("event-requests"), expect.anything());
+    });
+});

--- a/frontend/src/stylesheets/pages/_events.scss
+++ b/frontend/src/stylesheets/pages/_events.scss
@@ -1,0 +1,444 @@
+.event-operations {
+    width: min(1200px, calc(100% - 36px));
+    margin: 24px auto 64px;
+}
+
+.event-ops-header,
+.event-ops-form-heading,
+.event-ops-detail-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.event-ops-header {
+    margin-bottom: 24px;
+
+    h2,
+    h3,
+    p {
+        margin: 0;
+    }
+
+    h2 {
+        color: $color-uw-purple;
+        font-size: 2.25rem;
+    }
+
+    p {
+        color: $dark-gray;
+        margin-top: 8px;
+    }
+}
+
+.event-ops-kicker {
+    color: $color-primary;
+    display: block;
+    font-size: 0.75rem;
+    font-weight: bold;
+    letter-spacing: 0.12em;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+}
+
+.event-ops-filters {
+    align-items: end;
+    background: $gray;
+    border: 1px solid rgba($color-uw-purple, 0.12);
+    border-radius: $radius;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(5, minmax(110px, 1fr)) minmax(160px, 1.5fr);
+    margin-bottom: 24px;
+    padding: 16px;
+
+    label {
+        color: $color-uw-purple;
+        display: flex;
+        flex-direction: column;
+        font-size: 0.75rem;
+        font-weight: bold;
+        gap: 6px;
+    }
+
+    select,
+    input {
+        background: white;
+        border: 1px solid rgba($color-uw-purple, 0.22);
+        border-radius: 5px;
+        box-sizing: border-box;
+        color: #333;
+        min-height: 38px;
+        padding: 8px 10px;
+    }
+
+    select:focus,
+    input:focus {
+        border-color: $color-primary;
+        outline: 2px solid rgba($color-primary, 0.2);
+    }
+}
+
+.event-ops-layout {
+    align-items: start;
+    display: grid;
+    gap: 24px;
+    grid-template-columns: minmax(0, 1fr) minmax(300px, 0.44fr);
+}
+
+.event-ops-table-wrapper {
+    background: white;
+    border: 1px solid rgba($color-uw-purple, 0.12);
+    border-radius: $radius-card;
+    box-shadow: 0 2px 10px rgba($color-uw-purple, 0.08);
+    min-width: 0;
+    overflow-x: auto;
+}
+
+.event-ops-table {
+    border-collapse: collapse;
+    min-width: 920px;
+    width: 100%;
+
+    th,
+    td {
+        border-bottom: 1px solid rgba($color-uw-purple, 0.1);
+        padding: 12px 10px;
+        text-align: center;
+        vertical-align: middle;
+    }
+
+    thead {
+        background: $color-uw-purple;
+        color: white;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+
+    thead th {
+        font-size: 0.75rem;
+        letter-spacing: 0.04em;
+        white-space: nowrap;
+    }
+
+    tbody th {
+        min-width: 170px;
+        text-align: left;
+    }
+
+    tbody tr:last-child th,
+    tbody tr:last-child td {
+        border-bottom: 0;
+    }
+}
+
+.event-ops-row-selected {
+    background: $color-social-light;
+}
+
+.event-ops-event-button {
+    align-items: flex-start;
+    background: transparent;
+    border: 0;
+    color: $color-uw-purple;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+
+    &:hover,
+    &:focus-visible {
+        color: $color-primary;
+    }
+
+    span:not(.event-ops-status) {
+        color: $dark-gray;
+        font-size: 0.75rem;
+        font-weight: normal;
+    }
+}
+
+.event-ops-status {
+    border-radius: $radius-pill;
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: bold;
+    padding: 4px 8px;
+    text-transform: capitalize;
+    white-space: nowrap;
+}
+
+.event-ops-status-submitted,
+.event-ops-status-in_progress {
+    background: $color-career-secondary;
+    color: $color-career-primary;
+}
+
+.event-ops-status-changes_requested,
+.event-ops-status-pending {
+    background: $color-academic-secondary;
+    color: $color-academic-capsule;
+}
+
+.event-ops-status-approved,
+.event-ops-status-completed {
+    background: $color-social-secondary;
+    color: $color-social-capsule;
+}
+
+.event-ops-status-denied,
+.event-ops-status-cancelled {
+    background: #eee;
+    color: $dark-gray;
+}
+
+.event-ops-current {
+    background: rgba($color-primary, 0.1);
+    box-shadow: inset 0 -3px 0 $color-primary;
+}
+
+.event-ops-mobile-label {
+    display: none;
+}
+
+.event-ops-empty,
+.event-ops-error {
+    margin: 0;
+    padding: 28px;
+    text-align: center;
+}
+
+.event-ops-error {
+    background: #fff4f4;
+    border: 1px solid #d88;
+    border-radius: $radius;
+    color: #7a1717;
+    margin-bottom: 16px;
+}
+
+.event-ops-form,
+.event-ops-detail {
+    box-sizing: border-box;
+    padding: 24px;
+}
+
+.event-ops-form {
+    margin-bottom: 24px;
+
+    h3,
+    h4,
+    p {
+        margin-top: 0;
+    }
+}
+
+.event-ops-close,
+.event-ops-danger {
+    background: transparent;
+    border: 0;
+    color: $color-primary;
+    padding: 4px;
+}
+
+.event-ops-danger {
+    color: #8b1e1e;
+}
+
+.event-ops-form-grid {
+    display: grid;
+    gap: 0 18px;
+    grid-template-columns: 1fr 1fr;
+    margin-top: 20px;
+}
+
+.event-ops-full-width {
+    grid-column: 1 / -1;
+}
+
+.event-ops-form-actions,
+.event-ops-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.event-ops-form-actions {
+    justify-content: flex-end;
+}
+
+.event-ops-detail {
+    position: sticky;
+    top: 16px;
+
+    h3 {
+        color: $color-uw-purple;
+        margin: 0;
+    }
+
+    p {
+        line-height: 1.5;
+    }
+}
+
+.event-ops-detail-meta {
+    color: $dark-gray;
+    font-size: 0.85rem;
+}
+
+.event-ops-detail-section {
+    border-top: 1px solid rgba($color-uw-purple, 0.12);
+    margin-top: 20px;
+    padding-top: 18px;
+
+    h4 {
+        color: $color-uw-purple;
+        margin: 0 0 14px;
+    }
+
+    .form-input {
+        margin-bottom: 12px;
+    }
+}
+
+.event-ops-checkpoint-list {
+    display: grid;
+    gap: 8px;
+}
+
+.event-ops-checkpoint-edit {
+    align-items: center;
+    color: $dark-gray;
+    display: flex;
+    font-size: 0.85rem;
+    justify-content: space-between;
+    gap: 12px;
+
+    select {
+        border: 1px solid rgba($color-uw-purple, 0.2);
+        border-radius: 5px;
+        padding: 6px;
+    }
+}
+
+.event-ops-inline-fields {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 1fr 1fr;
+}
+
+.event-ops-checkbox {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    margin-bottom: 14px;
+}
+
+.sr-only {
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    position: absolute;
+    width: 1px;
+}
+
+@include media("screen", "<sm-desktop") {
+    .event-operations {
+        width: calc(100% - 24px);
+    }
+
+    .event-ops-header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .event-ops-filters {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .event-ops-search {
+        grid-column: 1 / -1;
+    }
+
+    .event-ops-layout {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .event-ops-detail {
+        position: static;
+        width: 100%;
+    }
+
+    .event-ops-table-wrapper {
+        border-radius: $radius;
+        width: 100%;
+    }
+
+    .event-ops-table {
+        min-width: 0;
+
+        thead {
+            display: none;
+        }
+
+        tbody,
+        tr,
+        th,
+        td {
+            display: block;
+        }
+
+        tr {
+            border-bottom: 1px solid rgba($color-uw-purple, 0.14);
+            padding: 14px;
+        }
+
+        tr:last-child {
+            border-bottom: 0;
+        }
+
+        tbody th,
+        td {
+            border: 0;
+            min-width: 0;
+            padding: 5px 0;
+            text-align: left;
+        }
+
+        td {
+            align-items: center;
+            display: flex;
+            justify-content: space-between;
+        }
+    }
+
+    .event-ops-mobile-label {
+        color: $dark-gray;
+        display: inline;
+        font-size: 0.75rem;
+        font-weight: bold;
+    }
+}
+
+@include media("screen", "<phone") {
+    .event-ops-form-grid,
+    .event-ops-inline-fields,
+    .event-ops-filters {
+        grid-template-columns: 1fr;
+    }
+
+    .event-ops-search,
+    .event-ops-full-width {
+        grid-column: auto;
+    }
+
+    .event-ops-form,
+    .event-ops-detail {
+        padding: 18px;
+    }
+}


### PR DESCRIPTION
## Summary

Adds Admin-only event operations to the existing Events page, including request filters, request creation, workflow actions, checkpoints, finance, booking, and review tracking.

## Rationale

Provides officers with an operational event workflow without introducing a separate dashboard, route, or SPA. Public users retain the existing Events experience, while backend authorization remains authoritative.

## Tests

- 71 frontend tests passed
- Production build passed with existing warnings
- `git diff --check` passed