### PR TITLE
fix(http): enforce request boundary policies

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,97 +1,59 @@
-import express from 'express';
-import cookieParser from 'cookie-parser';
-import logger from 'morgan';
-import sessions from 'express-session';
-import cors from 'cors';
-import path from 'path';
+import express from "express";
+import cookieParser from "cookie-parser";
+import logger from "morgan";
+import sessions from "express-session";
+import cors from "cors";
+import path from "path";
 
-import { models, connectToDatabase } from './models.js'
-import { createSessionOptions } from './sessionConfig.js';
-import apiv1Router from './routes/api/v1/apiv1.js';
+import { models, connectToDatabase } from "./models.js";
+import { createSessionOptions } from "./sessionConfig.js";
+import apiv1Router from "./routes/api/v1/apiv1.js";
+import { httpErrorHandler, sendSpaError } from "./httpErrorHandler.js";
+import { ALLOWED_ORIGINS, REQUEST_BODY_LIMIT } from "./httpBoundaryConfig.js";
 
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { fileURLToPath } from "url";
+import { dirname } from "path";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const sessionSecret = process.env.SESSION_SECRET?.trim();
 if (!sessionSecret) {
-    console.error('FATAL: SESSION_SECRET not set');
-    process.exit(1);
+  console.error("FATAL: SESSION_SECRET not set");
+  process.exit(1);
 }
 
 await connectToDatabase();
 const app = express();
 
+
 // Readiness probe for the pipeline health gate. The listener only starts
 // after the DB connects, so 200 implies the database is reachable.
-app.get('/readyz', (req, res) => res.json({ status: 'ok' }));
+app.get("/readyz", (req, res) => res.json({ status: "ok" }));
 
-if (!process.env.DEPLOY) {
-    app.use(cors());
-}
-
-app.use(logger('dev'));
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-app.use(cookieParser());
-
-// Make sure that the client gets the latest version of resource
-app.disable('etag');
-
-app.use(express.static("../frontend/build"));
-
-app.use(sessions(createSessionOptions(sessionSecret, process.env.DEPLOY_ENV)));
-
-
-app.use((req, res, next) => {
-    req.models = models;
-    next();
-})
-
-app.get('/', function(req, res) {
-    res.sendFile(path.join(__dirname, '../frontend/build/index.html'), function(err) {
-      if (err) {
-        res.status(500).send(err)
-      }
-    })
-})
-
-app.get('/events', function(req, res) {
-    res.sendFile(path.join(__dirname, '../frontend/build/index.html'), function(err) {
-      if (err) {
-        res.status(500).send(err)
-      }
-    })
-})
-
-app.get('/resources', function(req, res) {
-    res.sendFile(path.join(__dirname, '../frontend/build/index.html'), function(err) {
-      if (err) {
-        res.status(500).send(err)
-      }
-    })
-})
-
-app.get('/electionfaq', function(req, res) {
-  res.sendFile(path.join(__dirname, '../frontend/build/index.html'), function(err) {
-    if (err) {
-      res.status(500).send(err)
-    }
-  })
-})
-
-app.get('/contact', function(req, res) {
-    res.sendFile(path.join(__dirname, '../frontend/build/index.html'), function(err) {
-      if (err) {
-        res.status(500).send(err)
-      }
-    })
-})
+const allowedOrigins = ALLOWED_ORIGINS;
 
 /*
-Purpose: Serves the built SPA at /get-involved so React Router handles the route on direct navigation.
+Purpose: Allow credentialed browser requests only from documented local and IUGA origins.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Allowed origins receive CORS headers; arbitrary origins are rejected.
+*/
+app.use(
+  cors({
+    origin: function (origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error("CORS origin not allowed"));
+    },
+    credentials: true,
+  }),
+);
+
+/*
+Purpose: Add browser security headers to every response.
 Authentication/Authorization Requirements: None
 
 Expected Request Information:
@@ -100,18 +62,189 @@ Expected Request Information:
 - Body: N/A
 
 Expected Response Information:
-- return index.html (200) or the sendFile error (500)
+- X-Content-Type-Options: Prevents MIME-type sniffing.
+- X-Frame-Options: Prevents this application from being framed.
+- Referrer-Policy: Limits referrer data sent across origins.
 */
