### PR TITLE
chore(backend): migrate runtime to Mongoose 7

### DIFF
--- a/backend/models.js
+++ b/backend/models.js
@@ -10,6 +10,9 @@ import {
   eventReviewsSchema,
 } from "./schemas/schemas.js";
 
+// Preserve the Mongoose 6 unknown-filter behavior during the staged upgrade.
+mongoose.set("strictQuery", true);
+
 let models = {};
 
 async function connectToDatabase(){

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,436 +14,40 @@
         "dotenv-cli": "^7.0.0",
         "express": "^4.18.2",
         "express-session": "^1.17.3",
-        "mongoose": "^6.13.9",
+        "mongoose": "7.8.12",
         "morgan": "^1.12.0"
       }
     },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.977.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
-      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.37",
-        "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.31.1",
-        "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.66.tgz",
-      "integrity": "sha512-i4HTkP21eHaXA+XKoc6dYxlKPvYUqbusGGIsFRcSGTF8ln/q6RrWoRdVJ6UVODTCW59Ot1mVcbJXRAEf6kxa3w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
-      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
-      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
-      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-login": "^3.972.74",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.74",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
-      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.78",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
-      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-ini": "^3.973.12",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
-      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
-      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/token-providers": "3.1103.0",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.73",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
-      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.1106.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1106.0.tgz",
-      "integrity": "sha512-76a6HXmWZXgpQZRU3rnolfeMPPXrMvOfsQYlh7tkPXEgFrfdR6Hvo72uIQo57YVOBiOmVrwkTLA8NDNKbywTRQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-cognito-identity": "^3.972.66",
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-ini": "^3.973.12",
-        "@aws-sdk/credential-provider-login": "^3.972.74",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
-      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
-      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
-      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
-      "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.5.0.tgz",
+      "integrity": "sha512-Hk1SKJCMcCos38+vqDnZzlIo4XRj9yCGzYkjB4LcqpeXRIYfia1UWTz+VrueLxoU+uSRJzgkufxoRZg8gi52YA==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
     },
-    "node_modules/@smithy/core": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
-      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
-      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
-      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
-      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4": {
-      "version": "5.6.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
-      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@types/node": {
-      "version": "20.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.7.tgz",
-      "integrity": "sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
       "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
@@ -465,25 +69,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -520,45 +105,13 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/bson": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
-      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/bytes": {
@@ -1083,34 +636,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip-address": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
-      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1159,6 +693,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/merge-descriptors": {
@@ -1218,47 +753,72 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
-      "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^4.7.2",
+        "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
         "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongodb-connection-string-url": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
       "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
       }
     },
     "node_modules/mongoose": {
-      "version": "6.13.10",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.10.tgz",
-      "integrity": "sha512-5Xya7crlTwBrl3Gp1XCZMSnKI1WTLYzKkRdKaBiD51AprGtLQtgNoFO7v/qG0O5PixjfxzLuN3f3MChDOOFQOQ==",
+      "version": "7.8.12",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.12.tgz",
+      "integrity": "sha512-OLM9mdTuAc8oNDSJ9yoNtsMFFvHxQh/QAWR+yW0GwsXPywn/sdfHfOZnD2rZnNCMl7mo8EZM4zAK4ZOTuq7sMg==",
       "license": "MIT",
       "dependencies": {
-        "bson": "^4.7.2",
+        "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "4.17.2",
+        "mongodb": "5.9.2",
         "mpath": "0.9.0",
-        "mquery": "4.0.3",
+        "mquery": "5.0.0",
         "ms": "2.1.3",
         "sift": "16.0.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1299,22 +859,24 @@
       }
     },
     "node_modules/mquery": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
-      "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
       "dependencies": {
         "debug": "4.x"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/mquery/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1326,9 +888,10 @@
       }
     },
     "node_modules/mquery/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -1422,6 +985,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1636,6 +1200,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -1659,6 +1224,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
