### PR TITLE
fix(routing): serve SPA shell for client routes

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -15,6 +15,7 @@ import {
 import { httpErrorHandler, sendSpaError } from "./httpErrorHandler.js";
 import { ALLOWED_ORIGINS, REQUEST_BODY_LIMIT } from "./httpBoundaryConfig.js";
 import { createCsrfProtection } from "./routes/api/v1/utils/csrf.js";
+import { createSpaRouter } from "./spaRoutes.js";
 
 import { fileURLToPath } from "url";
 import { dirname } from "path";
@@ -36,7 +37,6 @@ const apiRateLimiter = createRateLimiter({
   limit: 100,
   windowMs: 15 * 60_000,
 });
-
 
 // Readiness probe for the pipeline health gate. The listener only starts
 // after the DB connects, so 200 implies the database is reachable.
@@ -146,106 +146,18 @@ app.use((req, res, next) => {
 });
 
 /*
-Purpose: Serve the compiled SPA shell for the root route.
+Purpose: Serve the compiled SPA shell for every registered client-side route.
 Authentication/Authorization Requirements: None
 
 Expected Response Information:
-- Return index.html so React Router can render the application.
+- Return index.html so React Router can render the requested application page.
 - Return a safe server error if index.html cannot be read.
 */
-app.get("/", function (req, res) {
-  res.sendFile(
-    path.join(__dirname, "../frontend/build/index.html"),
-    function (err) {
-      if (err) sendSpaError(res, err);
-    },
-  );
-});
-
-/*
-Purpose: Serve the compiled SPA shell for direct navigation to /events.
-Authentication/Authorization Requirements: None
-
-Expected Response Information:
-- Return index.html so React Router can render the events page.
-- Return a safe server error if index.html cannot be read.
-*/
-app.get("/events", function (req, res) {
-  res.sendFile(
-    path.join(__dirname, "../frontend/build/index.html"),
-    function (err) {
-      if (err) sendSpaError(res, err);
-    },
-  );
-});
-
-/*
-Purpose: Serve the compiled SPA shell for direct navigation to /resources.
-Authentication/Authorization Requirements: None
-
-Expected Response Information:
-- Return index.html so React Router can render the resources page.
-- Return a safe server error if index.html cannot be read.
-*/
-app.get("/resources", function (req, res) {
-  res.sendFile(
-    path.join(__dirname, "../frontend/build/index.html"),
-    function (err) {
-      if (err) sendSpaError(res, err);
-    },
-  );
-});
-
-/*
-Purpose: Serve the compiled SPA shell for direct navigation to /electionfaq.
-Authentication/Authorization Requirements: None
-
-Expected Response Information:
-- Return index.html so React Router can render the election FAQ page.
-- Return a safe server error if index.html cannot be read.
-*/
-app.get("/electionfaq", function (req, res) {
-  res.sendFile(
-    path.join(__dirname, "../frontend/build/index.html"),
-    function (err) {
-      if (err) sendSpaError(res, err);
-    },
-  );
-});
-
-/*
-Purpose: Serve the compiled SPA shell for direct navigation to /contact.
-Authentication/Authorization Requirements: None
-
-Expected Response Information:
-- Return index.html so React Router can render the contact page.
-- Return a safe server error if index.html cannot be read.
-*/
-app.get("/contact", function (req, res) {
-  res.sendFile(
-    path.join(__dirname, "../frontend/build/index.html"),
-    function (err) {
-      if (err) sendSpaError(res, err);
-    },
-  );
-});
-
-/*
-Purpose: Serve the compiled SPA shell for direct navigation to /get-involved.
-Authentication/Authorization Requirements: None
-
-Expected Response Information:
-- Return index.html so React Router can render the get-involved page.
-- Return a safe server error if index.html cannot be read.
-*/
-app.get("/get-involved", function (req, res) {
-  res.sendFile(
-    path.join(__dirname, "../frontend/build/index.html"),
-    function (err) {
-      if (err) sendSpaError(res, err);
-    },
-  );
-});
+app.use(
+  createSpaRouter({
+    indexPath: path.join(__dirname, "../frontend/build/index.html"),
+  }),
+);
 
 /*
 Purpose: Serve uploaded public assets from the backend upload directory.

--- a/backend/spaRoutes.js
+++ b/backend/spaRoutes.js
@@ -1,0 +1,33 @@
+/*
+ * Purpose: Serve the compiled SPA shell for browser routes that may be loaded directly.
+ * Auth/Authorization Requirements: None; route access remains enforced by API middleware.
+ * Expected Request: A GET request for one of the frontend's client-side routes.
+ * Expected Response: The compiled frontend index.html document.
+ */
+
+import express from "express";
+import { fileURLToPath } from "node:url";
+
+export const SPA_ROUTES = [
+  "/",
+  "/events",
+  "/resources",
+  "/student-voice",
+  "/shop",
+  "/elections",
+  "/electionfaq",
+  "/about",
+  "/get-involved",
+  "/contact",
+];
+
+export function createSpaRouter({ indexPath }) {
+  const router = express.Router();
+  const shellPath = indexPath instanceof URL ? fileURLToPath(indexPath) : indexPath;
+
+  router.get(SPA_ROUTES, (req, res, next) => {
+    res.sendFile(shellPath, next);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Serve the compiled React SPA shell for every registered frontend route, including `/shop`.

## Rationale

Client-side navigation to `/shop` worked after the application loaded, but refreshing or directly visiting the route returned `Cannot GET /shop` because Express had no matching SPA route. Centralizing the route list keeps browser navigation and server-side direct requests aligned without intercepting API paths.

## Tests

- SPA route regression test passed
- Backend tests: 76 passed
- Frontend tests: 73 passed
- Frontend production build passed
- `git diff --check` passed