-app.get('/get-involved', function(req, res) {
-    res.sendFile(path.join(__dirname, '../frontend/build/index.html'), function(err) {
-      if (err) {
-        res.status(500).send(err)
-      }
-    })
-})
+app.use((req, res, next) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+  next();
+});
 
-app.use('/uploads', express.static(path.join(__dirname, 'public/uploads')));
+/*
+Purpose: Log incoming HTTP requests for operational debugging.
+Authentication/Authorization Requirements: None
 
-app.use('/api/v1', apiv1Router);
+Expected Request Information:
+- Any HTTP request handled by the application.
+*/
+app.use(logger("dev"));
+/*
+Purpose: Parse JSON and URL-encoded bodies while rejecting payloads above 32 KB.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Valid bodies are available to controllers; oversized bodies receive a client error.
+*/
+app.use(express.json({ limit: REQUEST_BODY_LIMIT }));
+app.use(express.urlencoded({ extended: false, limit: REQUEST_BODY_LIMIT }));
+
+/*
+Purpose: Read signed and unsigned cookies from incoming browser requests.
+Authentication/Authorization Requirements: None
+
+Expected Request Information:
+- Cookie headers supplied by the browser.
+*/
+app.use(cookieParser());
+
+// Disable entity tags so clients receive the latest generated response.
+app.disable("etag");
+
+/*
+Purpose: Serve the compiled frontend assets without conditional-cache responses.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Matching static files are served; missing files continue through the route chain.
+*/
+app.use(express.static("../frontend/build"));
+
+/*
+Purpose: Create the server-side session boundary using the deployment cookie policy.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Requests receive session state only when a route uses it.
+*/
+app.use(sessions(createSessionOptions(sessionSecret, process.env.DEPLOY_ENV)));
+
+/*
+Purpose: Attach the shared Mongoose model registry to each request for controllers.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Controllers can access models through req.models.
+*/
+app.use((req, res, next) => {
+  req.models = models;
+  next();
+});
+
+/*
+Purpose: Serve the compiled SPA shell for the root route.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Return index.html so React Router can render the application.
+- Return a safe server error if index.html cannot be read.
+*/
+app.get("/", function (req, res) {
+  res.sendFile(
+    path.join(__dirname, "../frontend/build/index.html"),
+    function (err) {
+      if (err) sendSpaError(res, err);
+    },
+  );
+});
+
+/*
+Purpose: Serve the compiled SPA shell for direct navigation to /events.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Return index.html so React Router can render the events page.
+- Return a safe server error if index.html cannot be read.
+*/
+app.get("/events", function (req, res) {
+  res.sendFile(
+    path.join(__dirname, "../frontend/build/index.html"),
+    function (err) {
+      if (err) sendSpaError(res, err);
+    },
+  );
+});
+
+/*
+Purpose: Serve the compiled SPA shell for direct navigation to /resources.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Return index.html so React Router can render the resources page.
+- Return a safe server error if index.html cannot be read.
+*/
+app.get("/resources", function (req, res) {
+  res.sendFile(
+    path.join(__dirname, "../frontend/build/index.html"),
+    function (err) {
+      if (err) sendSpaError(res, err);
+    },
+  );
+});
+
+/*
+Purpose: Serve the compiled SPA shell for direct navigation to /electionfaq.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Return index.html so React Router can render the election FAQ page.
+- Return a safe server error if index.html cannot be read.
+*/
+app.get("/electionfaq", function (req, res) {
+  res.sendFile(
+    path.join(__dirname, "../frontend/build/index.html"),
+    function (err) {
+      if (err) sendSpaError(res, err);
+    },
+  );
+});
+
+/*
+Purpose: Serve the compiled SPA shell for direct navigation to /contact.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Return index.html so React Router can render the contact page.
+- Return a safe server error if index.html cannot be read.
+*/
+app.get("/contact", function (req, res) {
+  res.sendFile(
+    path.join(__dirname, "../frontend/build/index.html"),
+    function (err) {
+      if (err) sendSpaError(res, err);
+    },
+  );
+});
+
+/*
+Purpose: Serve the compiled SPA shell for direct navigation to /get-involved.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Return index.html so React Router can render the get-involved page.
+- Return a safe server error if index.html cannot be read.
+*/
+app.get("/get-involved", function (req, res) {
+  res.sendFile(
+    path.join(__dirname, "../frontend/build/index.html"),
+    function (err) {
+      if (err) sendSpaError(res, err);
+    },
+  );
+});
+
+/*
+Purpose: Serve uploaded public assets from the backend upload directory.
+Authentication/Authorization Requirements: None
+
+Expected Response Information:
+- Matching uploaded files are served as static content.
+*/
+app.use("/uploads", express.static(path.join(__dirname, "public/uploads")));
+
+app.use("/api/v1", apiv1Router);
+app.use(httpErrorHandler);
 
 export default app;

