### PR TITLE
docs(stylesheets): document adopted 7-1 folder structure

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -56,11 +56,11 @@ frontend/src/
 └── stylesheets/
     ├── main.scss          ← Central import file (7-1 architecture)
     ├── abstracts/         ← Variables, mixins, functions, media queries
+    ├── vendors/           ← Vendored third-party styles (include-media, toastify)
     ├── base/              ← Reset, typography, colors, misc
-    ├── components/        ← Component-specific styles
     ├── layout/            ← Container, split responsive navigation, footer, form
-    ├── pages/             ← Page-specific styles (e.g., _getInvolved.scss for page and member-card styles)
-    └── addons/            ← Third-party overrides (toastify)
+    ├── components/        ← Component-specific styles
+    └── pages/             ← Page-specific styles (e.g., _getInvolved.scss for page and member-card styles)
 ```
 
 ### Shared navigation
@@ -148,7 +148,9 @@ The backend creates **server-side sessions** (express-session), so the frontend 
 
 - **SCSS** with [7-1 architecture](https://sass-guidelin.es/#architecture)
 - Compiled via `sass` (devDependency)
-- Main entry: `src/stylesheets/main.scss` — imports all partials
+- Main entry: `src/stylesheets/main.scss` — imports only; no CSS rules
+- Import order in `main.scss` follows the 7-1 convention: abstracts → vendors → base → layout → components → pages
+- All design tokens (colors, fonts, spacing, radii, breakpoints) live in `abstracts/_variables.scss` and follow the `$[token-type]-*` naming convention
 - Fonts: **NotoSans** (body) and **PlayfairDisplay** (headings), served from `public/font/`
 - Responsive breakpoints: mobile below `768px`, tablet/desktop at `768px` and above,
   with the sm-desktop breakpoint at `1024px`

--- a/frontend/src/stylesheets/README.md
+++ b/frontend/src/stylesheets/README.md
@@ -1,2 +1,20 @@
 # Stylesheets for the IUGA Web Application
 - [7-1 Architecture](https://sass-guidelin.es/#architecture)
+
+## Folder structure
+
+| Folder | Purpose |
+|---|---|
+| `abstracts/` | Design tokens (`_variables.scss`) and shared mixins (`_mixins.scss`) |
+| `base/` | Global element styles: reset, typography, color utilities, misc helpers |
+| `vendors/` | Third-party library overrides (include-media, toastify) |
+| `layout/` | Structural components: container, responsive navigation, footer, form |
+| `components/` | Reusable UI: buttons, cards, calendar, tags, sidebar, etc. |
+| `pages/` | Page-specific styles (home, events, resources, etc.) |
+
+## Conventions
+
+- `main.scss` is an import-only file — no CSS rules, just `@import` statements
+- Import order: abstracts → vendors → base → layout → components → pages
+- All color and font variables use the `$color-*` naming convention
+- All variables are centralized in `abstracts/_variables.scss`


### PR DESCRIPTION
Updates frontend stylesheet documentation to reflect the 7-1 folder structure adopted in #115.

## Changes
- **FRONTEND.md**: replace directory layout with current 7-1 structure; expand Styling section with import order, token conventions, and `abstracts/_variables.scss` role
- **stylesheets/README.md**: expand from a single link into a folder table and conventions summary