### PR TITLE
Polish content pages and event components

### DIFF
--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -142,11 +142,26 @@ const Calendar = ({ calendarEvents, highlightEvent }) => {
                                 const isSelectedClass = "eLabels" in currentEvent && dateKey === selectedDate ? `calendar-day-selected-${currentEvent.eLabels[0].toLowerCase()}` : "";
                                 const today = new Date();
                                 const eventStartDate = new Date(currentEvent.eStartDate);
-                                return <div key={index} className={`calendar-item calendar-day-wrapper ${eventClassName} ${isSelectedClass}`} onClick={!currentEvent["isPlaceholder"] ? () => showEventDetails(currentEvent.eId, dateKey) : null}>
+                                const hasEvent = !currentEvent["isPlaceholder"];
+                                const openEvent = () => showEventDetails(currentEvent.eId, dateKey);
+                                return <div
+                                    key={index}
+                                    className={`calendar-item calendar-day-wrapper ${eventClassName} ${isSelectedClass}`}
+                                    role={hasEvent ? "button" : undefined}
+                                    tabIndex={hasEvent ? 0 : undefined}
+                                    aria-label={hasEvent ? `${currentEvent.eName} on ${format(day, "MMMM d, yyyy")}` : undefined}
+                                    onClick={hasEvent ? openEvent : undefined}
+                                    onKeyDown={hasEvent ? (event) => {
+                                        if (event.key === "Enter" || event.key === " ") {
+                                            event.preventDefault();
+                                            openEvent();
+                                        }
+                                    } : undefined}
+                                >
                                     <div className="calendar-day-container">
                                         {currentEvent.hasRSVPd && (
                                             <div>
-                                                <FontAwesomeIcon size="xs" icon={faCheck} />
+                                                <FontAwesomeIcon size="xs" icon={faCheck} aria-hidden="true" />
                                                 <span className="calendar-rsvp-status">{eventStartDate < today ? "" : "RSVPd"}</span>
                                             </div>
                                         )}

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -47,7 +47,7 @@ const EventCard = ({ event }) => {
                 )}
             </div>
             <div className="eventCardHeader">
-                <h1>{event.eName}</h1>
+                <h2>{event.eName}</h2>
                 <p>{dateFormat(new Date(parsedTimestamp), "ddd, mmm dd")} | {event.eOrganizers}</p>
             </div>
             <div className="eventCardBody">

--- a/frontend/src/components/EventStream.test.jsx
+++ b/frontend/src/components/EventStream.test.jsx
@@ -30,7 +30,7 @@ const renderStream = (events, category = "Academic") =>
 const cardNames = () =>
     screen
         .getAllByRole("link")
