### PR TITLE
docs(dev): document root startup commands

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,13 +12,15 @@
 ## Quick Start
 
 ```bash
-# Install everything and run in dev mode
-npm run dev
+# Run these commands from the repository root.
+# Install dependencies once
+npm run setup
+
+# Start frontend and backend concurrently
+npm start
+# npm run dev is an equivalent command
 ```
-
-This runs: `cd frontend; npm install && npm run build -- --mode development && cd ../backend; npm install && npm start`.
-
-The app is served at **http://localhost:7777**.
+`npm start` and `npm run dev` are equivalent. Both start the Vite frontend with hot reload at **http://localhost:3000** and the Express backend at **http://localhost:7777** concurrently. Neither command reinstalls dependencies; run `npm run setup` once first.
 
 ---
 
@@ -26,10 +28,10 @@ The app is served at **http://localhost:7777**.
 
 | Command | What it does |
 |---|---|
-| `npm run frontend` | Install dependencies and start Vite dev server on `:3000` |
-| `npm run backend`  | Install and start Express on `:7777` (uses production build of frontend) |
+| `npm run frontend` | Start Vite dev server only on `:3000` |
+| `npm run backend`  | Start Express on `:7777` (dev env) |
 | `npm run backend-debug` | Start backend with debug logging |
-| `npm run debug`    | Full rebuild + backend with debug logging |
+| `npm run debug`    | Legacy frontend build + backend debug mode |
 
 ### Frontend-only development
 
@@ -101,12 +103,13 @@ When the frontend runs on Vite at `http://localhost:3000`, the browser sends tha
 
 | Script | Action |
 |---|---|
-| `npm run dev` | Build frontend → start backend (dev env) |
+| `npm start` | Start Vite frontend and Express backend concurrently |
+| `npm run dev` | Same as `npm start` |
 | `npm run debug` | Build frontend → start backend (debug env) |
 | `npm run frontend` | Start Vite dev server only |
-| `npm run backend` | Install + start backend (dev env) |
+| `npm run backend` | Start backend (dev env) |
 | `npm run backend-dev` | Same as above |
-| `npm run backend-debug` | Install + start backend (debug env) |
+| `npm run backend-debug` | Start backend (debug env) |
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,4 +1,3 @@
-# Quickstart Guide
 
 Get the **Informatics Undergraduate Association (IUGA)** website running on your machine for development.
 
@@ -22,26 +21,31 @@ cd iuga-web-app
 
 # If you already cloned without --recurse-submodules:
 git submodule update --init --recursive
-```
+
+# Install root, backend, and frontend dependencies
+npm run setup
 
 ---
 
 ## Running the App
 
+Run the following commands from the repository root unless otherwise noted.
+
 ### Full stack (one command)
 
+Run this from the repository root:
+
 ```bash
-npm run dev
+npm start
+# npm run dev is an equivalent command
 ```
 
-This builds the frontend and starts the Express backend at **http://localhost:7777**.
+This starts the Vite frontend with hot reload at **http://localhost:3000** and the Express backend at **http://localhost:7777** concurrently.
 
 ### Frontend only (hot reload)
-
 ```bash
-cd frontend
-npm install
-npm start
+npm run frontend
+or cd frontend (from the root dir) && npm start
 ```
 
 Starts the Vite dev server on **http://localhost:3000** with hot reload. The frontend uses **mock data** — no backend or database needed.
@@ -49,15 +53,11 @@ Starts the Vite dev server on **http://localhost:3000** with hot reload. The fro
 ### Backend only
 
 ```bash
-cd backend
-npm install
-npm start                    # uses env/.env.dev
+npm run backend-dev
+or cd backend (from the root dir) && npm start
 ```
 
-The backend requires:
-1. A built frontend at `../frontend/build/` (run `VITE_API_URL=http://localhost:7777 npm run build` in `frontend/`)
-2. An environment file loaded by the selected backend script
-3. A MongoDB connection (Atlas for development)
+The backend runs on **http://localhost:7777** and requires an environment file plus a MongoDB connection.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -5,6 +5,17 @@
 > **Reference:** [Deployment Guide](DEPLOYMENT.md), [Maintainers Guide](MAINTAINERS.md).
 
 ---
+## Local development sign-in
+
+If clicking sign-in shows a backend/Docker reminder, start the Docker-based MongoDB environment used for local development, then run:
+
+```bash
+npm run dev
+```
+
+Development checks `http://localhost:7777/readyz` before redirecting to UW NetID. This prevents a missing local MongoDB/backend from leaving the developer on a blank or incomplete authentication flow. Production does not run this local Docker check.
+
+---
 
 ## 1. Pipeline Failures
 


### PR DESCRIPTION
## Summary

Document root `npm start` as the combined frontend/backend development command and clarify that root commands must be run from the repository root. Add local sign-in troubleshooting guidance.

## Rationale

The previous documentation did not clearly distinguish root scripts from package-level `npm start` commands. The updated guidance makes combined, frontend-only, and backend-only startup paths unambiguous.

## Tests

- Documentation formatting checked with `git diff --check`.
- Root `npm start` smoke test verified both services start concurrently.