### PR TITLE
fix(auth): use popup login to prevent full-page reload and screen flicker

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -71,13 +71,11 @@ export const AuthProvider = ({ children }) => {
   const signIn = async () => {
     try {
       await ensureDevelopmentBackend();
-      await instance.loginRedirect();
-      console.log("Acquire token silently...")
+      await instance.loginPopup(loginRequest);
     } catch (error) {
       if (error.errorCode === "invalid_grant" || error.errorCode === "consent_required") {
-        console.log("error")
         try {
-          await instance.loginRedirect({
+          await instance.loginPopup({
             ...loginRequest,
             prompt: "consent"
           });
@@ -87,7 +85,7 @@ export const AuthProvider = ({ children }) => {
         }
       } else {
         setUser({});
-        setLoginState(false)
+        setLoginState(false);
         setAuthError(error);
       }
     }

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -1,8 +1,12 @@
-// src/hooks/useAuth.js
+/*
+ * Purpose: Custom React hook for acquiring MSAL access tokens and synchronizing backend sessions.
+ * Authentication/Authorization Requirements: Used internally by AuthProvider.
+ * Expected Request: ensureBackendAuthentication() invoked when MSAL accounts are available.
+ * Expected Response: Authenticated user profile returned from /api/v1/user/login.
+ */
 import { useMsal } from '@azure/msal-react';
 import { loginRequest } from '../authConfig';
-import { InteractionRequiredAuthError, EventType } from '@azure/msal-browser';
-
+import { InteractionRequiredAuthError } from '@azure/msal-browser';
 const useAuth = () => {
   const { instance, accounts } = useMsal();
 
@@ -20,7 +24,7 @@ const useAuth = () => {
         if (error instanceof InteractionRequiredAuthError) {
           console.error('Interaction required to acquire token:', error);
           try {
-            const tokenResponse = await instance.acquireTokenRedirect({
+            const tokenResponse = await instance.acquireTokenPopup({
               ...loginRequest,
               account: accounts[0],
               prompt: 'consent',


### PR DESCRIPTION
## Summary

Switches sign-in from full-page redirects (`loginRedirect`) to in-place popups (`loginPopup`).

Previously, clicking "UW NetID Login" redirected your entire browser window to Microsoft and back, reloading all page assets, re-mounting React, and resetting your scroll position—making the screen twitch and shake. 

Now, Microsoft authentication happens in an isolated popup window. If you're already signed into your UW NetID, the popup verifies your login and closes instantly, updating your navbar button to "Hi, [Name]" right on the page without any reload or screen shake.

## Tests

- Ran `npm test`: all 149 tests passed (76 backend, 73 frontend).
- Ran frontend build: clean build passed (`npm run build --prefix frontend`).
