### PR TITLE
chore(deps): bump mongoose to 6.13.9

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,7 @@
         "handlebars": "^4.7.7",
         "JSONStream": "^1.3.5",
         "moment": "^2.29.4",
-        "mongoose": "^6.10.0",
+        "mongoose": "^6.13.9",
         "morgan": "~1.9.1",
         "node-cache": "^5.1.2",
         "node-cron": "^3.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "handlebars": "^4.7.7",
     "JSONStream": "^1.3.5",
     "moment": "^2.29.4",
-    "mongoose": "^6.10.0",
+    "mongoose": "^6.13.9",
     "morgan": "~1.9.1",
     "node-cache": "^5.1.2",
     "node-cron": "^3.0.2",


### PR DESCRIPTION
## Summary

Bumps the mongoose dependency range from `^6.10.0` to `^6.13.9` in `backend/package.json` and the lockfile's root entry, aligning the declared range with the already-resolved 6.13.10.

## Rationale

- The lockfile already resolves mongoose to 6.13.10 in both the `node_modules` and legacy sections, so `^6.10.0` was silently out of sync with the installed version.
- 6.13.x carries upstream maintenance and security fixes within the same major version; the mongoose 6 API is unchanged.
- No code changes required.

## Tests

- `npm install --package-lock-only` reports the lockfile up to date after the range change.
- Full backend suite (`cd backend && node --test`): 32/32 pass with the new range.