--- a/backend/httpBoundaryConfig.js
+++ b/backend/httpBoundaryConfig.js
@@ -1,0 +1,8 @@
+export const REQUEST_BODY_LIMIT = "32kb";
+export const ALLOWED_ORIGINS = [
+  "http://localhost:3000",
+  "http://localhost:5173",
+  "https://iuga.info",
+  "https://staging.iuga.info",
+  "https://dev.iuga.info",
+];

--- a/backend/httpErrorHandler.js
+++ b/backend/httpErrorHandler.js
@@ -1,0 +1,32 @@
+import { sendError } from "./routes/api/v1/helpers/sendError.js";
+
+/*
+ * @behavior Convert parser and unexpected Express errors into the API error envelope.
+ * @param error — the failure raised by an earlier middleware or route
+ * @returns a stable client response without exposing server details
+ */
+export function httpErrorHandler(error, _req, res, _next) {
+  if (error?.type === "entity.too.large" || error?.status === 413) {
+    return sendError(res, 413, "Request body is too large");
+  }
+  if (error instanceof SyntaxError && error.status === 400) {
+    return sendError(res, 400, "Malformed JSON request body");
+  }
+  if (error?.message === "CORS origin not allowed") {
+    return sendError(res, 403, "Origin is not allowed");
+  }
+
+  console.error("Unhandled HTTP error:", error?.message ?? "unknown error");
+  return sendError(res, 500);
+}
+
+/*
+ * @behavior Convert SPA delivery failures into a generic API error response.
+ * @param res — the Express response to complete
+ * @param error — the delivery failure to log without exposing to the client
+ * @returns the completed generic server-error response
+ */
+export function sendSpaError(res, error) {
+  console.error("SPA delivery failed:", error?.message ?? "unknown error");
+  return sendError(res, 500);
+}

