### PR TITLE
fix(events): enforce participant ownership

### DIFF
--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -10,7 +10,7 @@ import express from "express";
 import mongoose from "mongoose";
 import { sendError } from "../helpers/sendError.js";
 import { sendSuccess } from "../helpers/sendSuccess.js";
-import { requireAuth } from "../utils/auth.js";
+import { requireAuth, isOwnerOrAdmin } from "../utils/auth.js";
 
 var router = express.Router();
 //-------------------------------Event Endpoints----------------------------------------------
@@ -320,14 +320,22 @@ router.delete("/withdraw/:eId/:pId", requireAuth, async function (req, res) {
     const eId = req.params.eId;
     const event = await req.models.Events.findById(eId);
 
-    let newParticipants = [];
-    event.eParticipants.forEach((participant) => {
-      if (participant.toString() !== pId) {
-        newParticipants.push(participant);
-      }
-    });
+    const participant = await req.models.Participants.findById(pId);
+    if (!participant || participant.eID?.toString() !== eId) {
+      return sendError(res, 404, "Participant not found");
+    }
 
-    event.eParticipants = newParticipants;
+    if (!isOwnerOrAdmin(req, participant.pUID)) {
+      return sendError(
+        res,
+        403,
+        "You are not authorized to withdraw this participant",
+      );
+    }
+
+    event.eParticipants = event.eParticipants.filter(
+      (participant) => participant.toString() !== pId,
+    );
     await event.save();
 
     return sendSuccess(res);
@@ -338,13 +346,22 @@ router.delete("/withdraw/:eId/:pId", requireAuth, async function (req, res) {
 });
 
 //Given a participant's id, pull their answer list, user profile, and other info about them
-router.get("/:pId", async function (req, res) {
+router.get("/:pId", requireAuth, async function (req, res) {
   try {
     const pId = req.params.pId;
     const participant = await req.models.Participants.findById(pId);
     if (!participant) {
       return sendError(res, 404, "Participant not found.");
     }
+
+    if (!isOwnerOrAdmin(req, participant.pUID)) {
+      return sendError(
+        res,
+        403,
+        "You are not authorized to view this participant",
+      );
+    }
+
     const participantData = {
       id: pId,
       userId: participant.pUID,

--- a/backend/routes/api/v1/utils/auth.js
+++ b/backend/routes/api/v1/utils/auth.js
@@ -34,6 +34,26 @@ export function requireAuth(req, res, next) {
 }
 
 /*
+    @helper: isOwnerOrAdmin
+    @description: Checks if the current session user is an administrator
+                  or owns the specified target record.
+
+    Expected Request Information:
+    - req.session.isAdmin (Boolean, set at login)
+    - req.session.userId (ObjectId or String of current user)
+    - targetUserId (ObjectId or String of the record owner)
+
+    Expected Return Information:
+    - true when the session user is an admin or matches targetUserId; false otherwise
+*/
+export function isOwnerOrAdmin(req, targetUserId) {
+  return Boolean(
+    req.session.isAdmin ||
+    targetUserId?.toString() === req.session.userId?.toString(),
+  );
+}
+
+/*
     @middleware: requireAdmin
     @method: N/A (Express middleware)
     @description: Checks that the request comes from a logged-in officer.

--- a/backend/test/auth.test.js
+++ b/backend/test/auth.test.js
@@ -5,6 +5,7 @@ import {
   requireAdmin,
   requireOfficerRolePermission,
 } from "../routes/api/v1/utils/auth.js";
+import { isOwnerOrAdmin } from "../routes/api/v1/utils/auth.js";
 import { makeFakeRes } from "./makeFakeRes.js";
 
 describe("requireAuth", () => {
@@ -163,5 +164,31 @@ describe("requireOfficerRolePermission", () => {
 
     assert.strictEqual(res.statusCode, 403);
     assert.strictEqual(res.body.message, "Not authorized");
+  });
+});
+
+describe("isOwnerOrAdmin", () => {
+  it("returns true for an admin even if the record belongs to someone else", () => {
+    const req = { session: { isAdmin: true, userId: "admin-1" } };
+    const res = isOwnerOrAdmin(req, "other-user-not-admin");
+    assert.strictEqual(res, true);
+  });
+
+  it("returns true for an admin accessing their own record", () => {
+    const req = { session: { isAdmin: true, userId: "admin-1" } };
+    const res = isOwnerOrAdmin(req, "admin-1");
+    assert.strictEqual(res, true);
+  });
+
+  it("returns true for an owner accessing their own record", () => {
+    const req = { session: { isAdmin: false, userId: "owner-1" } };
+    const res = isOwnerOrAdmin(req, "owner-1");
+    assert.strictEqual(res, true);
+  });
+
+  it("returns false for a user accessing someone else's record when not admin", () => {
+    const req = { session: { isAdmin: false, userId: "owner-1" } };
+    const res = isOwnerOrAdmin(req, "not-owner-1");
+    assert.strictEqual(res, false);
   });
 });

--- a/backend/test/event-access.test.js
+++ b/backend/test/event-access.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import eventsRouter from "../routes/api/v1/controllers/events.js";
+import { makeTestApi } from "./testApi.js";
+
+const eventId = "507f1f77bcf86cd799439011";
+const otherEventId = "507f1f77bcf86cd799439012";
+const participantId = "507f1f77bcf86cd799439013";
+const userId = "507f1f77bcf86cd799439014";
+
+describe("event participant ownership", () => {
+  let api;
+  let saved;
+
+  before(async () => {
+    const event = {
+      _id: eventId,
+      eParticipants: [participantId],
+      async save() {
+        saved = true;
+      },
+    };
+    api = await makeTestApi({
+      router: eventsRouter,
+      mountPath: "/api/v1/events",
+      models: {
+        Events: { findById: async () => event },
+        Participants: {
+          findById: async () => ({ pUID: userId, eID: otherEventId }),
+        },
+      },
+      session: { isAuthenticated: true, userId },
+    });
+  });
+
+  after(async () => {
+    await api.close();
+  });
+
+  it("does not withdraw a participant belonging to another event", async () => {
+    const response = await api.request(
+      "DELETE",
+      `/api/v1/events/withdraw/${eventId}/${participantId}`,
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(response.body.status, "error");
+    assert.equal(saved, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
Enforce owner-or-admin access for participant details and withdrawals.

## Rationale
Participant records contain user identity and RSVP data, and mutations must not allow one user to operate on another user’s participant record.

## Stack Context
- Position: 4 of 10
- Base PR: `security/role-expiration`
- Depends on: PR #99

## Tests
- Added event participant ownership coverage
- Extended authorization helper coverage
- `node --test backend/test/event-access.test.js backend/test/auth.test.js`
- Full backend suite passed during preparation.