### PR TITLE
feat(ui): unify pill button styling

### DIFF
--- a/frontend/src/pages/GetInvolved.jsx
+++ b/frontend/src/pages/GetInvolved.jsx
@@ -60,7 +60,7 @@ function GetInvolvedPage({ teams }) {
                         <button
                             key={year}
                             type="button"
-                            className="filter-pill"
+                            className="pill-button"
                             aria-pressed={selectedYear === year}
                             onClick={() => setSelectedYear(year)}
                         >
@@ -87,7 +87,7 @@ function GetInvolvedPage({ teams }) {
                             <p className="getInvolvedCommittee__ledBy">Led by {committee.ledBy}</p>
                             <span className="getInvolvedCommittee__badge">Membership Open</span>
                             <p className="getInvolvedCommittee__description">{committee.description}</p>
-                            <a className="cta-primary" href={committee.mailto}>
+                            <a className="pill-button" href={committee.mailto}>
                                 Join {committee.name}
                             </a>
                         </article>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -71,7 +71,7 @@ function HomePage({ upcomingEvents }) {
                         University of Washington — a community that learns together, shows up
                         for each other, and opens doors.
                     </p>
-                    <Button text="Get Involved" className="standard-button" onClick={() => navigate("/get-involved")} />
+                    <Button text="Get Involved" className="pill-button" onClick={() => navigate("/get-involved")} />
                 </div>
                 <img className="heroImage" src={formalImage} alt="IUGA members at iFormal 2026" />
             </section>
@@ -105,7 +105,7 @@ function HomePage({ upcomingEvents }) {
                 <div className="viewAllEvents">
                     <Button
                         text="View All Events"
-                        className="standard-button"
+                        className="pill-button"
                         type="right-arrow"
                         onClick={() => navigate("/events")}
                     />

--- a/frontend/src/stylesheets/components/_buttons.scss
+++ b/frontend/src/stylesheets/components/_buttons.scss
@@ -71,43 +71,66 @@ button:before {
     border: 2px solid $color-primary;
 }
 
-.standard-button,
-.standard-button:disabled,
-.standard-button[disabled] {
-    background-color: white;
-    color: black;
-    border: 1px solid rgba($color-uw-purple, 0.16);
-    border-radius: 999px;
-    box-shadow: 0 4px 20px rgba($color-uw-purple, 0.12);
-    padding: 12px 28px;
-    font-size: 15px;
-}
-
-.standard-button:hover:not(:disabled),
-.standard-button:hover:not([disabled]) {
-    background-color: #F1E8FF;
-    box-shadow: 0 6px 20px rgba($color-uw-purple, 0.14);
-}
-
-.standard-button:hover::before {
-    opacity: 0;
-}
-
-.standard-button:focus-visible {
-    outline: 2px solid $color-uw-purple;
-    outline-offset: 2px;
-}
-
-.standard-button:disabled,
-.standard-button[disabled] {
-    cursor: not-allowed;
-}
-
 $cta-lavender: #F1E8FF;
 
+.pill-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 44px;
+    box-sizing: border-box;
+    padding: 10px 24px;
+    border: 2px solid $color-primary;
+    border-radius: $radius-pill;
+    background-color: white;
+    color: black;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.2;
+    text-align: center;
+    text-decoration: none;
+    text-shadow: none;
+    cursor: pointer;
+    transition: all 150ms cubic-bezier(0.19, 1, 0.22, 1);
+    @include focus-ring;
+
+    &:hover {
+        background-color: $cta-lavender;
+    }
+
+    &:hover::before,
+    &:focus-visible::before {
+        opacity: 0;
+    }
+
+    &:active {
+        transform: translateY(1px);
+    }
+
+    &[aria-pressed="true"] {
+        background-color: $color-primary;
+        color: white;
+    }
+
+    &:disabled,
+    &[disabled] {
+        cursor: not-allowed;
+    }
+}
+
+.pill-button .right-arrow {
+    width: 14px;
+    margin: 0;
+    filter: invert(29%) sepia(85%) saturate(616%) hue-rotate(225deg) brightness(93%) contrast(88%);
+}
+
+.standard-button {
+    @extend .pill-button;
+}
+
 .cta-primary,
-.cta-secondary,
-.filter-pill {
+.cta-secondary {
     border: 2px solid $color-primary;
     border-radius: $radius-pill;
     font-weight: bold;
@@ -145,28 +168,10 @@ $cta-lavender: #F1E8FF;
     color: $color-primary;
 }
 
-.filter-pill {
-    background-color: white;
-    color: $color-primary;
-    padding: 8px 20px;
-    font-size: 14px;
-}
-
-.filter-pill:hover {
-    background-color: $cta-lavender;
-}
-
-.filter-pill[aria-pressed="true"] {
-    background-color: $color-primary;
-    color: white;
-}
-
 .cta-primary:hover::before,
 .cta-primary:focus-visible::before,
 .cta-secondary:hover::before,
-.cta-secondary:focus-visible::before,
-.filter-pill:hover::before,
-.filter-pill:focus-visible::before {
+.cta-secondary:focus-visible::before {
     opacity: 0;
 }
 
@@ -178,7 +183,7 @@ $cta-lavender: #F1E8FF;
 }
 
 @include media(">=sm-desktop", "<desktop") {
-    button {
+    button:not(.pill-button):not(.standard-button) {
         font-size: 12px;
         padding: 10px 16px;
 

--- a/frontend/src/stylesheets/pages/_getInvolved.scss
+++ b/frontend/src/stylesheets/pages/_getInvolved.scss
@@ -229,10 +229,8 @@
         color: $dark-gray;
     }
 
-    .cta-primary {
+    .pill-button {
         margin-top: auto;
-        padding: 10px 22px;
-        font-size: 14px;
     }
 }
 

--- a/frontend/src/stylesheets/pages/_home.scss
+++ b/frontend/src/stylesheets/pages/_home.scss
@@ -255,13 +255,6 @@
     display: flex;
     justify-content: center;
     margin: 32px 0 120px;
-
-    .standard-button {
-        min-height: 44px;
-        padding: $padding-box-y 22px;
-        font-size: 16px;
-        border-radius: $radius-pill;
-    }
 }
 
 @include media(">=sm-desktop", "<desktop") {


### PR DESCRIPTION
## Summary

Unify Home and Get Involved actions under the shared `pill-button` styling.

## Rationale

Previously, these actions used multiple page-specific button classes with duplicate styling. The shared class keeps pill-button behavior and appearance consistent while preserving existing button compatibility.

## Tests

- `npm run build` passed.
- `CI=true npm run build` remains blocked by pre-existing lint warnings unrelated to this change.
