### PR TITLE
test(toolchain): wire root test commands

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "dotenv -e ./env/.env.dev node ./bin/www.cjs",
     "debug": "dotenv -e env/.env.debug node ./bin/www.cjs",
-    "deploy": "dotenv -e ./env/.env.prod node ./bin/www.cjs"
+    "deploy": "dotenv -e ./env/.env.prod node ./bin/www.cjs",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -194,7 +194,7 @@ The repository has a small but real test surface, although coverage is incomplet
   ```bash
   bash ci/test/e2e-deploy.sh
   ```
-- **Root:** `npm test` is still a placeholder that exits with `Error: no test specified`; it is not a meaningful project test command.
+- **Root:** `npm test` runs the backend and frontend suites.
 
 ### Required verification workflow
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },
   "proxy": "http://localhost:7777",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test:backend": "npm test --prefix backend",
+    "test:frontend": "npm test --prefix frontend",
+    "test": "npm run test:backend && npm run test:frontend",
     "debug": "cd frontend; npm install && npm run build && cd ../backend; npm install && npm run debug",
     "dev": "cd frontend; npm install && npm run build && cd ../backend; npm install && npm start",
     "frontend": "cd frontend; npm install && npm start",
     "backend": "cd backend; npm install && npm start",
     "backend-dev": "cd backend; npm install && npm start",
-    "backend-debug": "cd backend; npm install && npm run debug"
+    "backend-debug": "cd backend; npm install && npm run debug",
+    "setup": "npm ci && npm ci --prefix backend && npm ci --prefix frontend && git submodule update --init --recursive"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
## Summary
Added backend and root test scripts, made the combined test command finite, and added a setup command. Updated development documentation.

## Rationale
Provides one repeatable local command for the backend and frontend suites while keeping each package testable independently.

## Tests
- `npm test`: 30 backend tests and 71 frontend tests passed
- Clean dependency installs
- `git diff --check`