### PR TITLE
refactor(auth): name role permission middleware explicitly

### DIFF
--- a/backend/routes/api/v1/controllers/eventRequests.js
+++ b/backend/routes/api/v1/controllers/eventRequests.js
@@ -2,7 +2,7 @@ import express from "express";
 import mongoose from "mongoose";
 import { sendError } from "../helpers/sendError.js";
 import { sendSuccess } from "../helpers/sendSuccess.js";
-import { requireAdmin, requirePermission } from "../utils/auth.js";
+import { requireAdmin, requireOfficerRolePermission } from "../utils/auth.js";
 
 const router = express.Router();
 const CHECKPOINT_KEYS = [
@@ -146,7 +146,7 @@ async function requireCheckpointPermission(req, res, next) {
     finance: "events.finance.manage",
     purchases: "events.purchases.complete",
   }[req.params.step];
-  if (permission) return requirePermission(permission)(req, res, next);
+  if (permission) return requireOfficerRolePermission(permission)(req, res, next);
   return requireAdmin(req, res, next);
 }
 
@@ -263,7 +263,7 @@ router.get("/:id", requireAdmin, async (req, res) => {
   }
 });
 
-router.post("/:id/request-changes", requirePermission("events.leadership.approve"), async (req, res) => {
+router.post("/:id/request-changes", requireOfficerRolePermission("events.leadership.approve"), async (req, res) => {
   if (!validId(req.params.id)) return sendError(res, 400, "Invalid event request ID");
   const error = readReason(req.body, "reason");
   if (error) return sendError(res, 400, error);
@@ -283,7 +283,7 @@ router.post("/:id/request-changes", requirePermission("events.leadership.approve
   }
 });
 
-router.post("/:id/deny", requirePermission("events.leadership.approve"), async (req, res) => {
+router.post("/:id/deny", requireOfficerRolePermission("events.leadership.approve"), async (req, res) => {
   if (!validId(req.params.id)) return sendError(res, 400, "Invalid event request ID");
   const error = readReason(req.body, "reason");
   if (error) return sendError(res, 400, error);
@@ -303,7 +303,7 @@ router.post("/:id/deny", requirePermission("events.leadership.approve"), async (
   }
 });
 
-router.post("/:id/approve", requirePermission("events.leadership.approve"), async (req, res) => {
+router.post("/:id/approve", requireOfficerRolePermission("events.leadership.approve"), async (req, res) => {
   if (!validId(req.params.id)) return sendError(res, 400, "Invalid event request ID");
 
   try {
@@ -392,7 +392,7 @@ router.patch("/:id/checklist/:step", requireCheckpointPermission, async (req, re
   }
 });
 
-router.patch("/:id/budget", requirePermission("events.finance.manage"), async (req, res) => {
+router.patch("/:id/budget", requireOfficerRolePermission("events.finance.manage"), async (req, res) => {
   if (!validId(req.params.id)) return sendError(res, 400, "Invalid event request ID");
   const { allocatedCents, actualSpendCents, notes } = req.body ?? {};
   if (allocatedCents !== undefined && !cents(allocatedCents)) {

--- a/backend/routes/api/v1/controllers/roles.js
+++ b/backend/routes/api/v1/controllers/roles.js
@@ -14,7 +14,7 @@ import express from "express";
 import mongoose from "mongoose";
 import { sendError } from "../helpers/sendError.js";
 import { sendSuccess } from "../helpers/sendSuccess.js";
-import { requirePermission } from "../utils/auth.js";
+import { requireOfficerRolePermission } from "../utils/auth.js";
 
 const router = express.Router();
 
@@ -105,7 +105,7 @@ function readRoleFields(body = {}, partial = false) {
 Purpose: List role definitions so authorized officers can manage the role catalog.
 Authentication/Authorization Requirements: users.roles.manage
 */
-router.get("/", requirePermission("users.roles.manage"), async (req, res) => {
+router.get("/", requireOfficerRolePermission("users.roles.manage"), async (req, res) => {
   try {
     const roles = await req.models.Roles.find().sort({ roleName: 1 }).lean();
     return sendSuccess(res, { roles });
@@ -119,7 +119,7 @@ router.get("/", requirePermission("users.roles.manage"), async (req, res) => {
 Purpose: Create a role definition using only backend-approved permissions.
 Authentication/Authorization Requirements: users.roles.manage
 */
-router.post("/", requirePermission("users.roles.manage"), async (req, res) => {
+router.post("/", requireOfficerRolePermission("users.roles.manage"), async (req, res) => {
   const { fields, error } = readRoleFields(req.body);
   if (error) return sendError(res, 400, error);
 
@@ -143,7 +143,7 @@ Authentication/Authorization Requirements: users.roles.manage
 */
 router.patch(
   "/:id",
-  requirePermission("users.roles.manage"),
+  requireOfficerRolePermission("users.roles.manage"),
   async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return sendError(res, 400, "Invalid role ID");
@@ -175,7 +175,7 @@ Authentication/Authorization Requirements: users.roles.manage
 */
 router.get(
   "/users",
-  requirePermission("users.roles.manage"),
+  requireOfficerRolePermission("users.roles.manage"),
   async (req, res) => {
     const search =
       typeof req.query.search === "string" ? req.query.search.trim() : "";
@@ -208,7 +208,7 @@ Authentication/Authorization Requirements: users.roles.manage
 */
 router.get(
   "/users/:id/assignments",
-  requirePermission("users.roles.manage"),
+  requireOfficerRolePermission("users.roles.manage"),
   async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return sendError(res, 400, "Invalid user ID");
@@ -238,7 +238,7 @@ Authentication/Authorization Requirements: users.roles.manage
 */
 router.post(
   "/users/:id/assignments",
-  requirePermission("users.roles.manage"),
+  requireOfficerRolePermission("users.roles.manage"),
   async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return sendError(res, 400, "Invalid user ID");
@@ -334,7 +334,7 @@ Authentication/Authorization Requirements: users.roles.manage
 */
 router.delete(
   "/users/:id/assignments/:assignmentId",
-  requirePermission("users.roles.manage"),
+  requireOfficerRolePermission("users.roles.manage"),
   async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return sendError(res, 400, "Invalid user ID");

--- a/backend/routes/api/v1/utils/auth.js
+++ b/backend/routes/api/v1/utils/auth.js
@@ -60,14 +60,14 @@ export function requireAdmin(req, res, next) {
 }
 
 /*
-    @middleware: requirePermission
+    @middleware: requireOfficerRolePermission
     @method: N/A (Express middleware factory)
     @description: Checks that an authenticated admin has a specific
                   permission through an active role assignment.
 
-    Example: router.post("/roles", requirePermission("users.roles.manage"), handler)
+    Example: router.post("/roles", requireOfficerRolePermission("users.roles.manage"), handler)
 */
-export function requirePermission(permission) {
+export function requireOfficerRolePermission(permission) {
   return async function (req, res, next) {
     if (!req.session.isAuthenticated) {
       return sendError(res, 401, "Not authenticated");

--- a/backend/test/auth.test.js
+++ b/backend/test/auth.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import {
   requireAuth,
   requireAdmin,
-  requirePermission,
+  requireOfficerRolePermission,
 } from "../routes/api/v1/utils/auth.js";
 import { makeFakeRes } from "./makeFakeRes.js";
 
@@ -82,7 +82,7 @@ describe("requireAdmin", () => {
   });
 });
 
-describe("requirePermission", () => {
+describe("requireOfficerRolePermission", () => {
   function requestWithAssignments(assignments) {
     return {
       session: { isAuthenticated: true, isAdmin: true, userId: "user-1" },
@@ -107,7 +107,7 @@ describe("requirePermission", () => {
     const res = makeFakeRes();
     let nextCalled = false;
 
-    await requirePermission("users.roles.manage")(req, res, () => {
+    await requireOfficerRolePermission("users.roles.manage")(req, res, () => {
       nextCalled = true;
     });
 
@@ -121,7 +121,11 @@ describe("requirePermission", () => {
     ]);
     const res = makeFakeRes();
 
-    await requirePermission("users.roles.manage")(req, res, () => {});
+    await requireOfficerRolePermission("users.roles.manage")(
+      req,
+      res,
+      () => {},
+    );
 
     assert.strictEqual(res.statusCode, 403);
     assert.strictEqual(res.body.message, "Not authorized");


### PR DESCRIPTION
## Summary
Rename the authorization middleware to `requireOfficerRolePermission` and migrate all role-permission callers.

## Rationale
The name makes the existing active officer-role permission check explicit without changing authorization behavior.

## Stack Context
- Position: 2 of 10
- Base PR: `chore/dependency-hardening`
- Depends on: PR #97

## Tests
- Backend authorization tests
- Event-request and role-assignment tests
- Full backend suite passed during preparation.