### PR TITLE
fix(session): require runtime secret configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,7 @@
 DEPLOY_ENV=development
 DB_URI=mongodb://127.0.0.1:27017/iuga_dev
 PORT=7777
+SESSION_SECRET=replace-with-a-random-secret
 
 SMTP_HOST=smtp.uw.edu
 SMTP_PORT=587

--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,7 @@ import cors from 'cors';
 import path from 'path';
 
 import { models, connectToDatabase } from './models.js'
+import { createSessionOptions } from './sessionConfig.js';
 import apiv1Router from './routes/api/v1/apiv1.js';
 
 import { fileURLToPath } from 'url';
@@ -13,6 +14,12 @@ import { dirname } from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+const sessionSecret = process.env.SESSION_SECRET?.trim();
+if (!sessionSecret) {
+    console.error('FATAL: SESSION_SECRET not set');
+    process.exit(1);
+}
 
 await connectToDatabase();
 const app = express();
@@ -35,11 +42,7 @@ app.disable('etag');
 
 app.use(express.static("../frontend/build"));
 
-app.use(sessions({
-    secret: "CDF45B4E15F646CF38464A9E747D1",
-    saveUninitialized: true,
-    resave: false,
-}))
+app.use(sessions(createSessionOptions(sessionSecret, process.env.DEPLOY_ENV)));
 
 
 app.use((req, res, next) => {

--- a/backend/sessionConfig.js
+++ b/backend/sessionConfig.js
@@ -1,0 +1,18 @@
+/*
+ * @behavior Build the express-session options for the current deployment environment.
+ * @param sessionSecret — the operator-provided signing secret
+ * @param deployEnv — the configured deployment environment
+ * @returns explicit session persistence and cookie settings
+ */
+export function createSessionOptions(sessionSecret, deployEnv) {
+  return {
+    secret: sessionSecret,
+    saveUninitialized: false,
+    resave: false,
+    cookie: {
+      httpOnly: true,
+      secure: deployEnv === "staging" || deployEnv === "production",
+      sameSite: "lax",
+    },
+  };
+}

--- a/backend/test/session-config.test.js
+++ b/backend/test/session-config.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { createSessionOptions } from "../sessionConfig.js";
+
+const appPath = fileURLToPath(new URL("../app.js", import.meta.url));
+
+test("startup fails before database connection when SESSION_SECRET is missing", () => {
+  const result = spawnSync(process.execPath, [appPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SESSION_SECRET: "",
+      DB_URI: "mongodb://127.0.0.1:1/unreachable",
+    },
+  });
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(output, /FATAL: SESSION_SECRET not set/);
+  assert.doesNotMatch(output, /\[startup\] connecting to mongodb/);
+});
+
+test("development sessions use explicit non-secure cookie settings", () => {
+  const options = createSessionOptions("development-secret", "development");
+
+  assert.equal(options.secret, "development-secret");
+  assert.equal(options.saveUninitialized, false);
+  assert.equal(options.resave, false);
+  assert.deepEqual(options.cookie, {
+    httpOnly: true,
+    secure: false,
+    sameSite: "lax",
+  });
+});
+
+test("staging and production sessions use secure cookies", () => {
+  for (const deployEnv of ["staging", "production"]) {
+    const options = createSessionOptions(`${deployEnv}-secret`, deployEnv);
+
+    assert.equal(options.secret, `${deployEnv}-secret`);
+    assert.equal(options.cookie.httpOnly, true);
+    assert.equal(options.cookie.secure, true);
+    assert.equal(options.cookie.sameSite, "lax");
+  }
+});


### PR DESCRIPTION
## Summary

Require the backend session signing secret from the runtime environment and fail before database connection when it is missing. Configure explicit cookie security settings by deployment environment.

## Rationale

The backend previously used a committed session secret and started database initialization before detecting missing runtime configuration. This layer makes the Jenkins-provided `SESSION_SECRET` effective, prevents partial startup without it, and documents the local environment contract. Development uses non-secure cookies for local HTTP; staging and production use secure, HttpOnly, SameSite=Lax cookies.

## Stack Context

- Position: 1 of 2
- Base: `dev`
- Depends on: N/A
- Follow-up: #95 maps each deployment pipeline to its environment-specific credential.

## Tests

- Added startup-order coverage proving missing `SESSION_SECRET` exits before MongoDB connection.
- Added development, staging, and production session-option coverage.
- Full repository tests passed: 43 backend and 73 frontend.
- Frontend production build passed with `VITE_API_URL=https://dev.iuga.info`.
- Lint is unavailable because the repository has no `lint` script.