### PR TITLE
fix(csrf): protect session mutations by origin

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -10,6 +10,7 @@ import { createSessionOptions } from "./sessionConfig.js";
 import apiv1Router from "./routes/api/v1/apiv1.js";
 import { httpErrorHandler, sendSpaError } from "./httpErrorHandler.js";
 import { ALLOWED_ORIGINS, REQUEST_BODY_LIMIT } from "./httpBoundaryConfig.js";
+import { createCsrfProtection } from "./routes/api/v1/utils/csrf.js";
 
 import { fileURLToPath } from "url";
 import { dirname } from "path";
@@ -120,6 +121,7 @@ Expected Response Information:
 - Requests receive session state only when a route uses it.
 */
 app.use(sessions(createSessionOptions(sessionSecret, process.env.DEPLOY_ENV)));
+app.use(createCsrfProtection({ allowedOrigins }));
 
 /*
 Purpose: Attach the shared Mongoose model registry to each request for controllers.

--- a/backend/routes/api/v1/utils/csrf.js
+++ b/backend/routes/api/v1/utils/csrf.js
@@ -1,0 +1,29 @@
+import { sendError } from "../helpers/sendError.js";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const CSRF_ERROR_MESSAGE = "CSRF validation failed";
+
+/*
+ * @behavior Reject authenticated state-changing requests without a trusted browser origin.
+ * @param allowedOrigins — browser origins permitted to send cookie-authenticated mutations
+ * @returns Express middleware that continues trusted requests and returns 403 otherwise
+ */
+export function createCsrfProtection({ allowedOrigins }) {
+  const trustedOrigins = new Set(allowedOrigins);
+
+  return function csrfProtection(req, res, next) {
+    if (
+      SAFE_METHODS.has(req.method) ||
+      !req.session?.isAuthenticated
+    ) {
+      return next();
+    }
+
+    const origin = req.headers.origin;
+    if (!origin || !trustedOrigins.has(origin)) {
+      return sendError(res, 403, CSRF_ERROR_MESSAGE);
+    }
+
+    next();
+  };
+}

--- a/backend/test/csrf.test.js
+++ b/backend/test/csrf.test.js
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createCsrfProtection } from "../routes/api/v1/utils/csrf.js";
+
+function makeResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+function makeRequest({ method = "POST", origin, authenticated = true } = {}) {
+  return {
+    method,
+    headers: origin === undefined ? {} : { origin },
+    session: { isAuthenticated: authenticated },
+  };
+}
+
+describe("CSRF protection", () => {
+  const protect = createCsrfProtection({
+    allowedOrigins: ["http://localhost:3000"],
+  });
+
+  it("rejects authenticated mutations without an origin", () => {
+    const req = makeRequest();
+    const res = makeResponse();
+    let nextCalled = false;
+
+    protect(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(res.body, {
+      status: "error",
+      message: "CSRF validation failed",
+    });
+    assert.equal(nextCalled, false);
+  });
+
+  it("rejects authenticated mutations from an untrusted origin", () => {
+    const req = makeRequest({ origin: "https://evil.example" });
+    const res = makeResponse();
+    let nextCalled = false;
+
+    protect(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.equal(nextCalled, false);
+  });
+
+  it("allows authenticated mutations from a configured origin", () => {
+    const req = makeRequest({ origin: "http://localhost:3000" });
+    const res = makeResponse();
+    let nextCalled = false;
+
+    protect(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true);
+    assert.equal(res.statusCode, null);
+  });
+
+  it("does not require an origin for safe or unauthenticated requests", () => {
+    for (const req of [
+      makeRequest({ method: "GET" }),
+      makeRequest({ authenticated: false }),
+    ]) {
+      const res = makeResponse();
+      let nextCalled = false;
+
+      protect(req, res, () => {
+        nextCalled = true;
+      });
+
+      assert.equal(nextCalled, true);
+      assert.equal(res.statusCode, null);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Reject authenticated cookie-session mutations that do not include an allowed browser origin.

## Rationale
The middleware provides the CSRF boundary for session-authenticated state changes while leaving safe methods, unauthenticated requests, and bearer-token login unaffected.

## Stack Context
- Position: 8 of 10
- Base PR: `security/http-boundaries`
- Depends on: PR #103

## Tests
- Missing-origin, untrusted-origin, trusted-origin, safe-method, and unauthenticated cases
- `node --test backend/test/csrf.test.js`
- Full backend suite passed during preparation.