### PR TITLE
fix(ui): standardize shared pill dimensions

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -106,7 +106,6 @@ function HomePage({ upcomingEvents }) {
                     <Button
                         text="View All Events"
                         className="pill-button"
-                        type="right-arrow"
                         onClick={() => navigate("/events")}
                     />
                 </div>

--- a/frontend/src/pages/Home.test.jsx
+++ b/frontend/src/pages/Home.test.jsx
@@ -15,6 +15,7 @@ const renderHome = () =>
             <Routes>
                 <Route path="/" element={<HomePage upcomingEvents={[]} />} />
                 <Route path="/get-involved" element={<div>Get Involved Page</div>} />
+                <Route path="/events" element={<div>Events Page</div>} />
             </Routes>
         </MemoryRouter>
     );
@@ -26,16 +27,32 @@ describe("HomePage", () => {
         expect(screen.getByText("Get Involved Page")).toBeInTheDocument();
     });
 
+    test("View All Events navigates to the events page", async () => {
+        renderHome();
+        await userEvent.click(screen.getByRole("button", { name: "View All Events" }));
+        expect(screen.getByText("Events Page")).toBeInTheDocument();
+    });
+
     test("has no form inputs and no disabled Coming Soon submit", () => {
         renderHome();
         expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
         expect(screen.queryByText(/send.*coming soon/i)).not.toBeInTheDocument();
     });
 
-    test("renders all three function category labels", () => {
+    test("keeps the three IUGA function streams easy to scan", () => {
         renderHome();
-        expect(screen.getByText("Academic")).toBeInTheDocument();
-        expect(screen.getByText("Social")).toBeInTheDocument();
-        expect(screen.getByText("Professional")).toBeInTheDocument();
+
+        ["Academic", "Social", "Professional"].forEach((category) => {
+            expect(screen.getByText(category)).toBeVisible();
+            expect(screen.queryByRole("button", { name: category })).not.toBeInTheDocument();
+        });
+
+        [
+            "Learn together, grow together",
+            "Show up, connect, unwind",
+            "Meet the people who make it",
+        ].forEach((title) => {
+            expect(screen.getByRole("heading", { name: title, level: 2 })).toBeVisible();
+        });
     });
 });

--- a/frontend/src/stylesheets/abstracts/_variables.scss
+++ b/frontend/src/stylesheets/abstracts/_variables.scss
@@ -5,6 +5,12 @@ $radius-pill: 999px;
 $radius-media: 28px;
 $radius-card: 24px;
 
+// Shared standard pill dimensions. Text controls keep content-based widths.
+$pill-height: 44px;
+$pill-padding-y: 10px;
+$pill-padding-x: 24px;
+$pill-border-width: 2px;
+
 $padding-content: 18px;
 $padding-box-x: 18px;
 $padding-box-y: 12px;

