### PR TITLE
fix: return 404 when withdrawing from unknown event

### DIFF
--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -323,6 +323,9 @@ router.delete("/withdraw/:eId/:pId", async function (req, res) {
       const pId = req.params.pId;
       const eId = req.params.eId;
       const event = await req.models.Events.findById(eId);
+      if (!event) {
+        return sendError(res, 404, "Event not found.");
+      }
 
       let newParticipants = [];
       event.eParticipants.forEach((participant) => {


### PR DESCRIPTION
## Summary

fix: return 404 when withdrawing from unknown event

## Changes

- DELETE /withdraw/:eId/:pId now null-checks findById before touching eParticipants.
- Unknown eId returns 404 instead of a 500 TypeError.

Fixes #12
