### PR TITLE
feat(shop): add fail-closed checkout readiness

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,3 +22,14 @@ UW_NETID_PASSWORD=
 SMTP_FROM=IUGA <your-rso-netid@uw.edu>
 
 DISCORD_BOT_TOKEN=FAKE.MzI0NTY3ODkwMTIzNDU2Nzg.GfakeAbCdEfGhIjKlMnOp
+
+# --- Stripe checkout readiness (placeholders only; checkout stays fail-closed) ---
+STRIPE_MODE=test
+STRIPE_SECRET_KEY=replace-with-test-secret-key
+STRIPE_WEBHOOK_SECRET=replace-with-test-webhook-secret
+STRIPE_API_VERSION=replace-with-pinned-api-version
+STRIPE_BASE_URL=https://example.invalid
+STRIPE_CATALOG_VERSION=replace-with-catalog-version
+STRIPE_PAYMENT_METHODS=card
+STRIPE_CURRENCY=usd
+STRIPE_MINIMUM_TOTAL_MINOR=1

--- a/backend/app.js
+++ b/backend/app.js
@@ -16,6 +16,7 @@ import { httpErrorHandler, sendSpaError } from "./httpErrorHandler.js";
 import { ALLOWED_ORIGINS, REQUEST_BODY_LIMIT } from "./httpBoundaryConfig.js";
 import { createCsrfProtection } from "./routes/api/v1/utils/csrf.js";
 import { createSpaRouter } from "./spaRoutes.js";
+import { evaluateCheckoutReadiness } from "./checkoutReadiness.js";
 
 import { fileURLToPath } from "url";
 import { dirname } from "path";
@@ -41,14 +42,20 @@ await connectToDatabase();
 const app = express();
 configureTrustedProxy(app);
 
+// No infrastructure or policy evidence is wired yet, so this remains false.
+const checkoutReadiness = evaluateCheckoutReadiness({ env: process.env });
+
 const apiRateLimiter = createRateLimiter({
   limit: 100,
   windowMs: 15 * 60_000,
 });
 
-// Readiness probe for the pipeline health gate. The listener only starts
-// after the DB connects, so 200 implies the database is reachable.
-app.get("/readyz", (req, res) => res.json({ status: "ok" }));
+// General readiness remains tied to the running API and database. Checkout is
+// reported as a separate fail-closed capability and never changes the HTTP status.
+app.get("/readyz", (req, res) => res.json({
+  status: "ok",
+  checkoutEnabled: checkoutReadiness.checkoutEnabled,
+}));
 
 const allowedOrigins = ALLOWED_ORIGINS;
 

