### PR TITLE
Move team content into dedicated pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import EventsPage from "./pages/Events";
 import ResourcesPage from "./pages/Resources";
 import ElectionPage from "./pages/Elections";
 import ElectionsFAQPage from "./pages/ElectionsFAQ";
+import AboutPage from "./pages/About";
 import GetInvolvedPage from "./pages/GetInvolved";
 import { ToastContainer, Bounce } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -61,7 +62,8 @@ function App() {
                 <Route path="/resources" element={<ResourcesPage resources={resources} />} />
                 <Route path="/elections" element={<ElectionPage candidates={iugaCandidates} />} />
                 <Route path="/electionfaq" element={<ElectionsFAQPage electionFAQ={electionFAQ} />} />
-                <Route path="/get-involved" element={<GetInvolvedPage teams={iugaTeams} />} />
+                <Route path="/about" element={<AboutPage teams={iugaTeams} />} />
+                <Route path="/get-involved" element={<GetInvolvedPage />} />
             </Routes>
             <Footer />
         </div>

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import GetInvolvedMemberCard from "../components/GetInvolvedMemberCard";
+import { groupType } from "../assets/data/Enum";
+
+function AboutPage({ teams }) {
+    const years = Object.keys(teams);
+    const [selectedYear, setSelectedYear] = useState(years[years.length - 1]);
+    const officers = teams[selectedYear]?.[groupType.OFFICERS] ?? [];
+
+    return (
+        <div className="baseContainer">
+            <main className="about">
+                <section className="about__summary">
+                    <div className="about__summaryText">
+                        <h1>About Us</h1>
+                        <p>
+                            IUGA is a student-led organization run by Informatics undergraduates, for Informatics
+                            undergraduates. We create space for students to connect, build community, and shape the iSchool experience.
+                        </p>
+                    </div>
+                </section>
+
+                <section className="about__section" aria-labelledby="team-heading">
+                    <div className="about__header">
+                        <p className="about__kicker">Team</p>
+                        <h2 id="team-heading">Meet the {selectedYear} Team</h2>
+                    </div>
+                    <div className="about__yearFilter" role="group" aria-label="Team year">
+                        {years.map((year) => (
+                            <button
+                                key={year}
+                                type="button"
+                                className="pill-button"
+                                aria-pressed={selectedYear === year}
+                                onClick={() => setSelectedYear(year)}
+                            >
+                                {year}
+                            </button>
+                        ))}
+                    </div>
+                    <div className="about__teamGrid">
+                        {officers.map((member, index) => (
+                            <GetInvolvedMemberCard key={`${member.position}-${index}`} member={member} />
+                        ))}
+                    </div>
+                </section>
+            </main>
+        </div>
+    );
+}
+
+export default AboutPage;

--- a/frontend/src/pages/About.test.jsx
+++ b/frontend/src/pages/About.test.jsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import AboutPage from "./About";
+import { iugaTeams } from "../assets/data/AboutData";
+import { groupType } from "../assets/data/Enum";
+
+const approvedNames = iugaTeams[2026][groupType.OFFICERS].map((officer) => officer.name);
+const allYears = Object.keys(iugaTeams).map(String);
+
+describe("AboutPage", () => {
+    test("renders the latest team roster by default", () => {
+        render(<AboutPage teams={iugaTeams} />);
+
+        expect(screen.getByRole("heading", { level: 1, name: "About Us" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { level: 2, name: "Meet the 2026 Team" })).toBeInTheDocument();
+        expect(
+            screen.getAllByRole("heading", { level: 3 }).map((heading) => heading.textContent).filter((name) => approvedNames.includes(name))
+        ).toEqual(approvedNames);
+    });
+
+    test("switches the team roster when a prior year is selected", () => {
+        render(<AboutPage teams={iugaTeams} />);
+
+        const filter = screen.getByRole("group", { name: "Team year" });
+        expect(within(filter).getAllByRole("button").map((button) => button.textContent)).toEqual(allYears);
+        fireEvent.click(within(filter).getByRole("button", { name: "2025" }));
+
+        expect(screen.getByRole("heading", { level: 2, name: "Meet the 2025 Team" })).toBeInTheDocument();
+        expect(within(filter).getByRole("button", { name: "2025" })).toHaveAttribute("aria-pressed", "true");
+    });
+});

--- a/frontend/src/pages/GetInvolved.jsx
+++ b/frontend/src/pages/GetInvolved.jsx
@@ -24,6 +24,16 @@ const COMMITTEES = [
             "Hi IUGA,\n\nI'm an Informatics student and I'd love to join the Creative Committee. Please add me to the loop!\n\nThanks,\n[Your name]"
         ),
     },
+    {
+        name: "Diversity Committee",
+        ledBy: "Nitya Shankar",
+        description:
+            "Leads events and initiatives that strengthen diversity across the iSchool, partnering with diversity-focused student organizations to build meaningful community.",
+        mailto: mailto(
+            "Joining the Diversity Committee",
+            "Hi IUGA,\n\nI'm an Informatics student and I'd love to join the Diversity Committee. Please add me to the loop!\n\nThanks,\n[Your name]"
+        ),
+    },
 ];
 
 function GetInvolvedPage() {

--- a/frontend/src/pages/GetInvolved.jsx
+++ b/frontend/src/pages/GetInvolved.jsx
@@ -1,7 +1,3 @@
-import { useState } from "react";
-import GetInvolvedMemberCard from "../components/GetInvolvedMemberCard";
-import { groupType } from "../assets/data/Enum";
-
 const IUGA_EMAIL = "iuga@uw.edu";
 
 const mailto = (subject, body) =>
@@ -30,13 +26,7 @@ const COMMITTEES = [
     },
 ];
 
