### PR TITLE
chore(login): remove obsolete fetch dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,8 +15,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "mongoose": "^6.13.9",
-        "morgan": "~1.9.1",
-        "node-fetch": "^3.3.0"
+        "morgan": "~1.9.1"
       }
     },
     "node_modules/@aws-sdk/core": {
@@ -713,14 +712,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -999,28 +990,6 @@
         }
       ]
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -1049,17 +1018,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -1455,41 +1413,6 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -1920,14 +1843,6 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -2470,11 +2385,6 @@
         "which": "^2.0.1"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2657,15 +2567,6 @@
         }
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -2688,14 +2589,6 @@
             "ee-first": "1.1.1"
           }
         }
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "forwarded": {
@@ -2954,21 +2847,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3263,11 +3141,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,6 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "mongoose": "^6.13.9",
-    "morgan": "~1.9.1",
-    "node-fetch": "^3.3.0"
+    "morgan": "~1.9.1"
   }
 }

--- a/context/pr-stack/security-hardening_2026-08-25.md
+++ b/context/pr-stack/security-hardening_2026-08-25.md
@@ -1,0 +1,26 @@
+# Security hardening stack
+
+Trunk: `dev` at `63e9f70`
+
+## Current stack
+
+| Position | Branch | Concern | Base | GitHub PR |
+| --- | --- | --- | --- | --- |
+| 1 | `fix/login-hardening` | Harden Graph-backed login failures and remove obsolete login dependencies | `dev` | Pending |
+
+## Scope boundary
+
+This layer covers malformed or unsupported Bearer headers, non-successful or unavailable Microsoft Graph responses, required identity fields, email fallback, profile drift on re-login, session rotation at authentication, the Graph request timeout, native Node fetch, and removal of the dead `uNetId` officer-search consumer. It must preserve the existing successful login response contract.
+
+The session-boundary work described by the roadmap is not present in this repository commit. Environment-specific Jenkins session credentials were reported as created externally but remain deployment evidence to verify later; this PR does not claim that evidence.
+
+## Planned follow-up layers
+
+- `fix/ownership-boundaries`
+- `fix/authorization-gaps`
+- `fix/http-boundary`
+- `fix/input-validation`
+- `chore/backend-dependency-hardening`
+- `chore/frontend-dependency-hardening`
+
+Deployment/container hardening remains a separate stack.

--- a/context/pr-stack/security-hardening_2026-08-25.md
+++ b/context/pr-stack/security-hardening_2026-08-25.md
@@ -6,7 +6,7 @@ Trunk: `dev` at `63e9f70`
 
 | Position | Branch | Concern | Base | GitHub PR |
 | --- | --- | --- | --- | --- |
-| 1 | `fix/login-hardening` | Harden Graph-backed login failures and remove obsolete login dependencies | `dev` | Pending |
+| 1 | `fix/login-hardening` | Harden Graph-backed login failures and remove obsolete login dependencies | `dev` | [#90](https://github.com/UW-IUGA/iuga-web-app/pull/90) — draft |
 
 ## Scope boundary
 

--- a/context/pr-stack/security-hardening_2026-08-25.md
+++ b/context/pr-stack/security-hardening_2026-08-25.md
@@ -6,7 +6,9 @@ Trunk: `dev` at `63e9f70`
 
 | Position | Branch | Concern | Base | GitHub PR |
 | --- | --- | --- | --- | --- |
-| 1 | `fix/login-hardening` | Harden Graph-backed login failures and remove obsolete login dependencies | `dev` | [#90](https://github.com/UW-IUGA/iuga-web-app/pull/90) — draft |
+| 1 | `fix/login-hardening` | Graph-backed login hardening | `dev` | [#90](https://github.com/UW-IUGA/iuga-web-app/pull/90) — draft |
+| 2 | `fix/roles-netid` | Remove obsolete NetID search | `fix/login-hardening` | [#91](https://github.com/UW-IUGA/iuga-web-app/pull/91) — draft |
+| 3 | `chore/login-fetch-dependency` | Remove obsolete fetch dependency | `fix/roles-netid` | [#92](https://github.com/UW-IUGA/iuga-web-app/pull/92) — draft |
 
 ## Scope boundary
 


### PR DESCRIPTION
## Summary

<!-- What changed and what observable outcome does it produce? -->

Remove the obsolete `node-fetch` dependency from the backend. The login implementation in the lower stack layer uses Node 22’s native `fetch`, so the backend lockfile no longer carries the unused package subtree.

## Rationale

<!--
- What problem or limitation existed?
- What happens without this change?
- Why was this solution chosen over alternatives, and what tradeoffs were accepted?
-->

`node-fetch` was imported only by the login controller and is unnecessary on the repository’s Node 22 runtime. Removing it keeps the manifest and lockfile aligned and reduces unused production dependency surface. This layer is intentionally limited to dependency cleanup.

## Stack Context

<!-- Include only for stacked PRs. Describe the incremental diff from the immediate base branch. -->

- Position: 3 of 3
- Base PR: #91
- Depends on: #91

## Tests

<!--
- What tests were added or changed, and what verification was run?
-->

- Backend suite passed: 40/40 tests.
- Full repository tests passed: 40 backend and 73 frontend tests.
- Frontend production build passed with `VITE_API_URL=https://dev.iuga.info`.
- Backend audit still reports the pre-existing Morgan/on-headers advisories; those are deferred to the dependency-hardening layer.