--- a/backend/checkoutReadiness.js
+++ b/backend/checkoutReadiness.js
@@ -1,0 +1,163 @@
+const REQUIRED_CONFIGURATION = Object.freeze([
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "STRIPE_API_VERSION",
+  "STRIPE_BASE_URL",
+  "STRIPE_CATALOG_VERSION",
+]);
+
+const INFRASTRUCTURE_GATES = Object.freeze([
+  "databaseTransactions",
+  "sessionStore",
+  "worker",
+]);
+
+const POLICY_GATES = Object.freeze([
+  "identity",
+  "csrf",
+  "tax",
+  "fulfillment",
+  "gateA",
+  "gateB",
+]);
+
+function asRecord(value) {
+  return value !== null && typeof value === "object" ? value : {};
+}
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function hasValue(value) {
+  return text(value).length > 0;
+}
+
+function explicitlyTrue(value) {
+  return value === true || (typeof value === "string" && value.trim().toLowerCase() === "true");
+}
+
+function readPaymentMethods(value) {
+  if (Array.isArray(value)) return value.map(text);
+  if (typeof value === "string") return value.split(",").map(text);
+  return [];
+}
+
+function readPositiveTotal(value) {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+  if (typeof value !== "string" || !/^\d+$/u.test(value.trim())) return null;
+
+  const total = Number(value);
+  return Number.isSafeInteger(total) && total > 0 ? total : null;
+}
+
+function validPinnedApiVersion(value) {
+  const match = /^(\d{4}-\d{2}-\d{2})\.[A-Za-z0-9-]+$/.exec(text(value));
+  if (!match) return false;
+
+  const parsedDate = new Date(`${match[1]}T00:00:00.000Z`);
+  return !Number.isNaN(parsedDate.valueOf())
+    && parsedDate.toISOString().startsWith(match[1]);
+}
+
+function credentialsMatchMode(mode, secretKey) {
+  const key = text(secretKey);
+  if (mode === "test") return /^sk_test_.+$/u.test(key);
+  if (mode === "live") return /^sk_live_.+$/u.test(key);
+  return false;
+}
+
+function validHttpsBaseUrl(value) {
+  try {
+    const url = new URL(text(value));
+    return url.protocol === "https:"
+      && !url.username
+      && !url.password
+      && Boolean(url.hostname)
+      && url.pathname === "/"
+      && !url.search
+      && !url.hash;
+  } catch {
+    return false;
+  }
+}
+
+function safeBaseUrl(value) {
+  try {
+    const url = new URL(text(value));
+    if (!validHttpsBaseUrl(value)) return "[redacted]";
+    return url.origin;
+  } catch {
+    return "[redacted]";
+  }
+}
+
+function addReason(reasons, reason) {
+  if (!reasons.includes(reason)) reasons.push(reason);
+}
+
+/**
+ * @behavior Evaluate explicit checkout prerequisites without contacting Stripe.
+ * @param input — configuration plus infrastructure and policy evidence gates
+ * @returns a fail-closed capability state with redacted diagnostics
+ */
+export function evaluateCheckoutReadiness(input = {}) {
+  const source = asRecord(input);
+  const env = asRecord(source.env);
+  const infrastructure = asRecord(source.infrastructure);
+  const policy = asRecord(source.policy);
+  const reasons = [];
+
+  const mode = text(env.STRIPE_MODE).toLowerCase();
+  const missingConfiguration = REQUIRED_CONFIGURATION.some((key) => !hasValue(env[key]));
+  if (missingConfiguration) addReason(reasons, "missing_configuration");
+  if (mode !== "test" && mode !== "live") addReason(reasons, "invalid_mode");
+
+  if (!credentialsMatchMode(mode, env.STRIPE_SECRET_KEY)) {
+    addReason(reasons, "mode_credentials_mismatch");
+  }
+  if (!validPinnedApiVersion(env.STRIPE_API_VERSION)) addReason(reasons, "invalid_api_version");
+  if (!validHttpsBaseUrl(env.STRIPE_BASE_URL)) addReason(reasons, "invalid_base_url");
+
+  const paymentMethods = readPaymentMethods(env.STRIPE_PAYMENT_METHODS);
+  if (paymentMethods.length !== 1 || paymentMethods[0].toLowerCase() !== "card") {
+    addReason(reasons, "card_only_required");
+  }
+  if (text(env.STRIPE_CURRENCY).toLowerCase() !== "usd") addReason(reasons, "usd_required");
+  if (readPositiveTotal(env.STRIPE_MINIMUM_TOTAL_MINOR) === null) {
+    addReason(reasons, "positive_total_required");
+  }
+
+  if (!INFRASTRUCTURE_GATES.every((gate) => explicitlyTrue(infrastructure[gate]))) {
+    addReason(reasons, "infrastructure_unhealthy");
+  }
+  if (!POLICY_GATES.every((gate) => explicitlyTrue(policy[gate]))) {
+    addReason(reasons, "policy_unapproved");
+  }
+  if (mode === "live" && !explicitlyTrue(policy.livePayments)) {
+    addReason(reasons, "live_mode_disabled");
+  }
+
+  const diagnostics = {
+    mode: mode || "[missing]",
+    secretKey: hasValue(env.STRIPE_SECRET_KEY) ? "[redacted]" : "[missing]",
+    webhookSecret: hasValue(env.STRIPE_WEBHOOK_SECRET) ? "[redacted]" : "[missing]",
+    apiVersion: text(env.STRIPE_API_VERSION) || "[missing]",
+    baseUrl: safeBaseUrl(env.STRIPE_BASE_URL),
+    catalogVersion: text(env.STRIPE_CATALOG_VERSION) || "[missing]",
+    paymentMethods,
+    currency: text(env.STRIPE_CURRENCY).toLowerCase() || "[missing]",
+    minimumTotalMinor: readPositiveTotal(env.STRIPE_MINIMUM_TOTAL_MINOR) ?? "[invalid]",
+  };
+
+  const available = reasons.length === 0;
+  return {
+    available,
+    checkoutEnabled: available,
+    mode,
+    reasons,
+    diagnostics,
+  };
+}

