### PR TITLE
fix(roles): remove obsolete NetID search

### DIFF
--- a/backend/routes/api/v1/controllers/roles.js
+++ b/backend/routes/api/v1/controllers/roles.js
@@ -188,10 +188,9 @@ router.get(
         $or: [
           { uDisplayName: pattern },
           { uEmail: pattern },
-          { uNetId: pattern },
         ],
       })
-        .select("_id uFirstName uLastName uDisplayName uEmail uNetId uType")
+        .select("_id uFirstName uLastName uDisplayName uEmail uType")
         .limit(25)
         .lean();
 


### PR DESCRIPTION
## Summary

<!-- What changed and what observable outcome does it produce? -->

Remove the unused `uNetId` search field from officer user search. Authorized officers continue to search by display name and email, while the dead NetID query and response projection are no longer used.

## Rationale

<!--
- What problem or limitation existed?
- What happens without this change?
- Why was this solution chosen over alternatives, and what tradeoffs were accepted?
-->

The application never populated `uNetId`, so querying and returning it added an unused data path and conflicted with the accepted data-minimization decision. This is kept as a separate layer so the login hardening behavior can be reviewed independently.

## Stack Context

<!-- Include only for stacked PRs. Describe the incremental diff from the immediate base branch. -->

- Position: 2 of 3
- Base PR: #90
- Depends on: #90

## Tests

<!--
- What tests were added or changed, and what verification was run?
-->

- Preserved the existing role-management authorization and user-search route.
- Backend suite passed: 40/40 tests.
- No repository lint script is configured.