### PR TITLE
fix(session): return safe logout errors

### DIFF
--- a/backend/routes/api/v1/controllers/user.js
+++ b/backend/routes/api/v1/controllers/user.js
@@ -156,9 +156,14 @@ router.post("/login", async function (req, res) {
     @method: POST
     @description: destroy user session.
 */
-router.post("/logout", requireAuth, function (req, res, next) {
-  req.session.destroy();
-  return sendSuccess(res);
+router.post("/logout", requireAuth, function (req, res) {
+  req.session.destroy((error) => {
+    if (error) {
+      console.error("Logout session destruction failed:", error?.message);
+      return sendError(res, 500);
+    }
+    return sendSuccess(res);
+  });
 });
 
 //Get the user's specific information from the user's perspective, from an outsider perspective, and from the admin perspective

--- a/backend/test/user.test.js
+++ b/backend/test/user.test.js
@@ -289,3 +289,30 @@ describe("POST /user/login", () => {
     }
   });
 });
+
+describe("POST /user/logout", () => {
+  test("returns a safe server error when session destruction fails", async () => {
+    const api = await makeTestApi({
+      router: usersRouter,
+      mountPath: "/api/v1/user",
+      models: {},
+      session: {
+        isAuthenticated: true,
+        destroy(callback) {
+          callback(new Error("session store unavailable"));
+        },
+      },
+    });
+
+    try {
+      const result = await api.request("POST", "/api/v1/user/logout");
+      assert.equal(result.status, 500);
+      assert.deepEqual(result.body, {
+        status: "error",
+        message: "There was an error on our side :(",
+      });
+    } finally {
+      await api.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Return a safe JSON error when session destruction fails during logout.

## Rationale
A failed session-store operation must not leave the request hanging or expose internal error details to the client.

## Stack Context
- Position: 5 of 10
- Base PR: `security/event-ownership`
- Depends on: PR #100

## Tests
- Added logout session-destruction failure coverage
- `node --test backend/test/user.test.js`
- Full backend suite passed during preparation.