--- a/backend/test/checkout-readiness.test.js
+++ b/backend/test/checkout-readiness.test.js
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { evaluateCheckoutReadiness } from "../checkoutReadiness.js";
+
+const VALID_ENV = Object.freeze({
+  STRIPE_MODE: "test",
+  STRIPE_SECRET_KEY: "sk_test_redacted_fixture",
+  STRIPE_WEBHOOK_SECRET: "whsec_redacted_fixture",
+  STRIPE_API_VERSION: "2025-03-31.basil",
+  STRIPE_BASE_URL: "https://iuga.info",
+  STRIPE_CATALOG_VERSION: "catalog-2026-09",
+  STRIPE_PAYMENT_METHODS: ["card"],
+  STRIPE_CURRENCY: "usd",
+  STRIPE_MINIMUM_TOTAL_MINOR: 1,
+});
+
+const HEALTHY_INFRASTRUCTURE = Object.freeze({
+  databaseTransactions: true,
+  sessionStore: true,
+  worker: true,
+});
+
+const APPROVED_POLICY = Object.freeze({
+  identity: true,
+  csrf: true,
+  tax: true,
+  fulfillment: true,
+  gateA: true,
+  gateB: true,
+});
+
+
+function evaluate(overrides = {}) {
+  return evaluateCheckoutReadiness({
+    env: { ...VALID_ENV, ...(overrides.env ?? {}) },
+    infrastructure: { ...HEALTHY_INFRASTRUCTURE, ...(overrides.infrastructure ?? {}) },
+    policy: { ...APPROVED_POLICY, ...(overrides.policy ?? {}) },
+  });
+}
+
+function assertUnavailable(result, reason) {
+  assert.equal(result.available, false);
+  assert.equal(result.checkoutEnabled, false);
+  assert.ok(result.reasons.includes(reason), `expected reason ${reason}`);
+}
+
+describe("checkout configuration and readiness", () => {
+  it("fails closed when required configuration is missing", () => {
+    const result = evaluate({
+      env: {
+        STRIPE_SECRET_KEY: "",
+        STRIPE_WEBHOOK_SECRET: undefined,
+        STRIPE_API_VERSION: undefined,
+        STRIPE_BASE_URL: undefined,
+        STRIPE_CATALOG_VERSION: undefined,
+      },
+    });
+
+    assertUnavailable(result, "missing_configuration");
+  });
+
+  it("accepts a complete test-mode configuration when every gate is explicitly healthy", () => {
+    const result = evaluate();
+
+    assert.equal(result.available, true);
+    assert.equal(result.checkoutEnabled, true);
+    assert.equal(result.mode, "test");
+    assert.deepEqual(result.reasons, []);
+  });
+
+  it("keeps live mode unavailable unless live payments are explicitly enabled", () => {
+    const result = evaluate({
+      env: { STRIPE_MODE: "live", STRIPE_SECRET_KEY: "sk_live_redacted_fixture" },
+      policy: { livePayments: false },
+    });
+
+    assertUnavailable(result, "live_mode_disabled");
+    assert.equal(result.mode, "live");
+  });
+
+  it("rejects credentials that do not match the configured mode", () => {
+    const cases = [
+      [{ STRIPE_MODE: "test", STRIPE_SECRET_KEY: "sk_live_redacted_fixture" }, {}],
+      [
+        { STRIPE_MODE: "live", STRIPE_SECRET_KEY: "sk_test_redacted_fixture" },
+        { livePayments: true },
+      ],
+      [{ STRIPE_SECRET_KEY: "sk_test_" }, {}],
+    ];
+
+    for (const [env, policy] of cases) {
+      const result = evaluate({ env, policy });
+
+      assertUnavailable(result, "mode_credentials_mismatch");
+    }
+  });
+
+  it("requires a pinned Stripe API version", () => {
+    for (const apiVersion of ["", "latest", "2025-03", "2025-03-31", "2025-99-99.basil", "2025-02-30.basil"]) {
+      const result = evaluate({ env: { STRIPE_API_VERSION: apiVersion } });
+
+      assertUnavailable(result, "invalid_api_version");
+    }
+  });
+
+  it("requires an absolute HTTPS base URL", () => {
+    for (const baseUrl of ["iuga.info", "http://iuga.info", "https://", "javascript:alert(1)", "https://iuga.info/shop", "https://iuga.info?next=shop", "https://iuga.info#shop"]) {
+      const result = evaluate({ env: { STRIPE_BASE_URL: baseUrl } });
+
+      assertUnavailable(result, "invalid_base_url");
+    }
+  });
+
+  it("enforces the card-only USD positive-total baseline", () => {
+    const cases = [
+      [{ STRIPE_PAYMENT_METHODS: ["card", "link"] }, "card_only_required"],
+      [{ STRIPE_PAYMENT_METHODS: ["link"] }, "card_only_required"],
+      [{ STRIPE_PAYMENT_METHODS: "card," }, "card_only_required"],
+      [{ STRIPE_CURRENCY: "eur" }, "usd_required"],
+      [{ STRIPE_MINIMUM_TOTAL_MINOR: 0 }, "positive_total_required"],
+      [{ STRIPE_MINIMUM_TOTAL_MINOR: -1 }, "positive_total_required"],
+      [{ STRIPE_MINIMUM_TOTAL_MINOR: 0.5 }, "positive_total_required"],
+      [{ STRIPE_MINIMUM_TOTAL_MINOR: true }, "positive_total_required"],
+      [{ STRIPE_MINIMUM_TOTAL_MINOR: [1] }, "positive_total_required"],
+      [{ STRIPE_MINIMUM_TOTAL_MINOR: "1.0" }, "positive_total_required"],
+    ];
+
+    for (const [env, reason] of cases) {
+      const result = evaluate({ env });
+
+      assertUnavailable(result, reason);
+    }
+  });
+
+  it("returns redacted diagnostics rather than configuration values", () => {
+    const secret = "sk_test_super_secret_fixture";
+    const webhookSecret = "whsec_super_secret_fixture";
+    const result = evaluate({
+      env: {
+        STRIPE_SECRET_KEY: secret,
+        STRIPE_WEBHOOK_SECRET: webhookSecret,
+        STRIPE_API_VERSION: "latest",
+      },
+    });
+
+    assertUnavailable(result, "invalid_api_version");
+    const serialized = JSON.stringify(result);
+    assert.doesNotMatch(serialized, new RegExp(secret, "u"));
+    assert.doesNotMatch(serialized, new RegExp(webhookSecret, "u"));
+    assert.equal(result.diagnostics.secretKey, "[redacted]");
+    assert.equal(result.diagnostics.webhookSecret, "[redacted]");
+  });
+
+  it("requires explicit infrastructure and policy gates", () => {
+    const infrastructure = {
+      databaseTransactions: false,
+      sessionStore: false,
+      worker: false,
+    };
+    const policy = {
+      identity: false,
+      csrf: false,
+      tax: false,
+      fulfillment: false,
+      gateA: false,
+      gateB: false,
+    };
+    const result = evaluate({ infrastructure, policy });
+
+    assertUnavailable(result, "infrastructure_unhealthy");
+    assertUnavailable(result, "policy_unapproved");
+  });
+
+});

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,6 +86,27 @@ Required variables (see `backend/.env.example`):
 | `SESSION_SECRET_DEV` | Strong random string for session signing (development build reads this by `DEPLOY_ENV`) |
 | `DB_URI` | Full MongoDB connection string, e.g. `mongodb://<user>:<pass>@mongo:27017/iuga` (local dev: `mongodb://127.0.0.1:27017/iuga`) |
 
