### PR TITLE
fix(calendar): replace month nav arrow images with fontawesome icons

### DIFF
--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -1,6 +1,6 @@
 import dateFormat from "dateformat";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCheck } from '@fortawesome/free-solid-svg-icons'
+import { faArrowLeft, faArrowRight, faCheck } from '@fortawesome/free-solid-svg-icons'
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { startOfMonth, endOfMonth, eachDayOfInterval, format, getDay, parseISO } from "date-fns";
 import EventDetailsLoader from "./EventDetailsLoader";
@@ -106,14 +106,14 @@ const Calendar = ({ calendarEvents, highlightEvent }) => {
         <div className="calendar">
             <div className="calendar-header">
                 <button className="calendar-nav-button" type="button" aria-label="Previous month" onClick={prevMonth}>
-                    <img className="left-arrow" src="/assets/right-arrow.svg" alt="" />
+                    <FontAwesomeIcon icon={faArrowLeft} aria-hidden="true" />
                 </button>
                 <div>
                     <h1>{dateFormat(calendarDate, "mmmm yyyy")}</h1>
                     <p>Click an event to learn more.</p>
                 </div>
                 <button className="calendar-nav-button" type="button" aria-label="Next month" onClick={nextMonth}>
-                    <img className="right-arrow" src="/assets/right-arrow.svg" alt="" />
+                    <FontAwesomeIcon icon={faArrowRight} aria-hidden="true" />
                 </button>
             </div>
             <div className="calendar-wrapper">

--- a/frontend/src/stylesheets/components/_calendar.scss
+++ b/frontend/src/stylesheets/components/_calendar.scss
@@ -37,11 +37,19 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 8px;
+    width: 44px;
+    height: 44px;
+    flex: 0 0 44px;
+    padding: 0;
     border: 0;
     border-radius: $radius-pill;
     background: transparent;
-    color: inherit;
+    color: $color-primary;
+
+    svg {
+        width: 22px;
+        height: 22px;
+    }
 
     &:hover {
         background-color: $gray;
@@ -49,6 +57,11 @@
 
     &:hover::before {
         opacity: 0;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $color-primary;
+        outline-offset: 2px;
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the calendar month-navigation fix to `dev`: correct left/right FontAwesome arrows, 44px navigation hit targets, icon sizing, and visible keyboard focus styling.

## Rationale

The previous-month control used the right-arrow image asset, and the image-based controls were not styled consistently. This PR targets `dev` directly and contains only the intended calendar component and stylesheet changes.

## Tests

- Branch diff against `dev` verified as 2 files with 18 additions and 5 deletions
- `CI=true npm run build` previously reached the changed code but failed on pre-existing ESLint warnings in unrelated files; no warnings came from the changed files
