### PR TITLE
fix(ci): use BuildKit for Docker image builds

### DIFF
--- a/ci/deploy.groovy
+++ b/ci/deploy.groovy
@@ -14,9 +14,11 @@ Expected Response Information:
 */
 
 
-// Build an immutable, build-numbered image tag.
+// Build an immutable, build-numbered image tag with BuildKit. The Jenkins
+// agent image provides the buildx plugin, and --load makes the result available
+// to the Docker Engine for the later push/pull/deploy steps.
 void buildImage(Map cfg) {
-    sh "docker build . -t \"${cfg.image}:${env.BUILD_NUMBER}\" --build-arg DEPLOY_ENV=${cfg.deployEnv} --build-arg VITE_API_URL=${cfg.apiUrl}"
+    sh "docker buildx build --load . -t \"${cfg.image}:${env.BUILD_NUMBER}\" --build-arg DEPLOY_ENV=${cfg.deployEnv} --build-arg VITE_API_URL=${cfg.apiUrl}"
 }
 
 // Push the build-numbered image to the registry.


### PR DESCRIPTION
## Summary

Use `docker buildx build --load` in the shared Jenkins deployment helper.

## Rationale

The Dockerfile uses BuildKit cache mounts, but the previous `docker build` invocation used Jenkins' legacy builder. `--load` keeps the built image available to the local Docker engine for the existing push and deployment stages.

## Tests

- Backend tests: 75 passed
- Frontend tests: 73 passed
- Frontend production build passed
- `git diff --check`
- Local Docker Buildx availability check