--- a/frontend/src/stylesheets/components/_buttons.scss
+++ b/frontend/src/stylesheets/components/_buttons.scss
@@ -73,22 +73,27 @@ button:before {
 
 $cta-lavender: #F1E8FF;
 
-.pill-button {
+%pill-surface {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
-    min-height: 44px;
+    height: $pill-height;
     box-sizing: border-box;
-    padding: 10px 24px;
-    border: 2px solid $color-primary;
+    padding: $pill-padding-y $pill-padding-x;
+    white-space: nowrap;
+    border: $pill-border-width solid $color-primary;
     border-radius: $radius-pill;
     background-color: white;
     color: black;
     font-size: 1rem;
-    font-weight: 600;
+    font-weight: 700;
     line-height: 1.2;
     text-align: center;
+}
+
+.pill-button {
+    @extend %pill-surface;
+    gap: 6px;
     text-decoration: none;
     text-shadow: none;
     cursor: pointer;
@@ -117,12 +122,6 @@ $cta-lavender: #F1E8FF;
     &[disabled] {
         cursor: not-allowed;
     }
-}
-
-.pill-button .right-arrow {
-    width: 14px;
-    margin: 0;
-    filter: invert(29%) sepia(85%) saturate(616%) hue-rotate(225deg) brightness(93%) contrast(88%);
 }
 
 .standard-button {

--- a/frontend/src/stylesheets/components/_calendar.scss
+++ b/frontend/src/stylesheets/components/_calendar.scss
@@ -78,12 +78,6 @@
     gap: 12px;
     margin: 0 0 20px;
     cursor: default;
-
-    .tagText {
-        padding: 10px 24px;
-        font-size: 1rem;
-        font-weight: 600;
-    }
 }
 
 .calendar-item-container {
@@ -450,11 +444,6 @@
 
     .calendar-tag-wrapper {
         gap: 8px;
-
-        .tagText {
-            padding: 8px 18px;
-            font-size: 0.9rem;
-        }
     }
 
     .calendar-day {

--- a/frontend/src/stylesheets/components/_tag.scss
+++ b/frontend/src/stylesheets/components/_tag.scss
@@ -3,9 +3,7 @@
 }
 
 .tagText {
-    font-size: 1rem;
-    border-radius: $radius-pill;
-    padding: 4px 16px;
+    @extend %pill-surface;
     margin: 0;
 }
 
@@ -39,18 +37,10 @@
 
 .tag-small {
     .tagText {
+        height: auto;
         font-size: 0.8rem;
         border-radius: $radius;
         padding: 2px 8px;
-        margin: 0;
-    }
-}
-
-@include media(">=sm-desktop", "<desktop") {
-    .tagText {
-        font-size: 12px;
-        border-radius: $radius-pill;
-        padding: 6px 12px;
         margin: 0;
     }
 }

--- a/frontend/src/stylesheets/pages/_events.scss
+++ b/frontend/src/stylesheets/pages/_events.scss
@@ -6,7 +6,7 @@
 
     .calendar-tag-wrapper .tagText {
         background-color: white;
-        border: 2px solid $color-primary;
+        border-width: $pill-border-width;
         color: black;
     }
 }

--- a/frontend/src/stylesheets/pages/_home.scss
+++ b/frontend/src/stylesheets/pages/_home.scss
@@ -87,16 +87,8 @@
         color: black;
 
         .functionKicker {
-            display: inline-block;
-            padding: 6px 16px;
+            @extend %pill-surface;
             margin-bottom: 16px;
-            font-size: 0.8rem;
-            font-weight: 700;
-            letter-spacing: 0.14em;
-            text-transform: uppercase;
-            background-color: white;
-            border: 1px solid transparent;
-            border-radius: $radius-pill;
         }
 
         h2 {
@@ -111,21 +103,6 @@
             color: $dark-gray;
         }
     }
-}
-
-.functionRow.academic .functionKicker {
-    color: $color-primary;
-    border-color: $color-primary;
-}
-
-.functionRow.social .functionKicker {
-    color: $color-primary;
-    border-color: $color-primary;
-}
-
-.functionRow.professional .functionKicker {
-    color: $color-primary;
-    border-color: $color-primary;
 }
 
 .functionRowReversed .functionCopy {
@@ -147,30 +124,10 @@
     }
 }
 
-.eventStreamCards .eventCardCategories {
-    .tagText {
-        padding: 6px 12px;
-        font-size: 0.8rem;
-        font-weight: 700;
-        border: 1px solid;
-        border-radius: $radius-pill;
-        background-color: white;
-    }
-
-    .academic .tagText {
-        color: $color-primary;
-        border-color: $color-primary;
-    }
-
-    .social .tagText {
-        color: $color-primary;
-        border-color: $color-primary;
-    }
-
-    .professional .tagText {
-        color: $color-primary;
-        border-color: $color-primary;
-    }
+.eventStreamCards .eventCardCategories .tagText {
+    background-color: white;
+    color: black;
+    border-color: $color-primary;
 }
 
 .eventStreamCards .eventCardFallback {


### PR DESCRIPTION
## Summary

Standardize pill dimensions across Home, Events, Calendar, and Get Involved.

All standard pills now share one 44px height, padding, border width, and visual surface. View All Events no longer has a mismatched arrow.

## Rationale

Previously, related pills used separate hardcoded dimensions and responsive overrides, causing visible size differences.

Shared Sass tokens and `%pill-surface` now provide one source of truth while preserving smaller tag variants.

## Tests

- `CI=true npm test -- --watchAll=false --runInBand`
  - 10 suites passed
  - 72 tests passed
- `cd frontend && CI=false npm run build`
  - Compiled with existing warnings
- `git diff --check`
  - Passed
