### PR TITLE
fix(auth): ignore expired role assignments

### DIFF
--- a/backend/routes/api/v1/utils/auth.js
+++ b/backend/routes/api/v1/utils/auth.js
@@ -80,11 +80,13 @@ export function requireOfficerRolePermission(permission) {
       const assignments = await req.models.RoleAssignments.find({
         userId: req.session.userId,
         isActive: true,
+        $or: [{ expiresAt: null }, { expiresAt: { $gt: new Date() } }],
       }).populate("roleId");
 
-      const hasPermission = assignments.some((assignment) =>
-        assignment.roleId?.isActive &&
-        assignment.roleId.permissions.includes(permission),
+      const hasPermission = assignments.some(
+        (assignment) =>
+          assignment.roleId?.isActive &&
+          assignment.roleId.permissions.includes(permission),
       );
 
       if (!hasPermission) {

--- a/backend/test/auth.test.js
+++ b/backend/test/auth.test.js
@@ -88,10 +88,22 @@ describe("requireOfficerRolePermission", () => {
       session: { isAuthenticated: true, isAdmin: true, userId: "user-1" },
       models: {
         RoleAssignments: {
-          find() {
+          find(filter = {}) {
+            const filtered = assignments.filter((assignment) => {
+              if (!filter.$or) return true;
+              return filter.$or.some((condition) => {
+                if (condition.expiresAt === null) {
+                  return (
+                    assignment.expiresAt === null ||
+                    assignment.expiresAt === undefined
+                  );
+                }
+                return assignment.expiresAt > condition.expiresAt.$gt;
+              });
+            });
             return {
               async populate() {
-                return assignments;
+                return filtered;
               },
             };
           },
@@ -99,6 +111,28 @@ describe("requireOfficerRolePermission", () => {
       },
     };
   }
+
+  it("does not grant permissions from expired assignments", async () => {
+    const req = requestWithAssignments([
+      {
+        expiresAt: new Date(Date.now() - 1),
+        roleId: { isActive: true, permissions: ["users.roles.manage"] },
+      },
+    ]);
+    const res = makeFakeRes();
+    let nextCalled = false;
+
+    await requireOfficerRolePermission("users.roles.manage")(
+      req,
+      res,
+      () => {
+        nextCalled = true;
+      },
+    );
+
+    assert.strictEqual(res.statusCode, 403);
+    assert.strictEqual(nextCalled, false);
+  });
 
   it("passes when an active role grants the permission", async () => {
     const req = requestWithAssignments([


### PR DESCRIPTION
## Summary
Exclude expired role assignments from permission checks.

## Rationale
Assignments already store `expiresAt`; authorization must stop granting permissions after that time even when the assignment remains active for history.

## Stack Context
- Position: 3 of 10
- Base PR: `refactor/role-permission`
- Depends on: PR #98

## Tests
- Added an expired-assignment authorization regression test
- `node --test backend/test/auth.test.js`
- Full backend suite passed during preparation.