### PR TITLE
fix(api): reject malformed controller input

### DIFF
--- a/backend/routes/api/v1/controllers/eventRequests.js
+++ b/backend/routes/api/v1/controllers/eventRequests.js
@@ -21,12 +21,58 @@ const LEADERSHIP_STATUSES = ["submitted", "changes_requested"];
 function validId(value) {
   return mongoose.isValidObjectId(value);
 }
+function readRsvpQuestions(value) {
+  if (!Array.isArray(value)) return { error: "rsvpQuestions must be an array" };
+
+  const questions = [];
+  for (const [index, question] of value.entries()) {
+    if (!question || typeof question !== "object" || Array.isArray(question)) {
+      return { error: `rsvpQuestions[${index}] must be an object` };
+    }
+    if (
+      typeof question.qId !== "string" ||
+      question.qId.trim() === "" ||
+      question.qId.trim().length > 100
+    ) {
+      return {
+        error: `rsvpQuestions[${index}].qId must be a non-empty string of 100 characters or fewer`,
+      };
+    }
+    if (
+      typeof question.qString !== "string" ||
+      question.qString.trim() === "" ||
+      question.qString.trim().length > 500
+    ) {
+      return {
+        error: `rsvpQuestions[${index}].qString must be a non-empty string of 500 characters or fewer`,
+      };
+    }
+    questions.push({
+      qId: question.qId.trim(),
+      qString: question.qString.trim(),
+    });
+  }
+
+  return { fields: questions };
+}
+
+function readDate(value) {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
 
 function defaultCheckpoints() {
   return CHECKPOINT_KEYS.map((key) => ({ key, status: "pending" }));
 }
 
 function readRequestFields(body = {}) {
+  body ??= {};
+  if (typeof body !== "object" || Array.isArray(body)) {
+    return { error: "Event request body must be an object" };
+  }
+
   const fields = {};
   for (const key of ["eventName", "requestingGroup", "description", "audience"]) {
     if (body[key] !== undefined) {
@@ -48,15 +94,15 @@ function readRequestFields(body = {}) {
     return { error: "eventName, requestingGroup, and description are required" };
   }
 
-  const start = new Date(body.proposedStartDate);
-  if (!body.proposedStartDate || Number.isNaN(start.getTime())) {
+  const start = readDate(body.proposedStartDate);
+  if (!start) {
     return { error: "proposedStartDate must be a valid date" };
   }
   fields.proposedStartDate = start;
 
   if (body.proposedEndDate !== undefined && body.proposedEndDate !== null) {
-    const end = new Date(body.proposedEndDate);
-    if (Number.isNaN(end.getTime()) || end < start) {
+    const end = readDate(body.proposedEndDate);
+    if (!end || end < start) {
       return { error: "proposedEndDate must be a valid date after proposedStartDate" };
     }
     fields.proposedEndDate = end;
@@ -70,10 +116,9 @@ function readRequestFields(body = {}) {
     fields.rsvpEnabled = body.rsvpEnabled;
   }
   if (body.rsvpQuestions !== undefined) {
-    if (!Array.isArray(body.rsvpQuestions)) {
-      return { error: "rsvpQuestions must be an array" };
-    }
-    fields.rsvpQuestions = body.rsvpQuestions;
+    const questions = readRsvpQuestions(body.rsvpQuestions);
+    if (questions.error) return questions;
+    fields.rsvpQuestions = questions.fields;
   }
   if (body.slideTemplate !== undefined) {
     const template = body.slideTemplate;

--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -13,6 +13,39 @@ import { sendSuccess } from "../helpers/sendSuccess.js";
 import { requireAuth, isOwnerOrAdmin } from "../utils/auth.js";
 
 var router = express.Router();
+function validId(value) {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{24}$/i.test(value) &&
+    mongoose.isValidObjectId(value)
+  );
+}
+
+function readRsvpAnswers(value) {
+  if (!Array.isArray(value)) return "rsvpAnswers must be an array";
+
+  for (const answer of value) {
+    if (!answer || typeof answer !== "object" || Array.isArray(answer)) {
+      return "Each RSVP answer must be an object";
+    }
+    if (
+      typeof answer.qId !== "string" ||
+      answer.qId.trim() === "" ||
+      answer.qId.trim().length > 100
+    ) {
+      return "Each RSVP answer qId must be a non-empty string of 100 characters or fewer";
+    }
+    if (
+      typeof answer.aString !== "string" ||
+      answer.aString.length > 2000
+    ) {
+      return "Each RSVP answer aString must be a string of 2000 characters or fewer";
+    }
+  }
+
+  return null;
+}
+
 //-------------------------------Event Endpoints----------------------------------------------
 
 /*
@@ -116,62 +149,57 @@ Expected Response Information:
         }]
 */
 router.get("/id/:eId", async function (req, res) {
-  //When getting an event based on an id, get all info about the event asked for
   try {
     const eId = req.params.eId;
-    const regex = new RegExp("[0-9A-Fa-f]{24}");
-    if (regex.test(eId)) {
-      const event = await req.models.Events.findById(eId)
-        .populate("eParticipants", "pUID")
-        .exec();
-      if (event == null) {
-        return sendError(res, 404, "Event not found");
-      } else {
-        let hasRSVPd = false;
-        let rsvpAnswers = [];
-        if (req.session.isAuthenticated) {
-          const userObjectId = mongoose.Types.ObjectId(req.session.userId);
-          const participant = await req.models.Participants.findOne({
-            pUID: userObjectId,
-            eID: eId,
-          }).exec();
-          if (participant) {
-            hasRSVPd = true;
-            rsvpAnswers = participant.rsvpAnswers.map((answer) => ({
-              qId: answer.qId,
-              aString: answer.aString,
-            }));
-          }
-        }
-
-        const eventData = {
-          eId: event._id,
-          eName: event.eName,
-          eOrganizers: event.eOrganizers,
-          eStartDate: event.eStartDate,
-          eEndDate: event.eEndDate,
-          eLocation: event.eLocation,
-          eDescription: event.eDescription,
-          ePics: event.ePics,
-          eLabels: event.eLabels,
-          rsvpQuestions: event.rsvpQuestions,
-          rsvpAnswers: rsvpAnswers,
-          participants: event.eShowParticipants
-            ? event.eParticipants.length
-            : null,
-          showParticipants: event.eShowParticipants,
-          eThumbnailPath: event.eThumbnailPath,
-          rsvpEnabled: event.eRsvpEnabled,
-          eAltLink: event.eAltLink,
-          hasRSVPd: hasRSVPd,
-        };
-
-        res.json(eventData);
-      }
-    } else {
-      console.error(`/events/id/${eId} Failed regex test!`);
-      return sendError(res, 400, "Bad request...");
+    if (!validId(eId)) {
+      return sendError(res, 400, "Invalid event ID");
     }
+
+    const event = await req.models.Events.findById(eId)
+      .populate("eParticipants", "pUID")
+      .exec();
+    if (!event) {
+      return sendError(res, 404, "Event not found");
+    }
+
+    let hasRSVPd = false;
+    let rsvpAnswers = [];
+    if (req.session.isAuthenticated) {
+      const userObjectId = mongoose.Types.ObjectId(req.session.userId);
+      const participant = await req.models.Participants.findOne({
+        pUID: userObjectId,
+        eID: eId,
+      }).exec();
+      if (participant) {
+        hasRSVPd = true;
+        rsvpAnswers = participant.rsvpAnswers.map((answer) => ({
+          qId: answer.qId,
+          aString: answer.aString,
+        }));
+      }
+    }
+
+    const eventData = {
+      eId: event._id,
+      eName: event.eName,
+      eOrganizers: event.eOrganizers,
+      eStartDate: event.eStartDate,
+      eEndDate: event.eEndDate,
+      eLocation: event.eLocation,
+      eDescription: event.eDescription,
+      ePics: event.ePics,
+      eLabels: event.eLabels,
+      rsvpQuestions: event.rsvpQuestions,
+      rsvpAnswers,
+      participants: event.eShowParticipants ? event.eParticipants.length : null,
+      showParticipants: event.eShowParticipants,
+      eThumbnailPath: event.eThumbnailPath,
+      rsvpEnabled: event.eRsvpEnabled,
+      eAltLink: event.eAltLink,
+      hasRSVPd,
+    };
+
+    return res.json(eventData);
   } catch (error) {
     console.log(error);
     return sendError(res, 500);
@@ -251,7 +279,13 @@ Expected Response Information:
 router.post("/rsvp", requireAuth, async function (req, res) {
   //Using the given event id and user id parameters, create a participant profile for the user and this pId into the event's participant list
   try {
-    const { eId, rsvpAnswers } = req.body;
+    const { eId, rsvpAnswers } = req.body ?? {};
+    if (!validId(eId)) {
+      return sendError(res, 400, "Invalid event ID");
+    }
+    const rsvpError = readRsvpAnswers(rsvpAnswers);
+    if (rsvpError) return sendError(res, 400, rsvpError);
+
     const event = await req.models.Events.findById(eId)
       .populate("eParticipants")
       .exec();
@@ -284,7 +318,7 @@ router.post("/rsvp", requireAuth, async function (req, res) {
     const newParticipant = new req.models.Participants({
       pUID: userObjectId,
       eID: eId,
-      rsvpAnswers: rsvpAnswers,
+      rsvpAnswers,
     });
 
     const savedParticipant = await newParticipant.save();
@@ -318,7 +352,17 @@ router.delete("/withdraw/:eId/:pId", requireAuth, async function (req, res) {
   try {
     const pId = req.params.pId;
     const eId = req.params.eId;
+    if (!validId(eId)) {
+      return sendError(res, 400, "Invalid event ID");
+    }
+    if (!validId(pId)) {
+      return sendError(res, 400, "Invalid participant ID");
+    }
+
     const event = await req.models.Events.findById(eId);
+    if (!event) {
+      return sendError(res, 404, "Event not found");
+    }
 
     const participant = await req.models.Participants.findById(pId);
     if (!participant || participant.eID?.toString() !== eId) {
@@ -349,6 +393,10 @@ router.delete("/withdraw/:eId/:pId", requireAuth, async function (req, res) {
 router.get("/:pId", requireAuth, async function (req, res) {
   try {
     const pId = req.params.pId;
+    if (!validId(pId)) {
+      return sendError(res, 400, "Invalid participant ID");
+    }
+
     const participant = await req.models.Participants.findById(pId);
     if (!participant) {
       return sendError(res, 404, "Participant not found.");
@@ -368,7 +416,6 @@ router.get("/:pId", requireAuth, async function (req, res) {
       aList: participant.aList,
       isAnon: participant.isAnon,
     };
-    // fix this
     return sendSuccess(res, { participant: participantData });
   } catch (error) {
     console.log(error);
@@ -377,4 +424,3 @@ router.get("/:pId", requireAuth, async function (req, res) {
 });
 
 export default router;
-

--- a/backend/routes/api/v1/controllers/feedback.js
+++ b/backend/routes/api/v1/controllers/feedback.js
@@ -12,6 +12,39 @@ import { requireAuth, requireAdmin } from "../utils/auth.js";
 import mongoose from "mongoose";
 
 var router = express.Router();
+function readFeedbackFields(body = {}) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { error: "Feedback body must be an object" };
+  }
+
+  const fType = body.fType === undefined ? "General" : body.fType;
+  if (typeof fType !== "string" || fType.trim().length > 100) {
+    return { error: "fType must be a string of 100 characters or fewer" };
+  }
+  if (typeof body.fTopic !== "string" || body.fTopic.trim() === "") {
+    return { error: "fTopic must be a non-empty string" };
+  }
+  if (body.fTopic.trim().length > 200) {
+    return { error: "fTopic must be 200 characters or fewer" };
+  }
+  if (
+    typeof body.fDescription !== "string" ||
+    body.fDescription.trim() === ""
+  ) {
+    return { error: "fDescription must be a non-empty string" };
+  }
+  if (body.fDescription.trim().length > 5000) {
+    return { error: "fDescription must be 5000 characters or fewer" };
+  }
+
+  return {
+    fields: {
+      fType: fType.trim() || "General",
+      fTopic: body.fTopic.trim(),
+      fDescription: body.fDescription.trim(),
+    },
+  };
+}
 
 /*
 Purpose: Retrieve a feedback form's info from the database
@@ -65,19 +98,17 @@ Assumed req variables (Will need to check back with frontend for what is sent in
 - fDescription
 */
 router.post("/", requireAuth, async (req, res) => {
+  const { fields, error } = readFeedbackFields(req.body);
+  if (error) return sendError(res, 400, error);
+
   try {
-    //Fit the new feedback data into a new Feedback Schema Object
     const newFeedback = new req.models.Feedback({
-      fUID: req.session.userId, // Identity from the session
-      fType: req.body.fType,
-      fTopic: req.body.fTopic,
-      fDescription: req.body.fDescription,
+      fUID: req.session.userId,
+      ...fields,
     });
 
-    //Save the new Feedback object into the database.
     await newFeedback.save();
 
-    //Give the client a proper reply saying it went well.
     return sendSuccess(res);
   } catch (error) {
     console.log(error);
@@ -97,10 +128,16 @@ Assumed req variables (Will need to check back with frontend for what is sent in
 */
 router.delete("/", requireAdmin, async (req, res) => {
   const fID = req.query.fID;
+  if (
+    typeof fID !== "string" ||
+    !/^[0-9a-f]{24}$/i.test(fID) ||
+    !mongoose.isValidObjectId(fID)
+  ) {
+    return sendError(res, 400, "Invalid feedback ID");
+  }
+
   try {
-    //Delete the given feedback form
     await req.models.Feedback.deleteOne({ _id: fID });
-    //Tell the client it worked
     return sendSuccess(res);
   } catch (error) {
     console.log(error);

--- a/backend/routes/api/v1/controllers/roles.js
+++ b/backend/routes/api/v1/controllers/roles.js
@@ -37,53 +37,51 @@ function isProvided(value) {
   return value !== undefined && value !== null;
 }
 
-function readRoleFields(body = {}, partial = false) {
-  body = body ?? {};
+function normalizeRoleFields(body, partial) {
+  const source = body ?? {};
   const fields = {};
   const roleName =
-    typeof body.roleName === "string" ? body.roleName.trim() : undefined;
+    typeof source.roleName === "string" ? source.roleName.trim() : undefined;
   const roleKey =
-    typeof body.roleKey === "string"
-      ? body.roleKey.trim().toLowerCase()
+    typeof source.roleKey === "string"
+      ? source.roleKey.trim().toLowerCase()
       : undefined;
   const roleDescription =
-    typeof body.roleDescription === "string"
-      ? body.roleDescription.trim()
+    typeof source.roleDescription === "string"
+      ? source.roleDescription.trim()
       : undefined;
 
   if (!partial || roleName !== undefined) fields.roleName = roleName;
   if (!partial || roleKey !== undefined) fields.roleKey = roleKey;
-  if (!partial || roleDescription !== undefined)
+  if (!partial || roleDescription !== undefined) {
     fields.roleDescription = roleDescription ?? "";
-  if (!partial || body.permissions !== undefined)
-    fields.permissions = body.permissions;
-  if (body.isActive !== undefined) fields.isActive = body.isActive;
+  }
+  if (!partial || source.permissions !== undefined) {
+    fields.permissions = source.permissions;
+  }
+  if (source.isActive !== undefined) fields.isActive = source.isActive;
 
+  return fields;
+}
+
+function validateRoleFields(fields, partial) {
   if (!partial && (!fields.roleName || !fields.roleKey)) {
-    return { error: "roleName and roleKey are required" };
+    return "roleName and roleKey are required";
   }
-  if (fields.roleName && fields.roleName.length > ROLE_NAME_MAX_LENGTH) {
-    return {
-      error: `roleName must be ${ROLE_NAME_MAX_LENGTH} characters or fewer`,
-    };
+
+  const maxLengths = {
+    roleName: ROLE_NAME_MAX_LENGTH,
+    roleKey: ROLE_KEY_MAX_LENGTH,
+    roleDescription: ROLE_DESCRIPTION_MAX_LENGTH,
+  };
+  for (const [field, maxLength] of Object.entries(maxLengths)) {
+    if (fields[field] && fields[field].length > maxLength) {
+      return `${field} must be ${maxLength} characters or fewer`;
+    }
   }
-  if (fields.roleKey && fields.roleKey.length > ROLE_KEY_MAX_LENGTH) {
-    return {
-      error: `roleKey must be ${ROLE_KEY_MAX_LENGTH} characters or fewer`,
-    };
-  }
-  if (
-    fields.roleDescription &&
-    fields.roleDescription.length > ROLE_DESCRIPTION_MAX_LENGTH
-  ) {
-    return {
-      error: `roleDescription must be ${ROLE_DESCRIPTION_MAX_LENGTH} characters or fewer`,
-    };
-  }
+
   if (fields.roleKey && !/^[a-z][a-z0-9_]*$/.test(fields.roleKey)) {
-    return {
-      error: "roleKey must use lowercase letters, numbers, and underscores",
-    };
+    return "roleKey must use lowercase letters, numbers, and underscores";
   }
   if (
     fields.permissions !== undefined &&
@@ -92,13 +90,19 @@ function readRoleFields(body = {}, partial = false) {
         (permission) => !knownPermissions.has(permission),
       ))
   ) {
-    return { error: "permissions contains an unknown permission" };
+    return "permissions contains an unknown permission";
   }
   if (fields.isActive !== undefined && typeof fields.isActive !== "boolean") {
-    return { error: "isActive must be a boolean" };
+    return "isActive must be a boolean";
   }
 
-  return { fields };
+  return null;
+}
+
+function readRoleFields(body = {}, partial = false) {
+  const fields = normalizeRoleFields(body, partial);
+  const error = validateRoleFields(fields, partial);
+  return error ? { error } : { fields };
 }
 
 /*

--- a/backend/routes/api/v1/controllers/user.js
+++ b/backend/routes/api/v1/controllers/user.js
@@ -6,11 +6,19 @@ Schemas addressed in users.js:
 */
 
 import express from "express";
+import mongoose from "mongoose";
 import { sendError } from "../helpers/sendError.js";
 import { sendSuccess } from "../helpers/sendSuccess.js";
 import { requireAuth } from "../utils/auth.js";
 
 var router = express.Router();
+function validUserId(value) {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{24}$/i.test(value) &&
+    mongoose.isValidObjectId(value)
+  );
+}
 const GRAPH_PROFILE_URL = "https://graph.microsoft.com/v1.0/me";
 const GRAPH_REQUEST_TIMEOUT_MS = 5000;
 const INVALID_AUTHORIZATION_MESSAGE = "Invalid access token";
@@ -65,7 +73,7 @@ async function rotateSession(req) {
                   get information about the user using Graph API. Save information
                   about the user if already exists. Create user session.
 */
-router.post("/login", async function (req, res) {
+router.post("/login", loginRateLimiter, async function (req, res) {
   const accessToken = readBearerToken(req.headers.authorization);
   if (!accessToken) {
     return sendError(res, 401, INVALID_AUTHORIZATION_MESSAGE);
@@ -181,8 +189,11 @@ router.get("/", requireAuth, async function (req, res) {
 router.get("/:uId", requireAuth, async function (req, res) {
   try {
     const uId = req.params.uId;
-    const currId = req.session.id;
-    const currUser = await req.models.Users.findById({ currId });
+    if (!validUserId(uId)) {
+      return sendError(res, 400, "Invalid user ID");
+    }
+    const currId = req.session.userId;
+    const currUser = await req.models.Users.findById(currId);
 
     if (currId == uId) {
       //Current user is viewing their own account (account owner view)
@@ -201,8 +212,11 @@ router.get("/:uId", requireAuth, async function (req, res) {
 router.post("/:uId", requireAuth, async function (req, res) {
   try {
     const uId = req.params.uId;
-    const currId = req.session.id;
-    const currUser = await req.models.Users.findById({ currId });
+    if (!validUserId(uId)) {
+      return sendError(res, 400, "Invalid user ID");
+    }
+    const currId = req.session.userId;
+    const currUser = await req.models.Users.findById(currId);
     if (currId == uId) {
       //If current user edits their own account
     } else if (currId != uId && currUser.uType === "Admin") {

--- a/backend/test/input-validation.test.js
+++ b/backend/test/input-validation.test.js
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import eventsRouter from "../routes/api/v1/controllers/events.js";
+import eventRequestsRouter from "../routes/api/v1/controllers/eventRequests.js";
+import feedbackRouter from "../routes/api/v1/controllers/feedback.js";
+import userRouter from "../routes/api/v1/controllers/user.js";
+import { makeTestApi } from "./testApi.js";
+const validId = "507f1f77bcf86cd799439011";
+
+function unusedModel() {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error("database should not be reached for invalid input");
+      },
+    },
+  );
+}
+
+describe("request validation", () => {
+  let eventsApi;
+  let eventRequestsApi;
+  let feedbackApi;
+  let userApi;
+  before(async () => {
+    eventsApi = await makeTestApi({
+      router: eventsRouter,
+      mountPath: "/api/v1/events",
+      models: {
+        Events: unusedModel(),
+        Participants: unusedModel(),
+      },
+      session: { isAuthenticated: true, userId: validId },
+    });
+    eventRequestsApi = await makeTestApi({
+      router: eventRequestsRouter,
+      mountPath: "/api/v1/event-requests",
+      models: { EventRequests: unusedModel() },
+      session: { isAuthenticated: true, isAdmin: true, userId: validId },
+    });
+    feedbackApi = await makeTestApi({
+      router: feedbackRouter,
+      mountPath: "/api/v1/feedback",
+      models: { Feedback: unusedModel() },
+      session: { isAuthenticated: true, isAdmin: true, userId: validId },
+    });
+    userApi = await makeTestApi({
+      router: userRouter,
+      mountPath: "/api/v1/user",
+      models: { Users: unusedModel() },
+      session: { isAuthenticated: true, userId: validId },
+    });
+  });
+
+  after(async () => {
+    await Promise.all([
+      eventsApi.close(),
+      eventRequestsApi.close(),
+      feedbackApi.close(),
+      userApi.close(),
+    ]);
+  });
+  it("rejects malformed event and participant identifiers", async () => {
+    for (const path of [
+      "/api/v1/events/id/not-an-object-id",
+      "/api/v1/events/not-an-object-id",
+      "/api/v1/events/withdraw/not-an-object-id/" + validId,
+      "/api/v1/events/withdraw/" + validId + "/not-an-object-id",
+    ]) {
+      const response = await eventsApi.request(
+        path.includes("/withdraw/") ? "DELETE" : "GET",
+        path,
+      );
+      assert.equal(response.status, 400, path);
+      assert.equal(response.body.status, "error", path);
+    }
+  });
+
+  it("rejects malformed RSVP bodies before database access", async () => {
+    const response = await eventsApi.request("POST", "/api/v1/events/rsvp", {
+      eId: validId,
+      rsvpAnswers: { qId: "question", aString: "answer" },
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(response.body, {
+      status: "error",
+      message: "rsvpAnswers must be an array",
+    });
+  });
+
+  it("rejects nested event-request values with the API error envelope", async () => {
+    const response = await eventRequestsApi.request("POST", "/api/v1/event-requests", {
+      eventName: "Workshop",
+      requestingGroup: "Committee",
+      description: "Description",
+      proposedStartDate: "2026-09-01T18:00:00.000Z",
+      rsvpQuestions: [{ qId: "question", qString: 42 }],
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.status, "error");
+  });
+
+  it("rejects malformed feedback identifiers before deletion", async () => {
+    const response = await feedbackApi.request("DELETE", "/api/v1/feedback/?fID=not-an-object-id");
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(response.body, {
+      status: "error",
+      message: "Invalid feedback ID",
+    });
+  });
+
+  it("rejects malformed user identifiers before database access", async () => {
+    for (const method of ["GET", "POST"]) {
+      const response = await userApi.request(
+        method,
+        "/api/v1/user/not-an-object-id",
+        method === "POST" ? {} : undefined,
+      );
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(response.body, {
+        status: "error",
+        message: "Invalid user ID",
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Reject malformed controller identifiers, request bodies, dates, nested values, and numeric fields before database access.

## Rationale
The API should return stable 400 responses for invalid input instead of relying on downstream Mongoose errors or persisting malformed values.

## Stack Context
- Position: 6 of 10
- Base PR: `security/session-errors`
- Depends on: PR #101

## Tests
- Added focused input-validation tests across event, event-request, feedback, role, and user routes
- Verified model access is not reached for malformed input
- `node --test backend/test/input-validation.test.js`
- Full backend suite passed during preparation.