### PR TITLE
test(pages): scope scroll mocks to page tests

### DIFF
--- a/frontend/src/pages/Home.test.jsx
+++ b/frontend/src/pages/Home.test.jsx
@@ -1,5 +1,4 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import HomePage from "./Home";
@@ -21,6 +20,20 @@ const renderHome = () =>
     );
 
 describe("HomePage", () => {
+    beforeEach(() => {
+        jest.spyOn(window, "scrollTo").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("scrolls to the top when the page mounts", () => {
+        renderHome();
+
+        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
     test("renders the landing-page hero region", () => {
         renderHome();
 
@@ -33,10 +46,10 @@ describe("HomePage", () => {
         expect(screen.getByText(/events, resources, opportunities, and community/i)).toBeInTheDocument();
     });
 
-    test("keeps the primary event route accessible", async () => {
+    test("keeps the primary event route accessible", () => {
         renderHome();
 
-        await userEvent.click(screen.getByRole("link", { name: /Explore Events/ }));
+        fireEvent.click(screen.getByRole("link", { name: /Explore Events/ }));
         expect(screen.getByText("Events Page")).toBeInTheDocument();
     });
 

--- a/frontend/src/pages/Resources.test.jsx
+++ b/frontend/src/pages/Resources.test.jsx
@@ -22,10 +22,6 @@ resources[resourceTags.CAREER] = [
     },
 ];
 
-beforeEach(() => {
-    window.scrollTo = jest.fn();
-});
-
 function renderResourcesPage() {
     return render(
         <MemoryRouter>
@@ -34,7 +30,21 @@ function renderResourcesPage() {
     );
 }
 
+beforeEach(() => {
+    jest.spyOn(window, "scrollTo").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
 describe("ResourcesPage", () => {
+    test("scrolls to the top when the page mounts", () => {
+        renderResourcesPage();
+
+        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
     test("keeps categories compact until their accordion is opened", () => {
         renderResourcesPage();
 


### PR DESCRIPTION
## Summary

Replace the global scroll mock with page-local mocks and add assertions that Home and Resources scroll to the top on mount.

## Rationale

JSDOM does not implement `window.scrollTo`, but a global mock hid whether page behavior was actually tested. The page tests now own the mock and verify the intended behavior directly. The Home navigation test also uses `fireEvent` to avoid the React Router `act()` warning with the installed testing-library version.

## Tests

- `CI=true npm test -- --watchAll=false`
- `npm run build`
- 73 tests passed
- Build passed with existing ESLint and Browserslist warnings