### PR TITLE
fix(session): resolve signing secret by deployment environment

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,7 +8,12 @@
 DEPLOY_ENV=development
 DB_URI=mongodb://127.0.0.1:27017/iuga_dev
 PORT=7777
-SESSION_SECRET=replace-with-a-random-secret
+# The app selects the session secret by DEPLOY_ENV (backend/app.js): the
+# development/staging/production builds read SESSION_SECRET_DEV/_STAGING/_PROD.
+# A local .env.dev only needs SESSION_SECRET_DEV.
+SESSION_SECRET_DEV=replace-with-a-random-secret
+# SESSION_SECRET_STAGING=replace-with-a-random-secret
+# SESSION_SECRET_PROD=replace-with-a-random-secret
 
 SMTP_HOST=smtp.uw.edu
 SMTP_PORT=587

--- a/backend/app.js
+++ b/backend/app.js
@@ -23,9 +23,17 @@ import { dirname } from "path";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const sessionSecret = process.env.SESSION_SECRET?.trim();
+// Session signing secret is per deployment environment so one env source can
+// hold all three. DEPLOY_ENV is injected in every container (deploy.groovy).
+const secretKeyByEnv = {
+  development: "SESSION_SECRET_DEV",
+  staging: "SESSION_SECRET_STAGING",
+  production: "SESSION_SECRET_PROD",
+};
+const secretKey = secretKeyByEnv[process.env.DEPLOY_ENV] ?? "SESSION_SECRET";
+const sessionSecret = process.env[secretKey]?.trim();
 if (!sessionSecret) {
-  console.error("FATAL: SESSION_SECRET not set");
+  console.error(`FATAL: ${secretKey} not set`);
   process.exit(1);
 }
 

--- a/backend/test/session-config.test.js
+++ b/backend/test/session-config.test.js
@@ -6,19 +6,20 @@ import { createSessionOptions } from "../sessionConfig.js";
 
 const appPath = fileURLToPath(new URL("../app.js", import.meta.url));
 
