### PR TITLE
Refresh frontend guides

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ Browser
    ├──[SPA route]──→ React (frontend/build/)
    │                    │
    │                    ├── page components (pages/)
-   │                    ├── shared UI (components/)
+│                    ├── shared UI (components/ + layouts/)
    │                    ├── auth context (context/AuthContext.jsx)
    │                    └── API calls via fetch()
    │                         │
@@ -53,7 +53,9 @@ Browser
 
 - Serve the single-page application (SPA) shell (`index.html`)
 - Client-side routing with React Router v6
-- Render pages: Home, Events, Resources, About, Elections, Election FAQ
+- Render pages: Home, Events, Resources, About, Get Involved, Shop, Student Voice,
+  Elections, and Election FAQ
+- Render shared responsive navigation and footer layouts around the routed pages
 - Manage authentication state via Azure MSAL (Microsoft Authentication Library)
 - In **production**: fetch data from `REACT_APP_API_URL` (set via `.env.production`)
 - In **development**: use mock data from `src/assets/mock-data/` — no backend needed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ Browser
    ├──[SPA route]──→ React (frontend/build/)
    │                    │
    │                    ├── page components (pages/)
-│                    ├── shared UI (components/ + layouts/)
+   │                    ├── shared UI (components/ + layouts/)
    │                    ├── auth context (context/AuthContext.jsx)
    │                    └── API calls via fetch()
    │                         │

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,7 +16,7 @@
 npm run dev
 ```
 
-This runs: `cd frontend; npm install && npm run build && cd ../backend; npm install && npm start`
+This runs: `cd frontend; npm install && npm run build && cd ../backend; npm install && npm start`.
 
 The app is served at **http://localhost:7777**.
 
@@ -26,7 +26,7 @@ The app is served at **http://localhost:7777**.
 
 | Command | What it does |
 |---|---|
-| `npm run frontend` | Install and start CRA dev server on `:3000` |
+| `npm run frontend` | Install dependencies and start CRA dev server on `:3000` |
 | `npm run backend`  | Install and start Express on `:7777` (uses production build of frontend) |
 | `npm run backend-debug` | Start backend with debug logging |
 | `npm run debug`    | Full rebuild + backend with debug logging |
@@ -121,6 +121,11 @@ In dev mode, the frontend uses **mock data** from `src/assets/mock-data/` instea
 - One component per file.
 - Pages go in `pages/`, reusable UI in `components/`, shared state in `context/`.
 - CSS class naming follows BEM-like conventions (`.nav-container`, `.nav-items-wrapper`).
+- Shared SCSS tokens live in `stylesheets/abstracts/_variables.scss`; use those tokens for
+  navigation dimensions and radii instead of adding one-off values.
+- The shared `Navbar` has a desktop sidebar presentation and a mobile top-navbar
+  presentation. Mobile layout rules are in `layout/_navigation-mobile.scss`; desktop
+  rules are in `layout/_navigation-desktop.scss`.
 
 ### Backend
 
@@ -144,7 +149,7 @@ In dev mode, the frontend uses **mock data** from `src/assets/mock-data/` instea
 1. Create `frontend/src/pages/YourPage.jsx`
 2. Add `<Route>` in `frontend/src/App.jsx`
 3. Add a matching `GET /your-page` route in `backend/app.js` (to serve SPA on direct navigation)
-4. Add a Navbar link in `frontend/src/layouts/Navbar.jsx`
+4. Add a link to the shared responsive `Navbar` component in `frontend/src/layouts/Navbar.jsx` (desktop presentation: sidebar rail; mobile presentation: centered logo with left hamburger)
 5. Create page-specific SCSS at `frontend/src/stylesheets/pages/_yourpage.scss` and import in `main.scss`
 
 ### Add a new API endpoint
@@ -171,7 +176,7 @@ git submodule update --remote
 
 The repository has a small but real test surface, although coverage is incomplete:
 
-- **Frontend:** Jest and React Testing Library tests under `frontend/src/` (currently eight test files). Run them with:
+- **Frontend:** Jest and React Testing Library tests under `frontend/src/`. Run them with:
   ```bash
   cd frontend
   CI=true npm test -- --watchAll=false

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -43,7 +43,7 @@ frontend/src/
 ├── hooks/
 │   └── useAuth.jsx       ← MSAL token acquisition + backend handshake
 ├── layouts/
-│   ├── Navbar.jsx        ← Top navigation (responsive, scroll-aware)
+│   ├── Navbar.jsx        ← Shared responsive navigation: desktop sidebar rail and mobile navbar with hamburger menu
 │   └── Footer.jsx
 ├── pages/
 │   ├── Home.jsx          ← Landing page: hero, WHO WE ARE cards, upcoming events
@@ -58,9 +58,23 @@ frontend/src/
     ├── abstracts/         ← Variables, mixins, functions, media queries
     ├── base/              ← Reset, typography, colors, misc
     ├── components/        ← Component-specific styles
-    ├── layout/            ← Container, navigation, footer, form
+    ├── layout/            ← Container, split responsive navigation, footer, form
     ├── pages/             ← Page-specific styles (e.g., _getInvolved.scss for page and member-card styles)
     └── addons/            ← Third-party overrides (toastify)
+
+### Shared navigation
+
+`layouts/Navbar.jsx` is rendered once by `App.jsx` and uses the same navigation
+markup at every breakpoint. Its presentation is split across these partials:
+
+- `_navigation-base.scss` — shared container, links, and auth controls
+- `_navigation-mobile.scss` — top navbar, centered IUGA logo, left hamburger,
+  and collapsible menu below the tablet breakpoint
+- `_navigation-desktop.scss` — fixed sidebar rail and desktop account controls
+
+Use the shared variables in `stylesheets/abstracts/_variables.scss` for layout
+tokens such as `$radius-pill`, `$radius-card`, and `$pill-height`. Avoid hard-coded
+navigation radii or dimensions in page styles.
 ```
 
 ---
@@ -136,7 +150,8 @@ The backend creates **server-side sessions** (express-session), so the frontend 
 - Compiled via `sass` (devDependency)
 - Main entry: `src/stylesheets/main.scss` — imports all partials
 - Fonts: **NotoSans** (body) and **PlayfairDisplay** (headings), served from `public/font/`
-- Responsive breakpoints: desktop (≥1024px) and mobile (340–1023px)
+- Responsive breakpoints: mobile below `768px`, tablet/desktop at `768px` and above,
+  with the sm-desktop breakpoint at `1024px`
 - Some pages (Events calendar) are desktop-only with a "under construction" message on mobile
 - Toast notifications: `react-toastify` for user feedback
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -61,6 +61,7 @@ frontend/src/
     ├── layout/            ← Container, split responsive navigation, footer, form
     ├── pages/             ← Page-specific styles (e.g., _getInvolved.scss for page and member-card styles)
     └── addons/            ← Third-party overrides (toastify)
+```
 
 ### Shared navigation
 
@@ -75,7 +76,6 @@ markup at every breakpoint. Its presentation is split across these partials:
 Use the shared variables in `stylesheets/abstracts/_variables.scss` for layout
 tokens such as `$radius-pill`, `$radius-card`, and `$pill-height`. Avoid hard-coded
 navigation radii or dimensions in page styles.
-```
 
 ---
 


### PR DESCRIPTION
## Summary
Refresh the architecture, development, and frontend guides and correct their formatting.

## Rationale
Keeps contributor documentation aligned with the current frontend structure.

## Stack Context
- Position: 10 of 11
- Base PR: #80
- Depends on: #80

## Tests
Documentation-only change; frontend test suite and production build passed.