### PR TITLE
feat(home): refine hero headline, CTA color, and category tag placement

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -37,7 +37,7 @@ function HomePage({ upcomingEvents }) {
             <section className="homeRegion heroSection" aria-labelledby="heroHeading">
                 <div className="heroCopy">
                     <div className="heroCenterpiece">
-                        <h1 id="heroHeading">By informatics<br />students,<br /><span>for informatics<br />students.</span></h1>
+                        <h1 id="heroHeading">Informatics Undergraduate Association</h1>
                         <p>Events, people, and opportunities across the Informatics community.</p>
                         <nav className="heroActions" aria-label="Homepage shortcuts">
                             <Link className="pill-button homePrimaryLink" to="/events">Explore Events <span aria-hidden="true">→</span></Link>

--- a/frontend/src/pages/Home.test.jsx
+++ b/frontend/src/pages/Home.test.jsx
@@ -24,7 +24,7 @@ describe("HomePage", () => {
     test("renders the landing-page hero region", () => {
         renderHome();
 
-        expect(screen.getByRole("region", { name: /By informatics students, for informatics students/i })).toBeInTheDocument();
+        expect(screen.getByRole("region", { name: /Informatics Undergraduate Association/i })).toBeInTheDocument();
     });
 
     test("keeps the primary event route accessible", async () => {

--- a/frontend/src/stylesheets/pages/_home.scss
+++ b/frontend/src/stylesheets/pages/_home.scss
@@ -71,14 +71,14 @@
     min-height: $pill-height;
     gap: 8px;
     padding-right: 28px;
-    background-color: $color-uw-purple;
-    border-color: $color-uw-purple;
+    background-color: $color-primary;
+    border-color: $color-primary;
     color: white;
 
     &:hover,
     &:focus-visible {
-        background-color: $color-primary;
-        border-color: $color-primary;
+        background-color: $color-uw-purple;
+        border-color: $color-uw-purple;
     }
 }
 
@@ -1117,8 +1117,8 @@
     }
 
     .heroCategoryCareer {
-        top: 34%;
-        left: 27%;
+        top: 50%;
+        left: 22%;
         transform: rotate(-5deg);
 
         &::before {
@@ -1127,7 +1127,7 @@
     }
 
     .heroCategoryAcademic {
-        top: 19%;
+        top: 20%;
         right: 25%;
         transform: rotate(5deg);
 


### PR DESCRIPTION
## Summary

Refines the landing-page hero on the home page: replaces the "By informatics students, for informatics students" tagline with the organization name "Informatics Undergraduate Association," matches the "Explore Events" CTA color to the navbar primary purple (moving the dark purple to hover), and adjusts the placement of the Career and Academic category tags on desktop.

## Rationale

- The hero previously carried a tagline instead of the org identity; the heading now states the association name directly.
- The "Explore Events" button used the darker UW purple while the navbar pills use the lighter `$color-primary`; the CTA now reuses the same global SCSS variable (`$color-primary`) for visual consistency.
- Career/Academic tag positions were nudged for better hero composition on tablet and desktop.

## Tests

- Updated `Home.test.jsx` hero-region assertion to the new heading text.
- Test suite: 11 suites / 76 tests pass.
- Build compiles successfully (pre-existing lint warnings in unrelated files are untouched).