### PR TITLE
fix(login): harden Graph authentication

### DIFF
--- a/backend/routes/api/v1/controllers/user.js
+++ b/backend/routes/api/v1/controllers/user.js
@@ -6,12 +6,57 @@ Schemas addressed in users.js:
 */
 
 import express from "express";
-import fetch from "node-fetch";
 import { sendError } from "../helpers/sendError.js";
 import { sendSuccess } from "../helpers/sendSuccess.js";
 import { requireAuth } from "../utils/auth.js";
 
 var router = express.Router();
+const GRAPH_PROFILE_URL = "https://graph.microsoft.com/v1.0/me";
+const GRAPH_REQUEST_TIMEOUT_MS = 5000;
+const INVALID_AUTHORIZATION_MESSAGE = "Invalid access token";
+const GRAPH_UNAVAILABLE_MESSAGE = "Authentication provider unavailable";
+const INCOMPLETE_PROFILE_MESSAGE = "Authentication provider returned incomplete identity";
+
+function readBearerToken(header) {
+  if (typeof header !== "string") return null;
+  const match = /^Bearer\s+(\S+)$/i.exec(header.trim());
+  return match?.[1] ?? null;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function readGraphProfile(userData) {
+  const email = isNonEmptyString(userData?.mail)
+    ? userData.mail.trim()
+    : isNonEmptyString(userData?.userPrincipalName)
+      ? userData.userPrincipalName.trim()
+      : null;
+
+  if (
+    !email ||
+    !isNonEmptyString(userData?.displayName) ||
+    !isNonEmptyString(userData?.givenName) ||
+    !isNonEmptyString(userData?.surname)
+  ) {
+    return null;
+  }
+
+  return {
+    email,
+    displayName: userData.displayName.trim(),
+    firstName: userData.givenName.trim(),
+    lastName: userData.surname.trim(),
+  };
+}
+
+async function rotateSession(req) {
+  if (typeof req.session.regenerate !== "function") return;
+  await new Promise((resolve, reject) => {
+    req.session.regenerate((error) => (error ? reject(error) : resolve()));
+  });
+}
 
 /*
     @endpoint: /login
@@ -21,45 +66,87 @@ var router = express.Router();
                   about the user if already exists. Create user session.
 */
 router.post("/login", async function (req, res) {
-  const authorizationHeader = req.headers.authorization;
+  const accessToken = readBearerToken(req.headers.authorization);
+  if (!accessToken) {
+    return sendError(res, 401, INVALID_AUTHORIZATION_MESSAGE);
+  }
+
+  let response;
   try {
-    const accessToken = authorizationHeader.split(" ")[1];
-    const response = await fetch("https://graph.microsoft.com/v1.0/me", {
+    response = await fetch(GRAPH_PROFILE_URL, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
+      signal: AbortSignal.timeout(GRAPH_REQUEST_TIMEOUT_MS),
     });
+  } catch (error) {
+    console.error("Graph login request failed:", error?.name ?? "unknown error");
+    return sendError(res, 502, GRAPH_UNAVAILABLE_MESSAGE);
+  }
 
-    if (response.ok) {
-      const userData = await response.json();
-
-      // Create a new session with the user
-      req.session.isAuthenticated = true;
-      req.session.displayName = userData.displayName;
-      req.session.email = userData.mail;
-      req.session.firstName = userData.givenName;
-      req.session.lastName = userData.surname;
-
-      //Check if user is already in database, if not then make them an account
-      let user = await req.models.Users.findOne({ uEmail: req.session.email });
-      if (!user) {
-        const newUser = new req.models.Users({
-          uFirstName: req.session.firstName,
-          uLastName: req.session.lastName,
-          uDisplayName: req.session.displayName,
-          uEmail: req.session.email,
-        });
-
-        user = await newUser.save();
-      }
-
-      req.session.userId = user._id;
-      req.session.memberType = user.uType;
-      req.session.isAdmin = user.uType === "Admin";
-      res.status(200).json(user);
+  if (!response.ok) {
+    if (response.status === 401) {
+      return sendError(res, 401, INVALID_AUTHORIZATION_MESSAGE);
     }
-  } catch (err) {
-    console.log(err);
+    return sendError(res, 502, GRAPH_UNAVAILABLE_MESSAGE);
+  }
+
+  let userData;
+  try {
+    userData = await response.json();
+  } catch (error) {
+    console.error("Graph login response was not valid JSON:", error?.message);
+    return sendError(res, 502, GRAPH_UNAVAILABLE_MESSAGE);
+  }
+
+  const profile = readGraphProfile(userData);
+  if (!profile) {
+    return sendError(res, 502, INCOMPLETE_PROFILE_MESSAGE);
+  }
+
+  try {
+    await rotateSession(req);
+  } catch (error) {
+    console.error("Login session rotation failed:", error?.message);
+    return sendError(res, 500);
+  }
+
+  try {
+    let user = await req.models.Users.findOne({ uEmail: profile.email });
+    if (!user) {
+      user = await new req.models.Users({
+        uFirstName: profile.firstName,
+        uLastName: profile.lastName,
+        uDisplayName: profile.displayName,
+        uEmail: profile.email,
+      }).save();
+    } else {
+      const updates = {
+        uFirstName: profile.firstName,
+        uLastName: profile.lastName,
+        uDisplayName: profile.displayName,
+      };
+      let changed = false;
+      for (const [field, value] of Object.entries(updates)) {
+        if (user[field] !== value) {
+          user[field] = value;
+          changed = true;
+        }
+      }
+      if (changed) user = await user.save();
+    }
+
+    req.session.isAuthenticated = true;
+    req.session.displayName = profile.displayName;
+    req.session.email = profile.email;
+    req.session.firstName = profile.firstName;
+    req.session.lastName = profile.lastName;
+    req.session.userId = user._id;
+    req.session.memberType = user.uType;
+    req.session.isAdmin = user.uType === "Admin";
+    return res.status(200).json(user);
+  } catch (error) {
+    console.error("Login persistence failed:", error?.message);
     return sendError(res, 500);
   }
 });

--- a/backend/test/testApi.js
+++ b/backend/test/testApi.js
@@ -3,13 +3,14 @@ import { once } from "node:events";
 
 export async function makeTestApi({ router, mountPath, models, session = {} }) {
   const app = express();
-  let currentSession = session;
-  let currentModels = models;
+  const requestContexts = new Map();
+  let nextRequestId = 0;
 
   app.use(express.json());
   app.use((req, _res, next) => {
-    req.models = currentModels;
-    req.session = currentSession;
+    const context = requestContexts.get(req.headers["x-test-request-id"]);
+    req.models = context?.models ?? models;
+    req.session = context?.session ?? session;
     next();
   });
   app.use(mountPath, router);
@@ -19,21 +20,45 @@ export async function makeTestApi({ router, mountPath, models, session = {} }) {
   const { port } = server.address();
 
   return {
-    async request(method, path, body, { session: sessionOverrides = {}, models: requestModels } = {}) {
-      currentSession = { ...session, ...sessionOverrides };
-      currentModels = requestModels ?? models;
-      const response = await fetch(`http://127.0.0.1:${port}${path}`, {
-        method,
-        headers: { "content-type": "application/json" },
-        body: body === undefined ? undefined : JSON.stringify(body),
+    async request(
+      method,
+      path,
+      body,
+      {
+        session: sessionOverrides = {},
+        models: requestModels,
+        headers: requestHeaders = {},
+      } = {},
+    ) {
+      const requestId = String(++nextRequestId);
+      const requestSession = { ...session, ...sessionOverrides };
+      requestContexts.set(requestId, {
+        models: requestModels ?? models,
+        session: requestSession,
       });
-      const text = await response.text();
-      return {
-        status: response.status,
-        body: text ? JSON.parse(text) : null,
-      };
+
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+          method,
+          headers: {
+            "content-type": "application/json",
+            ...requestHeaders,
+            "x-test-request-id": requestId,
+          },
+          body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        const text = await response.text();
+        return {
+          status: response.status,
+          body: text ? JSON.parse(text) : null,
+          session: requestSession,
+        };
+      } finally {
+        requestContexts.delete(requestId);
+      }
     },
     async close() {
+      server.closeAllConnections?.();
       await new Promise((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
       });

--- a/backend/test/user.test.js
+++ b/backend/test/user.test.js
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { makeTestApi } from "./testApi.js";
+import usersRouter from "../routes/api/v1/controllers/user.js";
+
+const GRAPH_URL = "https://graph.microsoft.com/v1.0/me";
+const REAL_FETCH = globalThis.fetch;
+
+function makeUserDoc(overrides = {}) {
+  const doc = {
+    _id: "user-1",
+    uFirstName: "Jane",
+    uLastName: "Doe",
+    uDisplayName: "Jane Doe",
+    uEmail: "jane@uw.edu",
+    uType: "Member",
+    ...overrides,
+  };
+  doc.save = async function save() {
+    doc.saveCalls = (doc.saveCalls ?? 0) + 1;
+    return doc;
+  };
+  return doc;
+}
+
+function makeUsersModel(existing = []) {
+  const docs = [...existing];
+  function Users(data) {
+    const doc = makeUserDoc(data);
+    docs.push(doc);
+    return doc;
+  }
+  Users.docs = docs;
+  Users.findOne = async (filter) =>
+    docs.find((doc) => doc.uEmail === filter.uEmail) ?? null;
+  return Users;
+}
+
+function makeModels(existing = []) {
+  return { Users: makeUsersModel(existing) };
+}
+
+function graphProfile(overrides = {}) {
+  return {
+    displayName: "Jane Doe",
+    givenName: "Jane",
+    surname: "Doe",
+    mail: "jane@uw.edu",
+    userPrincipalName: "jdoe@uw.edu",
+    ...overrides,
+  };
+}
+
+function mockGraph(t, { ok = true, status = 200, data = {}, error } = {}) {
+  t.mock.method(globalThis, "fetch", async (url, init) => {
+    if (String(url) !== GRAPH_URL) return REAL_FETCH(url, init);
+    if (error) throw error;
+    return {
+      ok,
+      status,
+      async json() {
+        return data;
+      },
+    };
+  });
+}
+
+async function login(api, authorization = "Bearer test-token") {
+  return api.request("POST", "/user/login", undefined, {
+    headers: authorization === undefined ? {} : { authorization },
+  });
+}
+
+describe("POST /user/login", () => {
+  test("rejects a missing authorization header without contacting Graph", async () => {
+    const models = makeModels();
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models,
+      session: {},
+    });
+
+    try {
+      const result = await api.request("POST", "/user/login", undefined, {
+        headers: {},
+      });
+
+      assert.equal(result.status, 401);
+      assert.equal(models.Users.docs.length, 0);
+      assert.deepEqual(result.session, {});
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("rejects malformed and unsupported authorization headers", async (t) => {
+    mockGraph(t, { data: graphProfile() });
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models: makeModels(),
+      session: {},
+    });
+
+    try {
+      for (const authorization of ["Basic credentials", "Bearer", "Bearer one two"]) {
+        const result = await login(api, authorization);
+        assert.equal(result.status, 401, authorization);
+      }
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("returns 401 when Microsoft Graph rejects the token", async (t) => {
+    mockGraph(t, { ok: false, status: 401 });
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models: makeModels(),
+      session: {},
+    });
+
+    try {
+      const result = await login(api);
+
+      assert.equal(result.status, 401);
+      assert.match(result.body.message, /invalid|authentication/i);
+      assert.doesNotMatch(JSON.stringify(result.body), /test-token|Graph.*token/i);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("maps Graph outages to an upstream error instead of invalidating the token", async (t) => {
+    mockGraph(t, { ok: false, status: 503 });
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models: makeModels(),
+      session: {},
+    });
+
+    try {
+      const result = await login(api);
+
+      assert.equal(result.status, 502);
+      assert.match(result.body.message, /unavailable|provider/i);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("returns a safe upstream error when Graph is unavailable", async (t) => {
+    mockGraph(t, { error: new Error("upstream unavailable") });
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models: makeModels(),
+      session: {},
+    });
+
+    try {
+      const result = await login(api);
+
+      assert.equal(result.status, 502);
+      assert.doesNotMatch(JSON.stringify(result.body), /upstream unavailable/i);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("rejects incomplete Graph identity without creating a user or session", async (t) => {
+    mockGraph(t, { data: graphProfile({ mail: null, userPrincipalName: null }) });
+    const models = makeModels();
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models,
+      session: {},
+    });
+
+    try {
+      const result = await login(api);
+
+      assert.equal(result.status, 502);
+      assert.equal(models.Users.docs.length, 0);
+      assert.notEqual(result.session.isAuthenticated, true);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("uses userPrincipalName when Graph omits mail", async (t) => {
+    mockGraph(t, { data: graphProfile({ mail: null }) });
+    const models = makeModels();
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models,
+      session: {},
+    });
+
+    try {
+      const result = await login(api);
+
+      assert.equal(result.status, 200);
+      assert.equal(result.session.email, "jdoe@uw.edu");
+      assert.equal(models.Users.docs[0].uEmail, "jdoe@uw.edu");
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("syncs profile drift without duplicating an existing user", async (t) => {
+    const existing = makeUserDoc({ uFirstName: "Old" });
+    const models = makeModels([existing]);
+    mockGraph(t, { data: graphProfile() });
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models,
+      session: {},
+    });
+
+    try {
+      const result = await login(api);
+
+      assert.equal(result.status, 200);
+      assert.equal(models.Users.docs.length, 1);
+      assert.equal(existing.uFirstName, "Jane");
+      assert.ok(existing.saveCalls >= 1);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("rotates the session before establishing authenticated state", async (t) => {
+    mockGraph(t, { data: graphProfile() });
+    const session = {
+      id: "anonymous-session",
+      regenerate(callback) {
+        this.id = "authenticated-session";
+        this.regenerated = true;
+        callback(null);
+      },
+    };
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models: makeModels(),
+      session,
+    });
+
+    try {
+      const result = await login(api);
+
+      assert.equal(result.status, 200);
+      assert.equal(result.session.regenerated, true);
+      assert.equal(result.session.id, "authenticated-session");
+      assert.equal(result.session.isAuthenticated, true);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("passes an abort signal to the Graph request and handles cancellation safely", async (t) => {
+    let receivedSignal;
+    t.mock.method(globalThis, "fetch", async (url, init) => {
+      if (String(url) !== GRAPH_URL) return REAL_FETCH(url, init);
+      receivedSignal = init.signal;
+      throw new DOMException("The operation timed out", "TimeoutError");
+    });
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/user",
+      models: makeModels(),
+      session: {},
+    });
+
+    try {
+      const result = await login(api);
+
+      assert.equal(result.status, 502);
+      assert.ok(receivedSignal instanceof AbortSignal);
+    } finally {
+      await api.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

<!-- What changed and what observable outcome does it produce? -->

Harden the Graph-backed login boundary without changing the successful login response contract. Invalid credentials now receive stable client errors; Graph outages, timeouts, malformed responses, and incomplete identity data fail safely before authentication or persistence.

## Rationale

<!--
- What problem or limitation existed?
- What happens without this change?
- Why was this solution chosen over alternatives, and what tradeoffs were accepted?
-->

The previous handler could throw on missing or malformed authorization headers, hang without responding when Graph rejected a token, and persist incomplete profiles. This layer validates the Bearer token before the upstream call, uses native fetch with `AbortSignal.timeout`, distinguishes invalid tokens (`401`) from provider failures (`502`), validates the required profile, synchronizes profile drift, and regenerates the session before marking it authenticated.

## Stack Context

<!-- Include only for stacked PRs. Describe the incremental diff from the immediate base branch. -->

- Position: 1 of 3
- Base PR: `dev`
- Depends on: N/A

## Tests

<!--
- What tests were added or changed, and what verification was run?
-->

- Added 10 backend login behavior tests covering malformed headers, Graph `401`, Graph `503`, request failure, timeout cancellation, incomplete identity, email fallback, profile drift, and session rotation.
- `npm test`: passed — 40 backend tests and 73 frontend tests.
- `npm run build` with `VITE_API_URL=https://dev.iuga.info`: passed.
- Lint was not run because the repository has no `lint` script.