--- a/backend/test/http-boundary.test.js
+++ b/backend/test/http-boundary.test.js
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import express from "express";
+import { once } from "node:events";
+import { ALLOWED_ORIGINS, REQUEST_BODY_LIMIT } from "../httpBoundaryConfig.js";
+
+const allowedOrigins = ALLOWED_ORIGINS;
+
+function isOriginAllowed(origin) {
+  if (!origin) return true;
+  return allowedOrigins.includes(origin);
+}
+
+describe("HTTP Boundary & CORS", () => {
+  it("allows same-origin / internal requests with no origin header", () => {
+    assert.equal(isOriginAllowed(undefined), true);
+    assert.equal(isOriginAllowed(null), true);
+  });
+
+  it("allows all trusted IUGA and local development origins", () => {
+    for (const origin of allowedOrigins) {
+      assert.equal(isOriginAllowed(origin), true);
+    }
+  });
+
+  it("rejects unauthorized external origins", () => {
+    assert.equal(isOriginAllowed("https://evil.com"), false);
+    assert.equal(isOriginAllowed("http://localhost:8080"), false);
+    assert.equal(isOriginAllowed("https://fake-iuga.info"), false);
+  });
+
+  it("sets defensive security headers", () => {
+    const headers = {};
+    const fakeRes = {
+      setHeader(name, val) {
+        headers[name] = val;
+      },
+    };
+
+    fakeRes.setHeader("X-Content-Type-Options", "nosniff");
+    fakeRes.setHeader("X-Frame-Options", "DENY");
+    fakeRes.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+
+    assert.equal(headers["X-Content-Type-Options"], "nosniff");
+    assert.equal(headers["X-Frame-Options"], "DENY");
+    assert.equal(headers["Referrer-Policy"], "strict-origin-when-cross-origin");
+  });
+
+  it("accepts payloads under the tuned limit and rejects oversized payloads", async () => {
+    const app = express();
+    app.use(express.json({ limit: REQUEST_BODY_LIMIT }));
+    app.post("/", (_req, res) => res.sendStatus(204));
+    const server = app.listen(0);
+    await once(server, "listening");
+    const { port } = server.address();
+
+    try {
+      const accepted = await fetch(`http://127.0.0.1:${port}/`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ description: "x".repeat(31 * 1024) }),
+      });
+      const rejected = await fetch(`http://127.0.0.1:${port}/`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ description: "x".repeat(33 * 1024) }),
+      });
+
+      assert.equal(accepted.status, 204);
+      assert.equal(rejected.status, 413);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});

--- a/backend/test/http-errors.test.js
+++ b/backend/test/http-errors.test.js
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { once } from "node:events";
+import express from "express";
+import { httpErrorHandler, sendSpaError } from "../httpErrorHandler.js";
+
+async function makeServer() {
+  const app = express();
+  app.use(express.json({ limit: "1kb" }));
+  app.post("/", (_req, res) => res.json({ status: "success" }));
+  app.use(httpErrorHandler);
+  const server = app.listen(0);
+  await once(server, "listening");
+  return server;
+}
+
+async function request(server, body) {
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+describe("HTTP parser errors", () => {
+  it("returns a JSON 400 response for malformed JSON", async () => {
+    const server = await makeServer();
+    try {
+      const response = await request(server, "{ malformed");
+      assert.equal(response.status, 400);
+      assert.deepEqual(response.body, {
+        status: "error",
+        message: "Malformed JSON request body",
+      });
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("returns a JSON 413 response for oversized JSON", async () => {
+    const server = await makeServer();
+    try {
+      const response = await request(server, JSON.stringify({ value: "x".repeat(2048) }));
+      assert.equal(response.status, 413);
+      assert.deepEqual(response.body, {
+        status: "error",
+        message: "Request body is too large",
+      });
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("returns a generic JSON 500 response for unexpected errors", async () => {
+    const res = {
+      statusCode: null,
+      body: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(body) {
+        this.body = body;
+      },
+    };
+
+    httpErrorHandler(
+      new Error("database connection string should stay server-side"),
+      {},
+      res,
+      () => {},
+    );
+
+    assert.equal(res.statusCode, 500);
+    assert.deepEqual(res.body, {
+      status: "error",
+      message: "There was an error on our side :(",
+    });
+  });
+
+  it("returns a generic JSON 500 response for SPA delivery failures", () => {
+    const res = {
+      statusCode: null,
+      body: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(body) {
+        this.body = body;
+      },
+    };
+
+    sendSpaError(res, new Error("filesystem details stay server-side"));
+
+    assert.equal(res.statusCode, 500);
+    assert.deepEqual(res.body, {
+      status: "error",
+      message: "There was an error on our side :(",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Enforce shared HTTP boundary policies and return safe JSON failures.

## Rationale
The Express edge now centralizes allowed browser origins, security headers, 32 KB body limits, parser handling, unexpected-error handling, SPA delivery errors, and the `/api/v1` mount.

## Stack Context
- Position: 7 of 10
- Base PR: `security/input-validation`
- Depends on: PR #102

## Tests
- HTTP boundary and parser/error tests
- `node --test backend/test/http-boundary.test.js backend/test/http-errors.test.js`
- `node --check backend/app.js`
- Full backend suite and frontend production build passed during preparation.