+Stripe checkout configuration is evaluated separately from general application
+readiness. Supplying these values does not enable checkout: the evaluator also
+requires explicit infrastructure and policy approvals, and live mode requires a
+separate live-payments approval.
+
+`GET /readyz` continues to return `200` for a healthy application/database and
+reports checkout separately as `checkoutEnabled`. Until infrastructure and
+policy evidence is wired, that capability is always `false`.
+
+| Variable | Checkout readiness constraint |
+|---|---|
+| `STRIPE_MODE` | Exactly `test` or `live`; the secret-key prefix must match |
+| `STRIPE_SECRET_KEY` | Present and mode-matched; never returned in diagnostics |
+| `STRIPE_WEBHOOK_SECRET` | Present; never returned in diagnostics |
+| `STRIPE_API_VERSION` | Pinned Stripe date and release codename |
+| `STRIPE_BASE_URL` | Absolute credential-free HTTPS application origin |
+| `STRIPE_CATALOG_VERSION` | Non-empty approved catalog revision |
+| `STRIPE_PAYMENT_METHODS` | Exactly `card` |
+| `STRIPE_CURRENCY` | Exactly `usd` |
+| `STRIPE_MINIMUM_TOTAL_MINOR` | Positive integer minor-unit purchase floor |
+
 Frontend environment files are local and should not be committed:
 
 | File | Variable | Value |


### PR DESCRIPTION
## Rationale

Checkout must not become available merely because Stripe credentials are present. Identity, session, persistence, policy, and launch prerequisites need independent evidence before IUGA can safely accept payments.

This introduces the capability boundary before payment code is added. It keeps the application deployable while checkout remains explicitly disabled.

## Observable Behavior

`GET /readyz` continues returning HTTP 200 when the application and database are healthy, while also reporting:

```json
{
  "status": "ok",
  "checkoutEnabled": false
}
```

Checkout configuration is validated without contacting Stripe or exposing secrets. Missing, malformed, mode-mismatched, or unapproved configuration fails closed. Live mode requires a separate explicit approval.

No checkout route, Stripe SDK, payment request, identity migration, or live payment capability is introduced.

## Verification

- Focused checkout readiness tests: 9 passed
- Backend suite: 85 passed
- Frontend suite: 73 passed

## Stack Context

- Position: 1 of 11
- Base: `dev`
- This PR is the first foundation layer of the Stripe integration stack.
- Later commerce and payment layers remain blocked by the documented approval gates.