### PR TITLE
fix(ui): expand event operations table layout

### DIFF
--- a/frontend/src/components/EventOperations.jsx
+++ b/frontend/src/components/EventOperations.jsx
@@ -324,7 +324,7 @@ function EventOperations({ isAdmin }) {
                 <label className="event-ops-search">Search<input value={filters.search} onChange={(event) => setFilters({ ...filters, search: event.target.value })} placeholder="Event or group" /></label>
             </div>
             {error && <p className="event-ops-error" role="alert">{error}</p>}
-            <div className="event-ops-layout">
+            <div className={`event-ops-layout${selected ? "" : " event-ops-layout-full"}`}>
                 <div className="event-ops-table-wrapper">
                     <table className="event-ops-table">
                         <caption className="sr-only">Event requests and checkpoint status</caption>

--- a/frontend/src/stylesheets/pages/_events.scss
+++ b/frontend/src/stylesheets/pages/_events.scss
@@ -46,7 +46,7 @@
     align-items: end;
     background: $gray;
     border: 1px solid rgba($color-uw-purple, 0.12);
-    border-radius: $radius;
+    border-radius: $radius-card;
     display: grid;
     gap: 12px;
     grid-template-columns: repeat(5, minmax(110px, 1fr)) minmax(160px, 1.5fr);
@@ -85,6 +85,10 @@
     display: grid;
     gap: 24px;
     grid-template-columns: minmax(0, 1fr) minmax(300px, 0.44fr);
+}
+
+.event-ops-layout-full .event-ops-table-wrapper {
+    grid-column: 1 / -1;
 }
 
 .event-ops-table-wrapper {
@@ -215,7 +219,7 @@
 .event-ops-error {
     background: #fff4f4;
     border: 1px solid #d88;
-    border-radius: $radius;
+    border-radius: $radius-card;
     color: #7a1717;
     margin-bottom: 16px;
 }
@@ -224,6 +228,10 @@
 .event-ops-detail {
     box-sizing: border-box;
     padding: 24px;
+}
+
+.event-operations .form-input {
+    border-radius: $radius;
 }
 
 .event-ops-form {


### PR DESCRIPTION
## Summary

Expand the event operations table to the full available width when no event detail panel is selected, and standardize event-admin surface rounding.

## Rationale

The table previously reserved space for an empty detail panel, making it appear narrower than the surrounding page. The layout now spans the full grid until an event is selected, while preserving the two-column detail layout afterward. Event surfaces reuse the existing radius tokens.

## Tests

- Frontend tests: 71 passed
- Production build: passed with existing warnings
- Impeccable detector: clean
- `git diff --check`: passed