@@ -1686,19 +1252,13 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.1"
       },
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1725,9 +1285,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1758,6 +1319,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
@@ -1766,6 +1328,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
@@ -1790,329 +1353,21 @@
     }
   },
   "dependencies": {
-    "@aws-sdk/core": {
-      "version": "3.977.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
-      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.37",
-        "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.31.1",
-        "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.66.tgz",
-      "integrity": "sha512-i4HTkP21eHaXA+XKoc6dYxlKPvYUqbusGGIsFRcSGTF8ln/q6RrWoRdVJ6UVODTCW59Ot1mVcbJXRAEf6kxa3w==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-env": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
-      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-http": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
-      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-ini": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
-      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-login": "^3.972.74",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-login": {
-      "version": "3.972.74",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
-      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-node": {
-      "version": "3.972.78",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
-      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-ini": "^3.973.12",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-process": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
-      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-sso": {
-      "version": "3.973.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
-      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/token-providers": "3.1103.0",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.73",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
-      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/credential-providers": {
-      "version": "3.1106.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1106.0.tgz",
-      "integrity": "sha512-76a6HXmWZXgpQZRU3rnolfeMPPXrMvOfsQYlh7tkPXEgFrfdR6Hvo72uIQo57YVOBiOmVrwkTLA8NDNKbywTRQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-cognito-identity": "^3.972.66",
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-ini": "^3.973.12",
-        "@aws-sdk/credential-provider-login": "^3.972.74",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/nested-clients": {
-      "version": "3.997.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
-      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/token-providers": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
-      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
-      "optional": true,
-      "requires": {
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/xml-builder": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
-      "optional": true,
-      "requires": {
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws/lambda-invoke-store": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
-      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
-      "optional": true
-    },
     "@mongodb-js/saslprep": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
-      "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.5.0.tgz",
+      "integrity": "sha512-Hk1SKJCMcCos38+vqDnZzlIo4XRj9yCGzYkjB4LcqpeXRIYfia1UWTz+VrueLxoU+uSRJzgkufxoRZg8gi52YA==",
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
     },
-    "@smithy/core": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
-      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
-      "optional": true,
-      "requires": {
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/credential-provider-imds": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
-      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
-      "optional": true,
-      "requires": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/fetch-http-handler": {
-      "version": "5.6.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
-      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
-      "optional": true,
-      "requires": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/node-http-handler": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
-      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
-      "optional": true,
-      "requires": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/signature-v4": {
-      "version": "5.6.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
-      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
-      "optional": true,
-      "requires": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
     "@types/node": {
-      "version": "20.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.7.tgz",
-      "integrity": "sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~8.3.0"
       }
     },
     "@types/webidl-conversions": {
@@ -2143,11 +1398,6 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -2175,28 +1425,10 @@
         "unpipe": "~1.0.0"
       }
     },
-    "bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "optional": true
-    },
     "bson": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
-      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
-      "requires": {
-        "buffer": "^5.6.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g=="
     },
     "bytes": {
       "version": "3.1.2",
@@ -2531,20 +1763,15 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ip-address": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
-      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -2611,13 +1838,12 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mongodb": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
-      "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "requires": {
-        "@aws-sdk/credential-providers": "^3.186.0",
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^4.7.2",
+        "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       }
@@ -2632,15 +1858,15 @@
       }
     },
     "mongoose": {
-      "version": "6.13.10",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.10.tgz",
-      "integrity": "sha512-5Xya7crlTwBrl3Gp1XCZMSnKI1WTLYzKkRdKaBiD51AprGtLQtgNoFO7v/qG0O5PixjfxzLuN3f3MChDOOFQOQ==",
+      "version": "7.8.12",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.12.tgz",
+      "integrity": "sha512-OLM9mdTuAc8oNDSJ9yoNtsMFFvHxQh/QAWR+yW0GwsXPywn/sdfHfOZnD2rZnNCMl7mo8EZM4zAK4ZOTuq7sMg==",
       "requires": {
-        "bson": "^4.7.2",
+        "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "4.17.2",
+        "mongodb": "5.9.2",
         "mpath": "0.9.0",
-        "mquery": "4.0.3",
+        "mquery": "5.0.0",
         "ms": "2.1.3",
         "sift": "16.0.1"
       },
@@ -2670,25 +1896,25 @@
       "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
     },
     "mquery": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
-      "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
       "requires": {
         "debug": "4.x"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -2940,12 +2166,6 @@
         "punycode": "^2.1.1"
       }
     },
-    "tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "optional": true
-    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -2964,9 +2184,9 @@
       }
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,7 @@
     "dotenv-cli": "^7.0.0",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
-    "mongoose": "^6.13.9",
+    "mongoose": "7.8.12",
     "morgan": "^1.12.0"
   }
 }

--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -75,7 +75,7 @@ router.get("/", async function (req, res) {
       const events = await req.models.Events.find({})
         .populate("eParticipants")
         .exec();
-      const userObjectId = mongoose.Types.ObjectId(req.session.userId);
+      const userObjectId = new mongoose.Types.ObjectId(req.session.userId);
 
       const eventsData = await Promise.all(
         events.map(async (event) => {
@@ -165,7 +165,7 @@ router.get("/id/:eId", async function (req, res) {
     let hasRSVPd = false;
     let rsvpAnswers = [];
     if (req.session.isAuthenticated) {
-      const userObjectId = mongoose.Types.ObjectId(req.session.userId);
+      const userObjectId = new mongoose.Types.ObjectId(req.session.userId);
       const participant = await req.models.Participants.findOne({
         pUID: userObjectId,
         eID: eId,
@@ -289,7 +289,7 @@ router.post("/rsvp", requireAuth, async function (req, res) {
     const event = await req.models.Events.findById(eId)
       .populate("eParticipants")
       .exec();
-    const userObjectId = mongoose.Types.ObjectId(req.session.userId);
+    const userObjectId = new mongoose.Types.ObjectId(req.session.userId);
 
     if (!event) {
       return sendError(res, 404, "Event not found");


### PR DESCRIPTION
## Summary

Migrate the backend runtime from Mongoose 6 to Mongoose 7. The change updates the MongoDB driver line, makes strict-query behavior explicit, and uses the cross-version ObjectId constructor form.

## Rationale

Mongoose 7 removes callable ObjectId construction and changes the strictQuery default. This PR preserves established route/query behavior while moving the backend through the required intermediate major.

## Stack Context

- Position: 2 of 4
- Base: `chore/mongoose-baseline`
- Depends on: #108

## Tests

- Backend suite on current `origin/dev`: 75 passed, 0 failed
- Dependency tree: Mongoose 7.8.12 / MongoDB 5.9.2
- Event ObjectId and strict-query production behavior verified