### PR TITLE
feat(home): trim landing page to hero hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,50 @@
-# macOS
+# === Environment ===
+.env
+.env.*
+backend/env/*
+!backend/env/.env.example
+
+# === Dependencies ===
+node_modules/
+frontend/node_modules/
+backend/node_modules/
+
+# === Build artifacts ===
+frontend/build/
+dist/
+
+# === OS files ===
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+*.swp
+*.swo
+*~
 
-# local agent state
-.omo/
-/node_modules
+# === IDE / Editor ===
+.idea/
+.vscode/
+*.sublime-workspace
+*.sublime-project
+.project
+.classpath
+.settings/
 
+# === Logs ===
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
-# Personal agent guidance
-/AGENTS.md
+# === Testing ===
+coverage/
+
+# === Docker ===
+docker-compose.override.yml
+
+# === Local agent state ===
+.om*/
+AGENTS.md

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,34 +1,12 @@
-import { useEffect, useMemo } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import Button from "../components/Button";
-import EventStream from "../components/EventStream";
+import { useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
 import formalImage from "../assets/iFormal-2026.jpeg";
 import bowling from "../assets/gallery/bowling.jpeg";
-import gamenight from "../assets/gallery/gamenight.jpg";
 import groups from "../assets/gallery/groups.jpg";
 import heart from "../assets/gallery/heart.jpeg";
 import officers from "../assets/gallery/officers-22.png";
 import panelists from "../assets/gallery/panelists.jpg";
 import merch from "../assets/gallery/merch.jpeg";
-
-const FUNCTIONS = [
-    {
-        category: "Academic",
-        title: "Learn together, grow together",
-        body: "Workshops, info sessions, and study jams that help you get more out of the iSchool — with people who are figuring it out right alongside you.",
-    },
-    {
-        category: "Social",
-        title: "Show up, connect, unwind",
-        body: "Game nights, bowling, and mixers where the Informatics community actually gets to know each other. No agenda — just people.",
-    },
-    {
-        category: "Professional",
-        title: "Meet the people who make it",
-        body: "Industry panels, networking nights, and career prep with the people doing the work you want to do.",
-    },
-];
-
 function formatEventDate(value) {
     if (!value) return "New details coming soon";
 
@@ -45,9 +23,7 @@ function formatEventDate(value) {
 }
 
 function HomePage({ upcomingEvents }) {
-    const navigate = useNavigate();
     const { pathname } = useLocation();
-    const now = useMemo(() => Date.now(), []);
     const featuredEvent = upcomingEvents?.[0];
     const featuredEventName = featuredEvent?.eName || "The next IUGA gathering";
     const featuredEventDate = formatEventDate(featuredEvent?.eStartDate);
@@ -68,9 +44,9 @@ function HomePage({ upcomingEvents }) {
                         </nav>
                     </div>
                     <nav className="heroCategories" aria-label="Explore events by interest">
-                        <a className="heroCategory heroCategoryCareer" href="#events-professional">Career</a>
-                        <a className="heroCategory heroCategoryAcademic" href="#events-academic">Academic</a>
-                        <a className="heroCategory heroCategorySocial" href="#events-social">Social</a>
+                        <Link className="heroCategory heroCategoryCareer" to="/events">Career</Link>
+                        <Link className="heroCategory heroCategoryAcademic" to="/events">Academic</Link>
+                        <Link className="heroCategory heroCategorySocial" to="/events">Social</Link>
                     </nav>
                 </div>
                 <div className="heroWorld" aria-label="IUGA student community">
@@ -94,79 +70,11 @@ function HomePage({ upcomingEvents }) {
                         <strong>Join IUGA</strong>
                         <span>Help build what's next. <b aria-hidden="true">→</b></span>
                     </Link>
-                    <a className="heroMerch glassObject" href="#merch">
+                    <Link className="heroMerch glassObject" to="/get-involved">
                         <img src={merch} alt="IUGA branded merchandise arranged for students" />
                         <span><strong>Rep Informatics</strong><br />Shop merch <b aria-hidden="true">→</b></span>
-                    </a>
+                    </Link>
                 </div>
-            </section>
-
-            <section className="homeRegion eventsSection" aria-labelledby="eventsHeading">
-                <div className="homeSectionHeader">
-                    <p className="homeEyebrow">On the calendar</p>
-                    <h2 id="eventsHeading">Happening in Informatics</h2>
-                    <p>Find a workshop, gathering, or conversation that fits where you are right now.</p>
-                </div>
-
-                <div className="eventStreams">
-                    {FUNCTIONS.map((fn) => (
-                        <article className="functionGroup" id={`events-${fn.category.toLowerCase()}`} key={fn.category}>
-                            <div className="functionCopy">
-                                <p className="functionKicker">{fn.category}</p>
-                                <h3>{fn.title}</h3>
-                                <p>{fn.body}</p>
-                            </div>
-                            <EventStream category={fn.category} events={upcomingEvents} now={now} />
-                        </article>
-                    ))}
-                </div>
-
-                <div className="viewAllEvents">
-                    <Button text="View All Events" className="pill-button" onClick={() => navigate("/events")} />
-                </div>
-            </section>
-
-            <section className="homeRegion contentRegion communitySection" id="community" aria-labelledby="communityHeading">
-                <div className="contentRegionCopy">
-                    <p className="homeEyebrow">Find your people</p>
-                    <h2 id="communityHeading">Community</h2>
-                    <p>
-                        Informatics is better with people beside you. IUGA creates low-pressure
-                        ways to meet classmates, celebrate together, and make the iSchool feel smaller.
-                    </p>
-                </div>
-                <div className="imageGrid" aria-label="IUGA community photos">
-                    <img src={gamenight} alt="IUGA members at a game night" />
-                    <img src={groups} alt="IUGA members gathered together" />
-                </div>
-            </section>
-
-            <section className="homeRegion contentRegion involvementSection" aria-labelledby="involvementHeading">
-                <div className="contentRegionCopy">
-                    <p className="homeEyebrow">Make it yours</p>
-                    <h2 id="involvementHeading">Get Involved</h2>
-                    <p>
-                        Bring an idea, join a committee, or help shape what the Informatics community
-                        does next. There is room for your version of participation.
-                    </p>
-                    <Link className="pill-button" to="/get-involved">Explore ways to get involved</Link>
-                </div>
-                <div className="imageGrid" aria-label="IUGA involvement photos">
-                    <img src={officers} alt="IUGA officer team members representing Informatics" />
-                    <img src={panelists} alt="IUGA industry panelists speaking at an event" />
-                </div>
-            </section>
-
-            <section className="homeRegion contentRegion merchSection" id="merch" aria-labelledby="merchHeading">
-                <div className="contentRegionCopy">
-                    <p className="homeEyebrow">Carry the community with you</p>
-                    <h2 id="merchHeading">Rep Informatics</h2>
-                    <p>
-                        Find your place, then rep it. Tees, hoodies, and more — wear the
-                        community you're already part of.
-                    </p>
-                </div>
-                <img className="featureImage" src={merch} alt="IUGA branded merchandise arranged for students" />
             </section>
         </main>
     );

--- a/frontend/src/pages/Home.test.jsx
+++ b/frontend/src/pages/Home.test.jsx
@@ -21,24 +21,10 @@ const renderHome = () =>
     );
 
 describe("HomePage", () => {
-    test("renders the approved landing-page regions in order", () => {
+    test("renders the landing-page hero region", () => {
         renderHome();
 
-        const regions = [
-            screen.getByRole("region", { name: /By informatics students, for informatics students/i }),
-            screen.getByRole("region", { name: "Happening in Informatics" }),
-            screen.getByRole("region", { name: "Community" }),
-            screen.getByRole("region", { name: "Get Involved" }),
-            screen.getByRole("region", { name: "Rep Informatics" }),
-        ];
-
-        expect(regions.map((region) => region.querySelector("h1, h2, h3").textContent)).toEqual([
-            "By informaticsstudents,for informaticsstudents.",
-            "Happening in Informatics",
-            "Community",
-            "Get Involved",
-            "Rep Informatics",
-        ]);
+        expect(screen.getByRole("region", { name: /By informatics students, for informatics students/i })).toBeInTheDocument();
     });
 
     test("keeps the primary event route accessible", async () => {
@@ -57,17 +43,11 @@ describe("HomePage", () => {
     test("exposes category paths and compact secondary actions", () => {
         renderHome();
 
-        expect(screen.getByRole("link", { name: /Career/ })).toHaveAttribute("href", "#events-professional");
-        expect(screen.getByRole("link", { name: /Academic/ })).toHaveAttribute("href", "#events-academic");
-        expect(screen.getByRole("link", { name: /Social/ })).toHaveAttribute("href", "#events-social");
+        expect(screen.getByRole("link", { name: /Career/ })).toHaveAttribute("href", "/events");
+        expect(screen.getByRole("link", { name: /Academic/ })).toHaveAttribute("href", "/events");
+        expect(screen.getByRole("link", { name: /Social/ })).toHaveAttribute("href", "/events");
         expect(screen.getByRole("link", { name: /Join IUGA/ })).toHaveAttribute("href", "/get-involved");
-        expect(screen.getByRole("link", { name: /Shop merch/ })).toHaveAttribute("href", "#merch");
-    });
-
-    test("View All Events navigates to the events page", async () => {
-        renderHome();
-        await userEvent.click(screen.getByRole("button", { name: "View All Events" }));
-        expect(screen.getByText("Events Page")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /Shop merch/ })).toHaveAttribute("href", "/get-involved");
     });
 
     test("has no form inputs and no disabled Coming Soon submit", () => {
@@ -76,30 +56,12 @@ describe("HomePage", () => {
         expect(screen.queryByText(/send.*coming soon/i)).not.toBeInTheDocument();
     });
 
-    test("uses descriptive alternatives for landing-page images", () => {
+    test("uses descriptive alternatives for hero images", () => {
         renderHome();
 
         expect(screen.getByAltText("IUGA members at iFormal 2026")).toBeInTheDocument();
-        expect(screen.getByAltText("IUGA members at a game night")).toBeInTheDocument();
-        expect(screen.getByAltText("IUGA members gathered together")).toBeInTheDocument();
-        expect(screen.getByAltText("IUGA officer team members representing Informatics")).toBeInTheDocument();
+        expect(screen.getByAltText("IUGA members forming a heart")).toBeInTheDocument();
+        expect(screen.getByAltText("IUGA bowling night")).toBeInTheDocument();
         expect(screen.getAllByAltText("IUGA branded merchandise arranged for students").length).toBeGreaterThan(0);
-    });
-
-    test("keeps the three IUGA function streams easy to scan", () => {
-        renderHome();
-
-        ["Academic", "Social", "Professional"].forEach((category) => {
-            expect(screen.getAllByText(category).some((element) => element.checkVisibility?.() ?? true)).toBe(true);
-            expect(screen.queryByRole("button", { name: category })).not.toBeInTheDocument();
-        });
-
-        [
-            "Learn together, grow together",
-            "Show up, connect, unwind",
-            "Meet the people who make it",
-        ].forEach((title) => {
-            expect(screen.getByRole("heading", { name: title, level: 3 })).toBeVisible();
-        });
     });
 });


### PR DESCRIPTION
## Summary

- Restore repository ignore rules for environment and local agent state.
- Trim the home page to a centered hero hub.
- Rewire hero actions to the Events and Get Involved routes.

## Rationale

The home page should act as a focused entry point rather than duplicate content from destination pages. Removing the lower sections keeps the landing experience centered on the hero while preserving access to events and involvement content through real routes.

## Tests

- `CI=true npm test -- --watchAll=false --runInBand` — 11 suites, 76 tests passed.
- `npm run build` — compiled successfully with existing warnings.
- `git diff --check origin/dev...HEAD` — clean.