### PR TITLE
build(ci): scope submodule initialization to backend/schemas

### DIFF
--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -7,7 +7,7 @@ Purpose: CI/CD pipeline for the dev environment (dev.iuga.info). Builds, pushes,
 Authentication/Authorization Requirements: N/A (Jenkins job, triggered by GitHub push webhook)
 
 Expected Request Information:
-- SCM: checks out the `dev` branch with its submodules
+- SCM: checks out the `dev` branch and initializes the `backend/schemas` submodule
 - Credentials used (Configure Jenkins > Credentials): dockerhub (image push),
   DB_URI, SESSION_SECRET (runtime env vars)
 - cfg (Map): per-environment values passed to the shared deploy helpers
@@ -55,7 +55,6 @@ pipeline {
                     $class: 'GitSCM',
                     branches: [[name: '*/dev']],
                     doGenerateSubmoduleConfigurations: false,
-                    extensions: [[$class: 'SubmoduleOption', recursiveSubmodules: true, trackingSubmodules: false]],
                     submoduleCfg: [],
                     userRemoteConfigs: [[
                         credentialsId: 'github_classic',
@@ -68,7 +67,7 @@ pipeline {
         }
         stage('Initialize Submodules') {
             steps {
-                sh 'git submodule update --init --recursive'
+                sh 'git submodule update --init backend/schemas'
             }
         }
         stage('Build') {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -168,7 +168,7 @@ When the frontend runs on Vite at `http://localhost:3000`, the browser sends tha
 
 ```bash
 # After cloning this repo
-git submodule update --init --recursive
+git submodule update --init backend/schemas
 
 # After updating schemas in the remote
 git submodule update --remote

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -20,7 +20,7 @@ git clone --recurse-submodules https://github.com/UW-IUGA/iuga-web-app
 cd iuga-web-app
 
 # If you already cloned without --recurse-submodules:
-git submodule update --init --recursive
+git submodule update --init backend/schemas
 
 # Install root, backend, and frontend dependencies
 npm run setup

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "backend": "cd backend && npm start",
     "backend-dev": "cd backend && npm start",
     "backend-debug": "cd backend && npm run debug",
-    "setup": "npm ci && npm ci --prefix backend && npm ci --prefix frontend && git submodule update --init --recursive"
+    "setup": "npm ci && npm ci --prefix backend && npm ci --prefix frontend && git submodule update --init backend/schemas"
   },
   "devDependencies": {
     "concurrently": "^9.2.4"

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -7,7 +7,7 @@ Purpose: CI/CD pipeline for the production environment (iuga.info). Builds, push
 Authentication/Authorization Requirements: N/A (Jenkins job, triggered by GitHub push webhook)
 
 Expected Request Information:
-- SCM: checks out the `main` branch with its submodules
+- SCM: checks out the `main` branch and initializes the `backend/schemas` submodule
 - Credentials used (Configure Jenkins > Credentials): dockerhub (image push),
   DB_URI, SESSION_SECRET (runtime env vars)
 - cfg (Map): per-environment values passed to the shared deploy helpers
@@ -56,7 +56,6 @@ pipeline {
                     $class: 'GitSCM',
                     branches: [[name: '*/main']],
                     doGenerateSubmoduleConfigurations: false,
-                    extensions: [[$class: 'SubmoduleOption', recursiveSubmodules: true, trackingSubmodules: false]],
                     submoduleCfg: [],
                     userRemoteConfigs: [[
                         credentialsId: 'github_classic',
@@ -69,7 +68,7 @@ pipeline {
         }
         stage('Initialize Submodules') {
             steps {
-                sh 'git submodule update --init --recursive'
+                sh 'git submodule update --init backend/schemas'
             }
         }
         stage('Build') {

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
             steps {
                 setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Checking out repository...')
                 checkout scm
-                sh 'git submodule update --init --recursive'
+                sh 'git submodule update --init backend/schemas'
                 // load needs a workspace; the file is only present after checkout
                 script { deploy = load 'ci/deploy.groovy' }
             }


### PR DESCRIPTION
## Summary & Rationale

Previously, Jenkins deployment pipelines and developer setup scripts ran `git submodule update --init --recursive`, instructing Git to fetch every submodule listed in `.gitmodules`. When non-application or private submodules exist, this blanket checkout fails with permission errors, breaking deployments and local onboarding.

This change scopes the Jenkins checkout stages (`dev`, `staging`, and `prod`) and the root `npm run setup` script explicitly to `backend/schemas`. Builds and developer setups now initialize only the Mongoose schemas required by the application runtime, preventing deployment failures while keeping other submodules optional.

## Verification

- `npm run setup`: verified `git submodule update --init backend/schemas` checks out the schema submodule cleanly without touching other paths.
- `npm test`: verified the full backend test runner (23 test suites, 76 tests pass) and frontend Vitest suite (11 test files, 73 tests pass).
- `VITE_API_URL=https://dev.iuga.info npm run build --prefix frontend`: verified the production client build bundles successfully.
