### PR TITLE
fix(get-involved): improve mobile spacing and alignment

### DIFF
--- a/frontend/src/stylesheets/pages/_getInvolved.scss
+++ b/frontend/src/stylesheets/pages/_getInvolved.scss
@@ -37,6 +37,10 @@
     .getInvolved__header {
         text-align: center;
     }
+
+    .getInvolved__yearFilter {
+        justify-content: center;
+    }
 }
 
 .getInvolved {

--- a/frontend/src/stylesheets/pages/_getInvolved.scss
+++ b/frontend/src/stylesheets/pages/_getInvolved.scss
@@ -25,7 +25,18 @@
     box-sizing: border-box;
 }
 
-@include media(">=phone", "<tablet") {
+@include media("screen", "<tablet") {
+    .getInvolved__summary,
+    .getInvolved__section,
+    .getInvolved__committees {
+        box-sizing: border-box;
+        padding: 0 $padding-content;
+    }
+
+    .getInvolved__summaryText,
+    .getInvolved__header {
+        text-align: center;
+    }
 }
 
 .getInvolved {


### PR DESCRIPTION
## Summary

Adds mobile horizontal breathing room to the Get Involved page, centers its page and section headings, and centers the mobile team-year pill group while preserving left-aligned committee card content.

## Rationale

The mobile layout previously ran edge-to-edge, left the page hierarchy visually misaligned, and left the year selector anchored to the edge. The fix reuses the existing 18px content spacing token below the tablet breakpoint and scopes alignment changes to the page headings and year selector without changing committee card internals.

## Tests

- `CI=true npm test -- --watchAll=false --runInBand` — 11 suites, 76 tests passed.
- `npm run build` — passed.
- `./node_modules/.bin/eslint src` — 0 errors, 12 pre-existing warnings.
- Manual browser verification intentionally deferred to the user.