-        .map((card) => within(card).getByRole("heading", { level: 1 }).textContent);
+        .map((card) => within(card).getByRole("heading", { level: 2 }).textContent);
 
 describe("EventStream", () => {
     test("shows UPCOMING EVENTS with only future events, soonest first", () => {

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -12,6 +12,7 @@ function AboutPage({ teams }) {
             <main className="about">
                 <section className="about__summary">
                     <div className="about__summaryText">
+                        <p className="about__kicker">Meet the {selectedYear} Team</p>
                         <h1>About Us</h1>
                         <p>
                             IUGA is a student-led organization run by Informatics undergraduates, for Informatics
@@ -20,11 +21,7 @@ function AboutPage({ teams }) {
                     </div>
                 </section>
 
-                <section className="about__section" aria-labelledby="team-heading">
-                    <div className="about__header">
-                        <p className="about__kicker">Team</p>
-                        <h2 id="team-heading">Meet the {selectedYear} Team</h2>
-                    </div>
+                <section className="about__section" aria-label={`Meet the ${selectedYear} Team`}>
                     <div className="about__yearFilter" role="group" aria-label="Team year">
                         {years.map((year) => (
                             <button

--- a/frontend/src/pages/GetInvolved.jsx
+++ b/frontend/src/pages/GetInvolved.jsx
@@ -39,36 +39,38 @@ const COMMITTEES = [
 function GetInvolvedPage() {
     return (
         <div className="baseContainer">
-            <div className="getInvolved__summary">
-                <div className="getInvolved__summaryText">
-                    <h1>Get Involved</h1>
-                    <p>
-                        IUGA is a student-led organization run by Informatics undergraduates, for Informatics
-                        undergraduates. The best way to shape the community is to jump in: join a committee,
-                        lend a hand at an event, or pitch the next idea worth doing.
-                    </p>
+            <main className="getInvolved">
+                <div className="getInvolved__summary">
+                    <div className="getInvolved__summaryText">
+                        <h1>Get Involved</h1>
+                        <p>
+                            IUGA is a student-led organization run by Informatics undergraduates, for Informatics
+                            undergraduates. The best way to shape the community is to jump in: join a committee,
+                            lend a hand at an event, or pitch the next idea worth doing.
+                        </p>
+                    </div>
                 </div>
-            </div>
 
-            <div className="getInvolved__committees">
-                <div className="getInvolved__header">
-                    <p className="getInvolved__kicker">Committees</p>
-                    <h2>Committee Opportunities</h2>
+                <div className="getInvolved__committees">
+                    <div className="getInvolved__header">
+                        <p className="getInvolved__kicker">Committees</p>
+                        <h2>Committee Opportunities</h2>
+                    </div>
+                    <div className="getInvolved__committeeGrid">
+                        {COMMITTEES.map((committee) => (
+                            <article className="getInvolvedCommittee editorial-card" key={committee.name}>
+                                <h3>{committee.name}</h3>
+                                <p className="getInvolvedCommittee__ledBy">Led by {committee.ledBy}</p>
+                                <span className="getInvolvedCommittee__badge">Membership Open</span>
+                                <p className="getInvolvedCommittee__description">{committee.description}</p>
+                                <a className="pill-button" href={committee.mailto}>
+                                    Join {committee.name}
+                                </a>
+                            </article>
+                        ))}
+                    </div>
                 </div>
-                <div className="getInvolved__committeeGrid">
-                    {COMMITTEES.map((committee) => (
-                        <article className="getInvolvedCommittee editorial-card" key={committee.name}>
-                            <h3>{committee.name}</h3>
-                            <p className="getInvolvedCommittee__ledBy">Led by {committee.ledBy}</p>
-                            <span className="getInvolvedCommittee__badge">Membership Open</span>
-                            <p className="getInvolvedCommittee__description">{committee.description}</p>
-                            <a className="pill-button" href={committee.mailto}>
-                                Join {committee.name}
-                            </a>
-                        </article>
-                    ))}
-                </div>
-            </div>
+            </main>
         </div>
     );
 }

--- a/frontend/src/pages/Resources.jsx
+++ b/frontend/src/pages/Resources.jsx
@@ -14,6 +14,7 @@ function ResourcesPage({ resources }) {
     const [searchTerm, setSearchTerm] = useState("");
     const [selectedCategory, setSelectedCategory] = useState(ALL_RESOURCES);
     const [expandedCategories, setExpandedCategories] = useState(new Set());
+    const [collapsedFilteredCategories, setCollapsedFilteredCategories] = useState(new Set());
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -43,7 +44,24 @@ function ResourcesPage({ resources }) {
     const resultCount = visibleCategories.reduce((count, category) => count + category.items.length, 0);
     const isFiltering = searchTerm.trim().length > 0 || selectedCategory !== ALL_RESOURCES;
 
+    useEffect(() => {
+        setCollapsedFilteredCategories(new Set());
+    }, [isFiltering]);
+
     const toggleCategory = (category) => {
+        if (isFiltering) {
+            setCollapsedFilteredCategories((collapsed) => {
+                const nextCollapsed = new Set(collapsed);
+                if (nextCollapsed.has(category)) {
+                    nextCollapsed.delete(category);
+                } else {
+                    nextCollapsed.add(category);
+                }
+                return nextCollapsed;
+            });
+            return;
+        }
+
         setExpandedCategories((expanded) => {
             const nextExpanded = new Set(expanded);
             if (nextExpanded.has(category)) {
@@ -104,15 +122,15 @@ function ResourcesPage({ resources }) {
                     {visibleCategories.length > 0 ? (
                         <div className="resourceCategoryList">
                             {visibleCategories.map(({ category, items }) => (
-                                <section className="resourceCategory" key={category}>
+                                <section className="resourceCategory" id={categoryId(category)} key={category}>
                                     <div className="resourceCategoryHeader">
                                         <h2>
                                             <button
                                                 type="button"
                                                 className="resourceCategoryToggle"
-                                                aria-expanded={isFiltering || expandedCategories.has(category)}
+                                                aria-expanded={isFiltering ? !collapsedFilteredCategories.has(category) : expandedCategories.has(category)}
                                                 aria-controls={`${categoryId(category)}-panel`}
-                                                aria-label={`${isFiltering || expandedCategories.has(category) ? "Hide" : "Show"} ${category}`}
+                                                aria-label={`${(isFiltering ? !collapsedFilteredCategories.has(category) : expandedCategories.has(category)) ? "Hide" : "Show"} ${category}`}
                                                 onClick={() => toggleCategory(category)}
                                             >
                                                 <span>{category}</span>
@@ -127,7 +145,7 @@ function ResourcesPage({ resources }) {
                                             </button>
                                         </h2>
                                     </div>
-                                    {(isFiltering || expandedCategories.has(category)) && (
+                                    {(isFiltering ? !collapsedFilteredCategories.has(category) : expandedCategories.has(category)) && (
                                         <div className="resourceGrid" id={`${categoryId(category)}-panel`}>
                                             {items.map((resource) => (
                                                 <ResourceCard key={resource.rName} resource={resource} category={category} />

--- a/frontend/src/pages/Resources.test.jsx
+++ b/frontend/src/pages/Resources.test.jsx
@@ -66,4 +66,23 @@ describe("ResourcesPage", () => {
         expect(screen.getByText("1 match")).toBeInTheDocument();
         expect(screen.getByText("iSchool Career Services")).toBeInTheDocument();
     });
+
+    test("allows filtered categories to be collapsed and reopened", () => {
+        renderResourcesPage();
+
+        fireEvent.click(screen.getByRole("button", { name: resourceTags.ACADEMIC }));
+
+        const academicSection = document.getElementById("resource-academic");
+        const hideButton = screen.getByRole("button", { name: `Hide ${resourceTags.ACADEMIC}` });
+        expect(academicSection).toHaveAttribute("id", "resource-academic");
+        expect(hideButton).toHaveAttribute("aria-expanded", "true");
+        expect(screen.getByText("UW CLUE Program")).toBeInTheDocument();
+
+        fireEvent.click(hideButton);
+        expect(screen.getByRole("button", { name: `Show ${resourceTags.ACADEMIC}` })).toHaveAttribute("aria-expanded", "false");
+        expect(screen.queryByText("UW CLUE Program")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: `Show ${resourceTags.ACADEMIC}` }));
+        expect(screen.getByText("UW CLUE Program")).toBeInTheDocument();
+    });
 });

--- a/frontend/src/pages/Shop.jsx
+++ b/frontend/src/pages/Shop.jsx
@@ -1,16 +1,15 @@
 import { shopProducts } from "../assets/data/ShopData";
 
+const shopAvailability = "Available Fall 2026";
+
 function ShopPage({ products = shopProducts }) {
     return (
         <div className="baseContainer">
             <main className="shopPage">
                 <section className="shopPage__hero" aria-labelledby="shop-title">
                     <p className="shopPage__kicker">IUGA collection</p>
-                    <h1 id="shop-title">Wear your Info pride.</h1>
-                    <p>
-                        A first look at IUGA gear made for the people, projects, and late nights that make up the
-                        Information School community.
-                    </p>
+                    <h1 id="shop-title">Informatics Merch</h1>
+                    <p>Fall 2026 Informatics Merch</p>
                 </section>
 
                 <section className="shopPage__collection" aria-labelledby="collection-title">
@@ -19,7 +18,7 @@ function ShopPage({ products = shopProducts }) {
                             <p className="shopPage__kicker">The collection</p>
                             <h2 id="collection-title">Coming soon</h2>
                         </div>
-                        <p>{products.length} pieces</p>
+                        <p>{products.length} items</p>
                     </div>
 
                     <div className="shopPage__grid">
@@ -33,7 +32,7 @@ function ShopPage({ products = shopProducts }) {
                                         <h3>{product.title}</h3>
                                         <p>{product.description}</p>
                                     </div>
-                                    <span className="shopCard__status">Coming soon</span>
+                                    <span className="shopCard__status">{shopAvailability}</span>
                                 </div>
                             </article>
                         ))}

--- a/frontend/src/stylesheets/pages/_about.scss
+++ b/frontend/src/stylesheets/pages/_about.scss
@@ -1,6 +1,5 @@
 .about {
-    width: min(1200px, 90vw);
-    margin: 0 auto;
+    @extend %pageFrame;
     padding: 48px 0 64px;
 }
 
@@ -15,7 +14,7 @@
         font-size: 3rem;
     }
 
-    p {
+    > p:not(.about__kicker) {
         margin: 0;
         color: $dark-gray;
         font-size: 1.05rem;
@@ -32,13 +31,8 @@
 }
 
 .about__kicker {
-    margin: 0 0 10px;
-    color: $dark-gray;
-    font-size: 0.78rem;
-    font-weight: 700;
-    letter-spacing: 0.16em;
-    line-height: 1.4;
-    text-transform: uppercase;
+    @extend %pageKicker;
+    margin-bottom: 10px;
 }
 
 .about__yearFilter {

--- a/frontend/src/stylesheets/pages/_elections.scss
+++ b/frontend/src/stylesheets/pages/_elections.scss
@@ -297,3 +297,9 @@
     display: none;
   }
 }
+
+@include media("screen", "<tablet") {
+  .electionContainer {
+    width: 100%;
+  }
+}

--- a/frontend/src/stylesheets/pages/_electionsfaq.scss
+++ b/frontend/src/stylesheets/pages/_electionsfaq.scss
@@ -276,3 +276,9 @@
     display: none;
   }
 }
+
+@include media("screen", "<tablet") {
+  .resourceContainer {
+    width: 100%;
+  }
+}

--- a/frontend/src/stylesheets/pages/_events.scss
+++ b/frontend/src/stylesheets/pages/_events.scss
@@ -1,5 +1,5 @@
 .eventsPage {
-    width: 100%;
+    @extend %pageFrame;
     max-width: 1200px;
     box-sizing: border-box;
     padding: 40px 0 64px;

--- a/frontend/src/stylesheets/pages/_getInvolved.scss
+++ b/frontend/src/stylesheets/pages/_getInvolved.scss
@@ -1,4 +1,9 @@
 
+.getInvolved {
+    @extend %pageFrame;
+    padding: 48px 0 64px;
+}
+
 .getInvolved__summary {
     display: flex;
     align-items: center;
@@ -26,13 +31,6 @@
 }
 
 @include media("screen", "<tablet") {
-    .getInvolved__summary,
-    .getInvolved__section,
-    .getInvolved__committees {
-        box-sizing: border-box;
-        padding: 0 $padding-content;
-    }
-
     .getInvolved__summaryText,
     .getInvolved__header {
         text-align: center;
@@ -54,14 +52,9 @@
 }
 
 .getInvolved__kicker {
+    @extend %pageKicker;
     display: block;
-    margin: 0 0 10px;
-    font-size: 0.78rem;
-    font-weight: 700;
-    letter-spacing: 0.16em;
-    line-height: 1.4;
-    text-transform: uppercase;
-    color: $dark-gray;
+    margin-bottom: 10px;
 }
 
 .getInvolvedCard {

--- a/frontend/src/stylesheets/pages/_resources.scss
+++ b/frontend/src/stylesheets/pages/_resources.scss
@@ -1,6 +1,7 @@
 .resourcesPage {
-  width: min(1120px, 90vw);
-  margin: 0 auto 96px;
+  @extend %pageFrame;
+  max-width: 1120px;
+  margin-bottom: 96px;
 }
 
 .resourcesHero {
@@ -31,12 +32,7 @@
 
 .resourcesKicker,
 .resourceCardCategory {
-  margin: 0;
-  color: $color-primary;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+  @extend %pageKicker;
 }
 
 .resourcesDirectory {
@@ -185,7 +181,7 @@
 }
 
 @include media("screen", "<tablet") {
-  .resourcesPage { width: 90vw; margin-bottom: 64px; }
+  .resourcesPage { width: 100%; margin-bottom: 64px; }
   .resourcesHero { padding: 48px 0 32px; }
   .resourcesControls { grid-template-columns: 1fr; padding: 18px; }
   .resourceResultCount { text-align: left; }

--- a/frontend/src/stylesheets/pages/_shop.scss
+++ b/frontend/src/stylesheets/pages/_shop.scss
@@ -1,4 +1,5 @@
 .shopPage {
+    @extend %pageFrame;
     padding: 48px 0 88px;
 
     &__hero {
@@ -7,7 +8,7 @@
         padding: 48px clamp(24px, 6vw, 72px);
         border: 1px solid rgba($color-uw-purple, 0.12);
         border-radius: $radius-card;
-        background: linear-gradient(135deg, #f8f4ff 0%, #ffffff 62%, #f5efe3 100%);
+        box-shadow: 0 20px 48px rgba($color-uw-purple, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.86);
 
         h1 {
             max-width: 560px;
@@ -27,12 +28,7 @@
     }
 
     &__kicker {
-        margin: 0;
-        color: $color-primary;
-        font-size: 0.78rem;
-        font-weight: 700;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
+        @extend %pageKicker;
     }
 
     &__collectionHeader {
@@ -95,8 +91,8 @@
     &__details {
         display: flex;
         padding: 20px;
-        align-items: start;
-        justify-content: space-between;
+        flex-direction: column;
+        align-items: stretch;
         gap: 18px;
 
         h3 {
@@ -113,16 +109,20 @@
     }
 
     &__status {
-        padding: 6px 9px;
-        flex: 0 0 auto;
+        display: flex;
+        min-height: 44px;
+        box-sizing: border-box;
+        align-items: center;
+        justify-content: center;
+        padding: 10px 14px;
         border-radius: $radius-pill;
-        background: $color-academic-secondary;
-        color: $color-academic-capsule;
-        font-size: 0.7rem;
+        background: $color-uw-purple;
+        color: white;
+        font-size: 0.72rem;
         font-weight: 700;
-        letter-spacing: 0.04em;
+        letter-spacing: 0.06em;
+        line-height: 1.35;
         text-transform: uppercase;
-        white-space: nowrap;
     }
 }
 

--- a/frontend/src/stylesheets/pages/_studentVoice.scss
+++ b/frontend/src/stylesheets/pages/_studentVoice.scss
@@ -1,6 +1,7 @@
 .studentVoice {
-    width: min(1120px, 90vw);
-    margin: 0 auto 96px;
+    @extend %pageFrame;
+    max-width: 1120px;
+    margin-bottom: 96px;
 }
 
 .studentVoice__hero {
@@ -25,12 +26,7 @@
 }
 
 .studentVoice__kicker {
-    margin: 0;
-    color: $color-primary;
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
+    @extend %pageKicker;
 }
 
 .studentVoice__sectionHeader {


### PR DESCRIPTION
## Summary
Polish secondary pages and supporting event, resource, election, shop, and team presentation details.

## Rationale
Applies the page-level visual refinements after the underlying page features are present.

## Stack Context
- Position: 9 of 11
- Base PR: #79
- Depends on: #79

## Tests
Existing frontend test suite and production build passed.