### PR TITLE
fix(ui): standardize card media radii

### DIFF
--- a/frontend/src/stylesheets/abstracts/_variables.scss
+++ b/frontend/src/stylesheets/abstracts/_variables.scss
@@ -4,6 +4,7 @@ $radius: 8px;
 $radius-pill: 999px;
 $radius-media: 28px;
 $radius-card: 24px;
+$radius-card-media: 16px;
 
 $padding-content: 18px;
 $padding-box-x: 18px;

--- a/frontend/src/stylesheets/components/_eventCard.scss
+++ b/frontend/src/stylesheets/components/_eventCard.scss
@@ -12,7 +12,8 @@
     & > div:first-of-type {
         width: 100%;
         height: 200px;
-        border-radius: $radius-card;
+        overflow: hidden;
+        border-radius: $radius-card-media;
         background-color: black;
 
         img {
@@ -20,7 +21,6 @@
             object-fit: cover;
             width: 100%;
             height: 100%;
-            border-radius: $radius-card;
         }
     }
 }
@@ -68,7 +68,6 @@
         & > div:first-of-type {
             width: 100%;
             height: 170px;
-            border-radius: $radius-card;
             background-color: black;
         }
     }
@@ -96,7 +95,6 @@
         & > div:first-of-type {
             width: 100%;
             height: 170px;
-            border-radius: $radius-card;
             background-color: black;
         }
     }
@@ -112,7 +110,6 @@
     justify-content: center;
     width: 100%;
     height: 100%;
-    border-radius: $radius-card;
     color: white;
 
     svg {

--- a/frontend/src/stylesheets/pages/_getInvolved.scss
+++ b/frontend/src/stylesheets/pages/_getInvolved.scss
@@ -106,7 +106,7 @@
     &__media {
         width: 100%;
         aspect-ratio: 1 / 1;
-        border-radius: $radius-card;
+        border-radius: $radius-card-media;
         background-color: $gray;
         overflow: hidden;
 
@@ -126,7 +126,6 @@
         justify-content: center;
         width: 100%;
         height: 100%;
-        border-radius: $radius-card;
         color: $dark-gray;
 
         svg {
@@ -175,10 +174,6 @@
 @include media("screen", "<tablet") {
     .getInvolvedCard {
         padding: 14px;
-
-        &__media {
-            border-radius: $radius-card;
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

<!-- What changed and what observable outcome does it produce? -->

- Standardize card corners across Home event cards and Get Involved officer cards.
- Keep outer cards at 24px and inset media at 16px.
- Clip media through the wrapper instead of nested child radii.

## Rationale

<!-- Why was this change needed and why this approach? -->

Home and Get Involved used inconsistent media radii, especially on mobile. A shared Sass token keeps both card families visually consistent without duplicate overrides.

## Tests

<!-- What verification was run? -->

- Frontend tests: 10 suites, 71 tests passed.
- Production build passed with existing warnings.
- Desktop/mobile visual QA completed for both pages.
- `git diff --check` passed.