-function GetInvolvedPage({ teams }) {
-    // Object.keys returns integer-like keys in ascending numeric order (2015..2026),
-    // so the newest team is the LAST element, not years[0].
-    const years = Object.keys(teams);
-    const [selectedYear, setSelectedYear] = useState(years[years.length - 1]);
-    const officers = teams[selectedYear]?.[groupType.OFFICERS] ?? [];
-
+function GetInvolvedPage() {
     return (
         <div className="baseContainer">
             <div className="getInvolved__summary">
@@ -47,31 +37,6 @@ function GetInvolvedPage({ teams }) {
                         undergraduates. The best way to shape the community is to jump in: join a committee,
                         lend a hand at an event, or pitch the next idea worth doing.
                     </p>
-                </div>
-            </div>
-
-            <div className="getInvolved__section">
-                <div className="getInvolved__header">
-                    <p className="getInvolved__kicker">Team</p>
-                    <h2>Meet the {selectedYear} Team</h2>
-                </div>
-                <div className="getInvolved__yearFilter" role="group" aria-label="Team year">
-                    {years.map((year) => (
-                        <button
-                            key={year}
-                            type="button"
-                            className="pill-button"
-                            aria-pressed={selectedYear === year}
-                            onClick={() => setSelectedYear(year)}
-                        >
-                            {year}
-                        </button>
-                    ))}
-                </div>
-                <div className="getInvolved__teamGrid">
-                    {officers.map((member, index) => (
-                        <GetInvolvedMemberCard key={`${member.position}-${index}`} member={member} />
-                    ))}
                 </div>
             </div>
 

--- a/frontend/src/pages/GetInvolved.test.jsx
+++ b/frontend/src/pages/GetInvolved.test.jsx
@@ -35,24 +35,30 @@ describe("GetInvolvedPage", () => {
 
     test("renders only committee join links", () => {
         render(<GetInvolvedPage teams={iugaTeams} />);
-        expect(screen.getAllByRole("link", { name: /join .* committee/i })).toHaveLength(2);
+        expect(screen.getAllByRole("link", { name: /join .* committee/i })).toHaveLength(3);
         expect(screen.queryByRole("heading", { name: /meet the .* team/i })).not.toBeInTheDocument();
     });
 
-    test("renders exactly two committee opportunities: IT and Creative, each with open membership and a Join CTA", () => {
+    test("renders three committee opportunities with open membership and a Join CTA", () => {
         render(<GetInvolvedPage teams={iugaTeams} />);
-        expect(screen.getAllByRole("link", { name: /join .* committee/i })).toHaveLength(2);
+        expect(screen.getAllByRole("link", { name: /join .* committee/i })).toHaveLength(3);
         expect(screen.getByRole("heading", { level: 3, name: "IT Committee" })).toBeInTheDocument();
         expect(screen.getByRole("heading", { level: 3, name: "Creative Committee" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { level: 3, name: "Diversity Committee" })).toBeInTheDocument();
         expect(screen.getByText(/led by yonie rivera/i)).toBeInTheDocument();
         expect(screen.getByText(/led by ellie marsh/i)).toBeInTheDocument();
-        expect(screen.getAllByText(/membership open/i)).toHaveLength(2);
+        expect(screen.getByText(/led by nitya shankar/i)).toBeInTheDocument();
+        expect(screen.getByText(/partnering with diversity-focused student organizations/i)).toBeInTheDocument();
+        expect(screen.getAllByText(/membership open/i)).toHaveLength(3);
 
         const itLink = screen.getByRole("link", { name: "Join IT Committee" });
         expect(itLink).toHaveAttribute("href", expect.stringMatching(/^mailto:iuga@uw\.edu\?subject=/));
 
         const creativeLink = screen.getByRole("link", { name: "Join Creative Committee" });
         expect(creativeLink).toHaveAttribute("href", expect.stringMatching(/^mailto:iuga@uw\.edu\?subject=/));
+
+        const diversityLink = screen.getByRole("link", { name: "Join Diversity Committee" });
+        expect(diversityLink).toHaveAttribute("href", expect.stringMatching(/^mailto:iuga@uw\.edu\?subject=/));
     });
 
     test("renders an editorial kicker above the Committees heading", () => {

--- a/frontend/src/pages/GetInvolved.test.jsx
+++ b/frontend/src/pages/GetInvolved.test.jsx
@@ -1,11 +1,8 @@
-import { render, screen, within, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { MemoryRouter } from "react-router-dom";
 import App from "../App";
 import GetInvolvedPage from "./GetInvolved";
-import { team_2026 } from "../assets/data/teams/2026";
-import { team_2025 } from "../assets/data/teams/2025";
-import { groupType } from "../assets/data/Enum";
 import { iugaTeams } from "../assets/data/AboutData";
 import { useAuthContext } from "../context/AuthContext";
 
@@ -18,8 +15,6 @@ jest.mock("../context/AuthContext", () => ({
 // used by EventStream.test.jsx keeps the import chain intact.
 jest.mock("dateformat", () => (date, mask) => "Mar 01");
 
-const approvedNames = team_2026[groupType.OFFICERS].map((officer) => officer.name);
-const allYears = Object.keys(iugaTeams).map(String);
 const above = (a, b) => (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
 
 const renderAppAtGetInvolved = () => {
@@ -38,41 +33,10 @@ describe("GetInvolvedPage", () => {
         expect(screen.getByText(/student-led/i)).toBeInTheDocument();
     });
 
-    test("renders the Meet the 2026 Team section with all nine approved officer names in order", () => {
-        render(<GetInvolvedPage teams={iugaTeams} />);
-        expect(screen.getByRole("heading", { level: 2, name: "Meet the 2026 Team" })).toBeInTheDocument();
-        const officerNames = screen
-            .getAllByRole("heading", { level: 3 })
-            .map((heading) => heading.textContent)
-            .filter((name) => approvedNames.includes(name));
-        expect(officerNames).toEqual(approvedNames);
-    });
-
-    test("members without a photo render the fallback placeholder; members with one render the image", () => {
-        const fakeTeams = {
-            2026: {
-                [groupType.OFFICERS]: [
-                    { name: "Fabricated Student", position: "President", picture: null, socials: null },
-                    { name: "Fabricated Photographer", position: "Co-President", picture: "fabricated.jpg", socials: null },
-                ],
-            },
-        };
-        render(<GetInvolvedPage teams={fakeTeams} />);
-        expect(screen.getByLabelText("Fabricated Student photo unavailable")).toBeInTheDocument();
-        expect(screen.queryByRole("img", { name: "Fabricated Student" })).not.toBeInTheDocument();
-        expect(screen.getByRole("img", { name: "Fabricated Photographer" })).toHaveAttribute("src", "fabricated.jpg");
-    });
-
-    test("returning officers render their photos with name-based alt text", () => {
-        render(<GetInvolvedPage teams={iugaTeams} />);
-        for (const name of ["Abraham Gibson", "Akshat Ghuge", "George Lee", "Samantha Oh", "Preeti Kotipalli", "Yonie Rivera"]) {
-            expect(screen.getByRole("img", { name })).toBeInTheDocument();
-        }
-    });
-
-    test("officer cards carry no committee join links; committee opportunities keep theirs", () => {
+    test("renders only committee join links", () => {
         render(<GetInvolvedPage teams={iugaTeams} />);
         expect(screen.getAllByRole("link", { name: /join .* committee/i })).toHaveLength(2);
+        expect(screen.queryByRole("heading", { name: /meet the .* team/i })).not.toBeInTheDocument();
     });
 
     test("renders exactly two committee opportunities: IT and Creative, each with open membership and a Join CTA", () => {
@@ -91,53 +55,12 @@ describe("GetInvolvedPage", () => {
         expect(creativeLink).toHaveAttribute("href", expect.stringMatching(/^mailto:iuga@uw\.edu\?subject=/));
     });
 
-    test("renders editorial kickers above the Team and Committees headings", () => {
+    test("renders an editorial kicker above the Committees heading", () => {
         render(<GetInvolvedPage teams={iugaTeams} />);
-        expect(screen.getByText("Team")).toBeInTheDocument();
         expect(screen.getByText("Committees")).toBeInTheDocument();
-        expect(
-            above(screen.getByText("Team"), screen.getByRole("heading", { level: 2, name: "Meet the 2026 Team" }))
-        ).toBe(true);
         expect(
             above(screen.getByText("Committees"), screen.getByRole("heading", { level: 2, name: "Committee Opportunities" }))
         ).toBe(true);
-    });
-
-    test("renders twelve explicit year pills with 2026 pressed by default", () => {
-        render(<GetInvolvedPage teams={iugaTeams} />);
-        const filter = screen.getByRole("group", { name: "Team year" });
-        const pills = within(filter).getAllByRole("button");
-        expect(pills).toHaveLength(12);
-        expect(pills.map((pill) => pill.textContent)).toEqual(allYears);
-        expect(within(filter).getByRole("button", { name: "2026" })).toHaveAttribute("aria-pressed", "true");
-        expect(within(filter).getByRole("button", { name: "2025" })).toHaveAttribute("aria-pressed", "false");
-    });
-
-    test("selecting the 2025 pill swaps the roster and heading to the 2025 team", () => {
-        render(<GetInvolvedPage teams={iugaTeams} />);
-        fireEvent.click(screen.getByRole("button", { name: "2025" }));
-        expect(screen.getByRole("heading", { level: 2, name: "Meet the 2025 Team" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "2025" })).toHaveAttribute("aria-pressed", "true");
-        expect(screen.getByRole("button", { name: "2026" })).toHaveAttribute("aria-pressed", "false");
-
-        const names2025 = team_2025[groupType.OFFICERS].map((officer) => officer.name);
-        const officerNames = screen
-            .getAllByRole("heading", { level: 3 })
-            .map((heading) => heading.textContent)
-            .filter((name) => names2025.includes(name));
-        expect(officerNames).toEqual(names2025);
-        const yearOnly2026 = approvedNames.filter((name) => !names2025.includes(name));
-        yearOnly2026.forEach((name) =>
-            expect(screen.queryByRole("heading", { level: 3, name })).not.toBeInTheDocument()
-        );
-    });
-
-    test("year filtering leaves committee opportunities fixed", () => {
-        render(<GetInvolvedPage teams={iugaTeams} />);
-        fireEvent.click(screen.getByRole("button", { name: "2025" }));
-        expect(screen.getByRole("heading", { level: 2, name: "Committee Opportunities" })).toBeInTheDocument();
-        expect(screen.getAllByText(/membership open/i)).toHaveLength(2);
-        expect(screen.getAllByRole("link", { name: /join .* committee/i })).toHaveLength(2);
     });
 
     test("page content never mentions elections or an election FAQ", () => {
@@ -151,10 +74,7 @@ describe("App /get-involved route", () => {
     test("serves the Get Involved page within the app shell", () => {
         renderAppAtGetInvolved();
         expect(screen.getByRole("heading", { level: 1, name: "Get Involved" })).toBeInTheDocument();
-        expect(screen.getByRole("heading", { level: 2, name: "Meet the 2026 Team" })).toBeInTheDocument();
-        for (const name of approvedNames) {
-            expect(screen.getByRole("heading", { level: 3, name })).toBeInTheDocument();
-        }
+        expect(screen.getByRole("heading", { level: 2, name: "Committee Opportunities" })).toBeInTheDocument();
     });
 
     test("does not render Elections or Election FAQ content on the route", () => {

--- a/frontend/src/stylesheets/main.scss
+++ b/frontend/src/stylesheets/main.scss
@@ -30,6 +30,7 @@
 @import 'pages/home';
 @import 'pages/events';
 @import 'pages/resources';
+@import 'pages/about';
 @import 'pages/getInvolved';
 @import 'pages/_elections';
 @import 'pages/electionsfaq';

--- a/frontend/src/stylesheets/pages/_about.scss
+++ b/frontend/src/stylesheets/pages/_about.scss
@@ -1,0 +1,63 @@
+.about {
+    width: min(1200px, 90vw);
+    margin: 0 auto;
+    padding: 48px 0 64px;
+}
+
+.about__summary {
+    max-width: 720px;
+    margin-bottom: 40px;
+}
+
+.about__summaryText {
+    h1 {
+        margin: 0 0 16px;
+        font-size: 3rem;
+    }
+
+    p {
+        margin: 0;
+        color: $dark-gray;
+        font-size: 1.05rem;
+        line-height: 1.65;
+    }
+}
+
+.about__header {
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid rgba($color-uw-purple, 0.12);
+
+    h2 { margin: 0; }
+}
+
+.about__kicker {
+    margin: 0 0 10px;
+    color: $dark-gray;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    line-height: 1.4;
+    text-transform: uppercase;
+}
+
+.about__yearFilter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 32px;
+}
+
+.about__teamGrid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: $grid-gap;
+}
+
+@include media(">=tablet", "<sm-desktop") {
+    .about__teamGrid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@include media(">=sm-desktop") {
+    .about__teamGrid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}

--- a/frontend/src/stylesheets/pages/_getInvolved.scss
+++ b/frontend/src/stylesheets/pages/_getInvolved.scss
@@ -43,33 +43,6 @@
     }
 }
 
-.getInvolved {
-    width: 1200px;
-    margin: 0 auto;
-    box-sizing: border-box;
-    padding: 48px 0 64px;
-}
-
-.getInvolved__intro {
-    max-width: 720px;
-
-    h1 {
-        margin: 0 0 16px;
-        font-size: 3rem;
-    }
-
-    p {
-        margin: 0;
-        font-size: 1.05rem;
-        line-height: 1.65;
-        color: $dark-gray;
-    }
-}
-
-.getInvolved__section {
-    margin-top: 40px;
-}
-
 .getInvolved__header {
     margin-bottom: 24px;
     padding: 0 0 16px;
@@ -89,20 +62,6 @@
     line-height: 1.4;
     text-transform: uppercase;
     color: $dark-gray;
-}
-
-.getInvolved__yearFilter {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    margin-bottom: 32px;
-}
-
-.getInvolved__teamGrid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: $grid-gap;
-    align-items: stretch;
 }
 
 .getInvolvedCard {
@@ -241,32 +200,6 @@
 
     .pill-button {
         margin-top: auto;
-    }
-}
-
-
-@include media(">=sm-desktop", "<desktop") {
-    .getInvolved {
-        width: 1000px;
-    }
-}
-
-@include media("<sm-desktop") {
-    .getInvolved {
-        width: 90vw;
-    }
-}
-
-@include media(">=tablet", "<sm-desktop") {
-    .getInvolved__teamGrid {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
-
-@include media(">=sm-desktop") {
-    .getInvolved__teamGrid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: $grid-gap;
     }
 }
 


### PR DESCRIPTION
## Summary
Move team roster content into About Us and add Diversity Committee content to Get Involved.

## Rationale
Gives team information dedicated, discoverable page locations.

## Stack Context
- Position: 6 of 11
- Base PR: #76
- Depends on: #76

## Tests
Existing frontend test suite and production build passed.