-test("startup fails before database connection when SESSION_SECRET is missing", () => {
+test("startup fails before database connection when the development session secret is missing", () => {
   const result = spawnSync(process.execPath, [appPath], {
     encoding: "utf8",
     env: {
       ...process.env,
-      SESSION_SECRET: "",
+      DEPLOY_ENV: "development",
+      SESSION_SECRET_DEV: "",
       DB_URI: "mongodb://127.0.0.1:1/unreachable",
     },
   });
 
   const output = `${result.stdout}\n${result.stderr}`;
   assert.notEqual(result.status, 0);
-  assert.match(output, /FATAL: SESSION_SECRET not set/);
+  assert.match(output, /FATAL: SESSION_SECRET_DEV not set/);
   assert.doesNotMatch(output, /\[startup\] connecting to mongodb/);
 });
 

--- a/ci/deploy.groovy
+++ b/ci/deploy.groovy
@@ -34,6 +34,9 @@ void healthGatedDeploy(Map cfg) {
     def newImage = "${cfg.image}:${env.BUILD_NUMBER}"
     def lastGoodImage = "${cfg.image}:last-good"
     def netFlag = cfg.network ? "--network iuga-server-config_default" : ""
+    // Forward the deployment-specific secret under its own runtime name so the
+    // app can select it by DEPLOY_ENV (backend/app.js).
+    def secretEnv = cfg.deployEnv == 'development' ? 'SESSION_SECRET_DEV' : cfg.deployEnv == 'staging' ? 'SESSION_SECRET_STAGING' : 'SESSION_SECRET_PROD'
     sh """
     CANDIDATE="${cfg.container}-candidate"
     CONTAINER="${cfg.container}"
@@ -49,7 +52,7 @@ void healthGatedDeploy(Map cfg) {
       docker run -d --name "\$1" -p "127.0.0.1:\$2:7777" \\
         -e DEPLOY_ENV=${cfg.deployEnv} \\
         -e DB_URI="\$DB_URI" \\
-        -e SESSION_SECRET="\$SESSION_SECRET" \\
+        -e ${secretEnv}="\$${secretEnv}" \\
         -v ${cfg.uploadsDir}:/app/backend/public/uploads \\
         ${netFlag}\\
         "\$3"

--- a/ci/test/deploy-groovy.test.js
+++ b/ci/test/deploy-groovy.test.js
@@ -36,6 +36,7 @@ function extractShell() {
         '${cfg.deployEnv}': 'development',
         '${cfg.uploadsDir}': '/tmp/iuga-test-uploads',
         '${netFlag}': '',
+        '${secretEnv}': 'SESSION_SECRET_DEV',
         '${newImage}': 'iuga/test-app:123',
         '${lastGoodImage}': 'iuga/test-app:last-good',
     }
@@ -69,7 +70,7 @@ function runDeploy(stubScript) {
         STUB_LOG: logFile,
         COUNTER_FILE: path.join(dir, 'count'),
         DB_URI: 'mongodb://test-db',
-        SESSION_SECRET: 'test-secret',
+        SESSION_SECRET_DEV: 'test-secret',
     }
     let status = 0
     try {
@@ -95,6 +96,9 @@ test('healthy candidate is promoted to the live port; last-good untouched', () =
     assert.equal(candidateRun.length, 2)
     assert.ok(candidateRun[0].includes('--name iuga-test-candidate') && candidateRun[0].includes('127.0.0.1:16667:7777'))
     assert.ok(candidateRun[1].includes('--name iuga-test') && candidateRun[1].includes('127.0.0.1:16666:7777'))
+    // The app receives the deployment-specific secret under its suffixed name
+    // (bash expands the "$SESSION_SECRET_DEV" reference before docker runs).
+    assert.ok(candidateRun.every((c) => c.includes('-e SESSION_SECRET_DEV=test-secret')))
     // Health checks run inside the container against the app's own port.
     const probes = runCalls(calls, 'fetch("http://127.0.0.1:7777/readyz")')
     assert.equal(probes.length, 2)

--- a/ci/test/e2e-deploy.sh
+++ b/ci/test/e2e-deploy.sh
@@ -21,7 +21,7 @@
 #   - Uses only loopback host ports: 16766 (live), 16767 (candidate),
 #     5011 (registry). Never touches live ports 6666/6667/7777/8888.
 #   - Every resource is prefixed iuga-e2e-* and removed on exit via trap.
-#   - Test-only DB_URI/SESSION_SECRET; never touches real databases.
+#   - Test-only DB_URI/SESSION_SECRET_DEV; never touches real databases.
 #
 # Requirements
 #   - A running Docker daemon (e.g. Docker Desktop)
@@ -143,7 +143,7 @@ bash -n /tmp/iuga-e2e-deploy.sh  # the extracted script must parse
 echo
 echo "=== running the real deploy sequence ==="
 DB_URI="mongodb://iuga-e2e-mongo:27017/iuga_e2e" \
-SESSION_SECRET="e2e-secret" \
+SESSION_SECRET_DEV="e2e-secret" \
     bash /tmp/iuga-e2e-deploy.sh
 
 # --- Verification -----------------------------------------------------------

--- a/dev.jenkinsfile
+++ b/dev.jenkinsfile
@@ -9,7 +9,7 @@ Authentication/Authorization Requirements: N/A (Jenkins job, triggered by GitHub
 Expected Request Information:
 - SCM: checks out the `dev` branch and initializes the `backend/schemas` submodule
 - Credentials used (Configure Jenkins > Credentials): dockerhub (image push),
-  DB_URI, SESSION_SECRET (runtime env vars)
+  DB_URI, SESSION_SECRET_DEV (runtime env var)
 - cfg (Map): per-environment values passed to the shared deploy helpers
 
 Expected Response Information:
@@ -89,7 +89,7 @@ pipeline {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/dev", "pending", "Deploying application...");
                 withCredentials([
                     string(credentialsId: 'DB_URI', variable: 'DB_URI'),
-                    string(credentialsId: 'SESSION_SECRET_DEV', variable: 'SESSION_SECRET'),
+                    string(credentialsId: 'SESSION_SECRET_DEV', variable: 'SESSION_SECRET_DEV'),
                 ]) {
                     script { deploy.healthGatedDeploy(cfg) }
                 }

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -207,7 +207,7 @@ Attach them in the route chain, e.g. `router.post("/", requireAuth, handler)` or
 
 The application applies these checks before API handlers:
 
-- `SESSION_SECRET` must be supplied at startup; there is no source-controlled fallback.
+- The session signing secret is supplied at startup from the deployment-matching variable (`SESSION_SECRET_DEV`, `SESSION_SECRET_STAGING`, or `SESSION_SECRET_PROD`, chosen by `DEPLOY_ENV`); there is no source-controlled fallback.
 - Session cookies are `httpOnly`, use `SameSite=Lax`, and are `secure` in staging and production.
 - Authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests must include an allowed browser `Origin`. Login is exempt because it uses a Microsoft Bearer token instead of a session cookie.
 - CORS allows only `http://localhost:3000`, `http://localhost:5173`, and the documented IUGA domains. Backend ports such as `7777` are not browser origins.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -37,7 +37,7 @@ Every environment (dev, staging, production) follows the same five-stage pipelin
 - **Host port:** `6666` → container port `7777`
 - **Network:** None (default bridge)
 - **Volume:** `/var/lib/iuga-web-app/uploads/dev:/app/backend/public/uploads`
-- **DB credentials:** `DB_URI` (Jenkins Secret text credential, injected as `DB_URI` env var), `SESSION_SECRET_DEV` (injected as runtime `SESSION_SECRET`)
+- **DB credentials:** `DB_URI` (Jenkins Secret text credential, injected as `DB_URI` env var), `SESSION_SECRET_DEV` (injected as runtime `SESSION_SECRET_DEV`)
 - **Database:** MongoDB Atlas (dev database)
 - **Deploy pattern:** health-gated candidate swap; temp port `6667` → live port `6666`; tags images `:${BUILD_NUMBER}` and `:last-good`
 - **Commit status context:** `iuga/jenkins/cicd/dev`
@@ -50,7 +50,7 @@ Every environment (dev, staging, production) follows the same five-stage pipelin
 - **Host port:** `7777` → container port `7777`
 - **Network:** `iuga-server-config_default`
 - **Volume:** `/var/lib/iuga-web-app/uploads/staging:/app/backend/public/uploads`
-- **DB credentials:** `DB_URI` (Jenkins Secret text credential, injected as `DB_URI` env var), `SESSION_SECRET_STAGING` (injected as runtime `SESSION_SECRET`)
+- **DB credentials:** `DB_URI` (Jenkins Secret text credential, injected as `DB_URI` env var), `SESSION_SECRET_STAGING` (injected as runtime `SESSION_SECRET_STAGING`)
 - **Database:** MongoDB container at `mongo:27017` (via `iuga-server-config_default` network)
 - **Deploy pattern:** health-gated candidate swap; temp port `7778` → live port `7777`; tags images `:${BUILD_NUMBER}` and `:last-good`
 - **Commit status context:** `iuga/jenkins/cicd/staging`
@@ -62,7 +62,7 @@ Every environment (dev, staging, production) follows the same five-stage pipelin
 - **Host port:** `8888` → container port `7777`
 - **Network:** `iuga-server-config_default`
 - **Volume:** `/var/lib/iuga-web-app/uploads/prod:/app/backend/public/uploads`
-- **DB credentials:** `DB_URI` (Jenkins Secret text credential, injected as `DB_URI` env var), `SESSION_SECRET_PROD` (injected as runtime `SESSION_SECRET`)
+- **DB credentials:** `DB_URI` (Jenkins Secret text credential, injected as `DB_URI` env var), `SESSION_SECRET_PROD` (injected as runtime `SESSION_SECRET_PROD`)
 - **Database:** MongoDB container at `mongo:27017` (via `iuga-server-config_default` network)
 - **Deploy pattern:** health-gated candidate swap; temp port `8889` → live port `8888`; tags images `:${BUILD_NUMBER}` and `:last-good`
 - **Commit status context:** `iuga/jenkins/cicd/prod`
@@ -78,9 +78,9 @@ Jenkins requires these credential IDs (values are **not** in this repository):
 | `github_classic` | Username+Password | GitHub API authentication for checkout and commit status updates |
 | `dockerhub` | Username+Password | Docker Hub login for image push |
 | `DB_URI` | Secret text | Jenkins credential holding the MongoDB connection URI; injected into the app as the `DB_URI` env var for all environments |
-| `SESSION_SECRET_DEV` | Secret text | Development session signing secret; injected as runtime `SESSION_SECRET` |
-| `SESSION_SECRET_STAGING` | Secret text | Staging session signing secret; injected as runtime `SESSION_SECRET` |
-| `SESSION_SECRET_PROD` | Secret text | Production session signing secret; injected as runtime `SESSION_SECRET` |
+| `SESSION_SECRET_DEV` | Secret text | Development session signing secret; injected as runtime `SESSION_SECRET_DEV` |
+| `SESSION_SECRET_STAGING` | Secret text | Staging session signing secret; injected as runtime `SESSION_SECRET_STAGING` |
+| `SESSION_SECRET_PROD` | Secret text | Production session signing secret; injected as runtime `SESSION_SECRET_PROD` |
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,7 +83,7 @@ Required variables (see `backend/.env.example`):
 |---|---|
 | `PORT` | Server port (default 7777) |
 | `DEPLOY_ENV` | `development`, `staging`, or `production` |
-| `SESSION_SECRET` | Strong random string for session signing |
+| `SESSION_SECRET_DEV` | Strong random string for session signing (development build reads this by `DEPLOY_ENV`) |
 | `DB_URI` | Full MongoDB connection string, e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` (local dev: `mongodb://127.0.0.1:27017/iuga`) |
 
 Frontend environment files are local and should not be committed:

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -164,7 +164,7 @@ Credentials are stored in Jenkins. This repository references them by ID only.
 | `github_classic` | Per GitHub token expiry | [Team lead / IT] — *Escalate to fill* |
 | `dockerhub` | Per Docker Hub policy | [Team lead / IT] — *Escalate to fill* |
 | `DB_URI` | As needed | [Database admin] — *Escalate to fill* |
-| `SESSION_SECRET` | As needed | [Team lead / IT] — *Escalate to fill* |
+| `SESSION_SECRET_DEV` / `_STAGING` / `_PROD` | As needed | [Team lead / IT] — *Escalate to fill* |
 
 When rotating, update the credential in Jenkins directly. No application code changes are needed.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -91,7 +91,7 @@ Required variables (see `backend/.env.example`):
 |---|---|
 | `PORT` | Server port (default 7777) |
 | `DEPLOY_ENV` | `development`, `staging`, or `production` |
-| `SESSION_SECRET` | Strong random string for session signing |
+| `SESSION_SECRET_DEV` | Strong random string for session signing (development build reads this by `DEPLOY_ENV`) |
 | `DB_URI` | Full MongoDB connection string, e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` (local dev: `mongodb://127.0.0.1:27017/iuga`) |
 
 ### Debug backend setup (optional)

--- a/prod.jenkinsfile
+++ b/prod.jenkinsfile
@@ -9,7 +9,7 @@ Authentication/Authorization Requirements: N/A (Jenkins job, triggered by GitHub
 Expected Request Information:
 - SCM: checks out the `main` branch and initializes the `backend/schemas` submodule
 - Credentials used (Configure Jenkins > Credentials): dockerhub (image push),
-  DB_URI, SESSION_SECRET (runtime env vars)
+  DB_URI, SESSION_SECRET_PROD (runtime env var)
 - cfg (Map): per-environment values passed to the shared deploy helpers
 
 Expected Response Information:
@@ -90,7 +90,7 @@ pipeline {
                 setBuildStatus("github_classic", "iuga/jenkins/cicd/prod", "pending", "Deploying application...");
                 withCredentials([
                     string(credentialsId: 'DB_URI', variable: 'DB_URI'),
-                    string(credentialsId: 'SESSION_SECRET_PROD', variable: 'SESSION_SECRET'),
+                    string(credentialsId: 'SESSION_SECRET_PROD', variable: 'SESSION_SECRET_PROD'),
                 ]) {
                     script { deploy.healthGatedDeploy(cfg) }
                 }

--- a/staging.jenkinsfile
+++ b/staging.jenkinsfile
@@ -10,7 +10,7 @@ Authentication/Authorization Requirements: N/A (Jenkins job, triggered by GitHub
 Expected Request Information:
 - SCM: multibranch `checkout scm` with submodules initialized in the Checkout stage
 - Credentials used (Configure Jenkins > Credentials): dockerhub (image push),
-  DB_URI, SESSION_SECRET (runtime env vars)
+  DB_URI, SESSION_SECRET_STAGING (runtime env var)
 - cfg (Map): per-environment values passed to the shared deploy helpers
 
 Expected Response Information:
@@ -80,7 +80,7 @@ pipeline {
                 setBuildStatus('github_classic','iuga/jenkins/cicd/staging','pending','Deploying application...')
                 withCredentials([
                   string(credentialsId: 'DB_URI', variable: 'DB_URI'),
-                  string(credentialsId: 'SESSION_SECRET_STAGING', variable: 'SESSION_SECRET'),
+                  string(credentialsId: 'SESSION_SECRET_STAGING', variable: 'SESSION_SECRET_STAGING'),
                 ]) {
                     script { deploy.healthGatedDeploy(cfg) }
                 }


### PR DESCRIPTION
## Summary & Rationale

The app previously demanded a single runtime variable `SESSION_SECRET`, while the actual deployment secrets are stored in Jenkins as `SESSION_SECRET_DEV`, `SESSION_SECRET_STAGING`, and `SESSION_SECRET_PROD` and injected under the collapsed name `SESSION_SECRET`. That indirection meant a local `.env.dev` written with the suffixed names — the natural form matching DEPLOY_ENV — caused `FATAL: SESSION_SECRET not set` at boot, because dotenv loaded the suffixed keys the app never read.

This change makes the runtime naming honest: the app selects its signing secret from `DEPLOY_ENV` and reads `SESSION_SECRET_DEV`, `SESSION_SECRET_STAGING`, or `SESSION_SECRET_PROD` directly. Jenkins and the deploy script forward the credential under its own suffixed name instead of remapping to `SESSION_SECRET`, so a single env source can carry all three environment secrets.

## Observable Behavior

- Backend boot resolves the session-signing secret by deployment environment (`development` → `SESSION_SECRET_DEV`, `staging` → `SESSION_SECRET_STAGING`, `production` → `SESSION_SECRET_PROD`); with `DEPLOY_ENV` unset it falls back to the legacy `SESSION_SECRET` for safety.
- Missing-secret startup still fails fast before any database connection, with the FATAL message naming the specific missing suffixed variable.
- Jenkins dev/staging/prod pipelines bind their credential (`SESSION_SECRET_DEV/_STAGING/_PROD`) under that same runtime name and pass it into the app container; no credential values live in the repo.
- Local development sets `SESSION_SECRET_DEV` (plus `DEPLOY_ENV=development`) in `backend/env/.env.dev`.

## Verification

- Updated `backend/test/session-config.test.js` to assert the guard: with `DEPLOY_ENV=development` and `SESSION_SECRET_DEV` empty, the app exits non-zero with `FATAL: SESSION_SECRET_DEV not set` before connecting to MongoDB.
- Extended `ci/test/deploy-groovy.test.js` to assert the deployed container receives `-e SESSION_SECRET_DEV=…` from the extracted deploy script.
- Ran `npm test --prefix backend` (76/76 pass) and `node --test test/deploy-groovy.test.js` (3/3 pass).
- Booted the backend against a local MongoDB with `.env.dev` containing only `SESSION_SECRET_DEV`: `[startup] successfully connected to mongodb … Listening at 0.0.0.0:7777`.
