### PR TITLE
feat(identity): add migration conflict report analyzer

### DIFF
--- a/backend/identityMigrationReport.js
+++ b/backend/identityMigrationReport.js
@@ -1,0 +1,224 @@
+const IDENTITY_KEYS = ["issuer", "tenantId", "objectId"];
+
+function normalizedEmail(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function identityOf(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const identity = {};
+  for (const key of IDENTITY_KEYS) {
+    const field = typeof value[key] === "string" ? value[key].trim() : "";
+    if (field) identity[key] = field;
+  }
+  return Object.keys(identity).length ? identity : null;
+}
+
+function completeIdentity(identity) {
+  return identity && IDENTITY_KEYS.every((key) => typeof identity[key] === "string" && identity[key].length > 0);
+}
+
+function identityKey(identity) {
+  return JSON.stringify(IDENTITY_KEYS.map((key) => identity[key]));
+}
+
+function compareText(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function sortedUnique(values) {
+  return [...new Set(values)].sort(compareText);
+}
+
+function compareIdentityRows(left, right) {
+  const userOrder = compareText(left.userId, right.userId);
+  return userOrder || compareText(identityKey(left), identityKey(right));
+}
+
+/**
+ * @behavior Build a deterministic dry-run report without mutating source data.
+ * @param input — existing users and independently verified directory rows
+ * @returns projected mappings, review holds, and aggregate counts
+ * @exceptions TypeError when either input is not an array
+ */
+export function buildReport({ users, directory } = {}) {
+  if (!Array.isArray(users) || !Array.isArray(directory)) {
+    throw new TypeError("users and directory must be arrays");
+  }
+
+  const projectedUsers = users
+    .map((user) => ({
+      userId: String(user?._id ?? ""),
+      normalizedEmail: normalizedEmail(user?.uEmail),
+      identity: identityOf(user?.identity),
+    }))
+    .sort((left, right) => compareText(left.userId, right.userId));
+  const userById = new Map(projectedUsers.map((user) => [user.userId, user]));
+
+  const emailMap = new Map();
+  for (const user of projectedUsers) {
+    if (!user.normalizedEmail) continue;
+    const userIds = emailMap.get(user.normalizedEmail) ?? [];
+    userIds.push(user.userId);
+    emailMap.set(user.normalizedEmail, userIds);
+  }
+  const emailGroups = [...emailMap.entries()]
+    .sort(([left], [right]) => compareText(left, right))
+    .map(([email, userIds]) => ({
+      normalizedEmail: email,
+      userIds: sortedUnique(userIds),
+    }));
+
+  const completeRows = [];
+  const incompleteDirectory = new Set();
+  const incompleteDirectoryRows = [];
+  const malformedDirectoryRows = [];
+  const unknownUserIds = new Set();
+  const emailOnly = [];
+  for (const [index, sourceRow] of directory.entries()) {
+    const hasUserId = sourceRow
+      && typeof sourceRow === "object"
+      && !Array.isArray(sourceRow)
+      && Object.hasOwn(sourceRow, "userId");
+    const userId = typeof sourceRow?.userId === "string" ? sourceRow.userId.trim() : "";
+    if (!userId) {
+      if (hasUserId) {
+        malformedDirectoryRows.push({ index });
+        continue;
+      }
+      const email = normalizedEmail(sourceRow?.email ?? sourceRow?.uEmail);
+      if (!email) {
+        malformedDirectoryRows.push({ index });
+        continue;
+      }
+      emailOnly.push({
+        index,
+        normalizedEmail: email,
+        candidateUserIds: sortedUnique(emailMap.get(email) ?? []),
+        identity: identityOf(sourceRow),
+      });
+      continue;
+    }
+    const identity = identityOf(sourceRow);
+    if (!userById.has(userId)) {
+      unknownUserIds.add(userId);
+      if (completeIdentity(identity)) completeRows.push({ userId, ...identity });
+      else incompleteDirectoryRows.push({ index, userId });
+      continue;
+    }
+
+    if (!completeIdentity(identity)) {
+      incompleteDirectory.add(userId);
+      incompleteDirectoryRows.push({ index, userId });
+      continue;
+    }
+    completeRows.push({ userId, ...identity });
+  }
+
+  const rowByKey = new Map();
+  for (const row of completeRows) {
+    const key = JSON.stringify([row.userId, identityKey(row)]);
+    const entry = rowByKey.get(key) ?? { row, count: 0 };
+    entry.count += 1;
+    rowByKey.set(key, entry);
+  }
+  const uniqueRows = [...rowByKey.values()].map(({ row }) => row).sort(compareIdentityRows);
+  const duplicateRows = [...rowByKey.values()]
+    .filter(({ count }) => count > 1)
+    .map(({ row, count }) => ({ ...row, count }))
+    .sort(compareIdentityRows);
+
+  const providerAssignments = new Map();
+  const userAssignments = new Map();
+  for (const user of projectedUsers) {
+    if (!completeIdentity(user.identity)) continue;
+    const providerKey = identityKey(user.identity);
+    const provider = providerAssignments.get(providerKey) ?? { identity: user.identity, userIds: [] };
+    provider.userIds.push(user.userId);
+    providerAssignments.set(providerKey, provider);
+  }
+  for (const row of uniqueRows) {
+    const providerKey = identityKey(row);
+    const provider = providerAssignments.get(providerKey) ?? { identity: identityOf(row), userIds: [] };
+    provider.userIds.push(row.userId);
+    providerAssignments.set(providerKey, provider);
+
+    const identities = userAssignments.get(row.userId) ?? new Map();
+    identities.set(providerKey, identityOf(row));
+    userAssignments.set(row.userId, identities);
+  }
+
+  const duplicateProviderIdentities = [...providerAssignments.values()]
+    .filter(({ userIds }) => sortedUnique(userIds).length > 1)
+    .map(({ identity, userIds }) => ({ ...identity, userIds: sortedUnique(userIds) }))
+    .sort((left, right) => compareText(identityKey(left), identityKey(right)));
+  const conflictingUserMappings = [...userAssignments.entries()]
+    .filter(([, identities]) => identities.size > 1)
+    .map(([userId, identities]) => ({
+      userId,
+      identities: [...identities.values()].sort((left, right) => compareText(identityKey(left), identityKey(right))),
+    }))
+    .sort((left, right) => compareText(left.userId, right.userId));
+
+  const identityMismatches = new Set();
+  for (const row of uniqueRows) {
+    const existing = userById.get(row.userId)?.identity;
+    if (!existing) continue;
+    const sharedFieldDiffers = IDENTITY_KEYS.some(
+      (key) => existing[key] !== undefined && existing[key] !== row[key],
+    );
+    if (sharedFieldDiffers) identityMismatches.add(row.userId);
+  }
+
+  const blockedUserIds = new Set([
+    ...incompleteDirectory,
+    ...identityMismatches,
+    ...duplicateRows.map((row) => row.userId),
+    ...duplicateProviderIdentities.flatMap((entry) => entry.userIds),
+    ...conflictingUserMappings.map((entry) => entry.userId),
+  ]);
+  const mappings = uniqueRows
+    .filter((row) => userById.has(row.userId) && !blockedUserIds.has(row.userId))
+    .map((row) => ({ ...row }))
+    .sort((left, right) => compareText(left.userId, right.userId));
+  const mappedUserIds = new Set(mappings.map((mapping) => mapping.userId));
+  const missingIdentity = projectedUsers
+    .filter((user) => !completeIdentity(user.identity) && !mappedUserIds.has(user.userId))
+    .map((user) => user.userId);
+  const directoryUserIds = new Set(uniqueRows.map((row) => row.userId));
+  const missingDirectoryEvidence = projectedUsers
+    .filter((user) => !directoryUserIds.has(user.userId))
+    .map((user) => user.userId);
+  emailOnly.sort((left, right) => left.index - right.index);
+
+  const heldReferences = new Set([
+    ...missingIdentity, ...missingDirectoryEvidence, ...incompleteDirectory, ...identityMismatches,
+    ...unknownUserIds, ...duplicateRows.map((row) => row.userId),
+    ...duplicateProviderIdentities.flatMap((entry) => entry.userIds),
+    ...conflictingUserMappings.map((entry) => entry.userId), ...emailOnly.flatMap((entry) => entry.candidateUserIds),
+    ...emailOnly.filter((entry) => entry.candidateUserIds.length === 0).map(({ index }) => `directory-row:${index}`),
+    ...malformedDirectoryRows.map(({ index }) => `directory-row:${index}`),
+  ]);
+
+  return {
+    users: projectedUsers,
+    emailGroups,
+    mappings,
+    holds: {
+      emailOnly, missingIdentity, missingDirectoryEvidence,
+      incompleteDirectory: sortedUnique(incompleteDirectory), incompleteDirectoryRows, malformedDirectoryRows,
+      identityMismatches: sortedUnique(identityMismatches),
+      unknownUserIds: sortedUnique(unknownUserIds),
+      duplicateProviderIdentities, conflictingUserMappings, duplicateRows,
+    },
+    counts: {
+      users: projectedUsers.length, emailGroups: emailGroups.length,
+      emailCollisions: emailGroups.filter((group) => group.userIds.length > 1).length,
+      directoryRows: directory.length, completeMappings: mappings.length, reviewHolds: heldReferences.size,
+      duplicateRows: duplicateRows.length,
+    },
+  };
+}

--- a/backend/test/identity-migration.test.js
+++ b/backend/test/identity-migration.test.js
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { buildReport } from "../identityMigrationReport.js";
+
+// Directory rows are authoritative only when they contain an explicit userId
+// and a complete issuer/tenantId/objectId tuple. Deterministic ordering and
+// counts are the report's observable compatibility boundary.
+
+const users = [
+  {
+    _id: "u-1",
+    uEmail: " Alice@Example.edu ",
+    uFirstName: "Alice",
+    uLastName: "One",
+    accessToken: "redacted-access-token",
+    idToken: "redacted-id-token",
+    arbitraryExtra: { shouldNot: "escape" },
+    identity: { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-1" },
+  },
+  {
+    _id: "u-2",
+    uEmail: "alice@example.EDU",
+    uFirstName: "Alice",
+    uLastName: "Two",
+    identity: null,
+  },
+  { _id: "u-3", uEmail: "bob@example.edu", identity: { issuer: "https://issuer.example", tenantId: "tenant-a" } },
+  { _id: "u-4", uEmail: "carol@example.edu", identity: { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-4" } },
+  { _id: "u-5", uEmail: "dave@example.edu", identity: { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-5" } },
+  { _id: "u-6", uEmail: "erin@example.edu", identity: null },
+];
+
+const directory = [
+  { userId: "u-1", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-1" },
+  // Email is deliberately present but must not be accepted as a match.
+  { email: "alice@example.edu", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-2" },
+  // Incomplete directory identity is a hold, not a mapping.
+  { userId: "u-3", issuer: "https://issuer.example", tenantId: "tenant-a" },
+  // The same provider identity is claimed by two users.
+  { userId: "u-4", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-shared" },
+  { userId: "u-5", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-shared" },
+  // One user is claimed by two different provider identities.
+  { userId: "u-5", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-other" },
+  // Unknown IDs must be held and never create a user.
+  { userId: "u-unknown", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-unknown" },
+  // A separate clean one-to-one mapping remains eligible.
+  { userId: "u-6", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-6" },
+  // Duplicate source rows are counted once as an assignment and reported.
+  { userId: "u-1", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-1" },
+];
+
+function reportFor(inputUsers = users, inputDirectory = directory) {
+  return buildReport({ users: inputUsers, directory: inputDirectory });
+}
+
+
+describe("identity migration report", () => {
+  test("groups emails deterministically after trimming and case normalization", () => {
+    const report = reportFor();
+    assert.deepEqual(report.emailGroups, [
+      { normalizedEmail: "alice@example.edu", userIds: ["u-1", "u-2"] },
+      { normalizedEmail: "bob@example.edu", userIds: ["u-3"] },
+      { normalizedEmail: "carol@example.edu", userIds: ["u-4"] },
+      { normalizedEmail: "dave@example.edu", userIds: ["u-5"] },
+      { normalizedEmail: "erin@example.edu", userIds: ["u-6"] },
+    ]);
+    assert.deepEqual(report.counts.emailCollisions, 1);
+  });
+
+  test("accepts only a clean explicit userId-to-complete-identity mapping", () => {
+    const report = reportFor();
+    assert.deepEqual(report.mappings, [
+      { userId: "u-6", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-6" },
+    ]);
+    assert.equal(report.mappings.some((row) => row.userId === "u-1" || row.userId === "u-2"), false);
+    assert.equal(report.holds.missingIdentity.includes("u-6"), false);
+  });
+
+  test("refuses email-only matches and incomplete directory identities", () => {
+    const report = reportFor();
+    assert.deepEqual(report.holds.emailOnly, [
+      {
+        index: 1,
+        normalizedEmail: "alice@example.edu",
+        candidateUserIds: ["u-1", "u-2"],
+        identity: {
+          issuer: "https://issuer.example",
+          tenantId: "tenant-a",
+          objectId: "oid-2",
+        },
+      },
+    ]);
+    assert.deepEqual(report.holds.missingIdentity, ["u-2", "u-3"]);
+    assert.ok(report.holds.incompleteDirectory.includes("u-3"));
+    assert.equal(report.mappings.some((row) => row.userId === "u-2" || row.userId === "u-3"), false);
+  });
+  test("holds an explicit mapping that conflicts with an existing identity", () => {
+    const tenantMismatch = reportFor([users[0]], [
+      { userId: "u-1", issuer: "https://issuer.example", tenantId: "tenant-b", objectId: "oid-1" },
+    ]);
+    const objectMismatch = reportFor([users[0]], [
+      { userId: "u-1", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-other" },
+    ]);
+
+    assert.deepEqual(tenantMismatch.mappings, []);
+    assert.deepEqual(tenantMismatch.holds.identityMismatches, ["u-1"]);
+    assert.deepEqual(objectMismatch.mappings, []);
+    assert.deepEqual(objectMismatch.holds.identityMismatches, ["u-1"]);
+  });
+
+  test("holds unknown IDs, duplicate provider identities, and conflicting user mappings", () => {
+    const report = reportFor();
+    assert.deepEqual(report.holds.unknownUserIds, ["u-unknown"]);
+    assert.deepEqual(report.holds.duplicateProviderIdentities, [
+      { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-shared", userIds: ["u-4", "u-5"] },
+    ]);
+    assert.deepEqual(report.holds.conflictingUserMappings, [
+      { userId: "u-5", identities: [
+        { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-other" },
+        { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-shared" },
+      ] },
+    ]);
+  });
+
+  test("reports duplicate directory rows without changing stable assignment counts", () => {
+    const report = reportFor();
+    assert.deepEqual(report.holds.duplicateRows, [
+      { userId: "u-1", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-1", count: 2 },
+    ]);
+    assert.deepEqual(report.counts, {
+      users: 6,
+      emailGroups: 5,
+      emailCollisions: 1,
+      directoryRows: 9,
+      completeMappings: 1,
+      reviewHolds: 6,
+      duplicateRows: 1,
+    });
+  });
+
+
+  test("holds duplicate source rows even without another conflict", () => {
+    const duplicateRow = {
+      userId: "u-6",
+      issuer: "https://issuer.example",
+      tenantId: "tenant-a",
+      objectId: "oid-6",
+    };
+    const report = reportFor([users[5]], [duplicateRow, { ...duplicateRow }]);
+
+    assert.deepEqual(report.mappings, []);
+    assert.deepEqual(report.holds.duplicateRows, [{ ...duplicateRow, count: 2 }]);
+    assert.equal(report.counts.reviewHolds, 1);
+  });
+
+  test("holds users that have no authoritative directory evidence", () => {
+    const report = reportFor([users[3]], []);
+
+    assert.deepEqual(report.mappings, []);
+    assert.deepEqual(report.holds.missingDirectoryEvidence, ["u-4"]);
+    assert.equal(report.counts.reviewHolds, 1);
+  });
+
+  test("reports email-only evidence without overriding an exact mapping", () => {
+    const report = reportFor([users[3]], [
+      { userId: "u-4", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-4" },
+      { email: "carol@example.edu", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "ignored" },
+    ]);
+
+    assert.deepEqual(report.mappings, [
+      { userId: "u-4", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-4" },
+    ]);
+    assert.deepEqual(report.holds.emailOnly, [
+      {
+        index: 1,
+        normalizedEmail: "carol@example.edu",
+        candidateUserIds: ["u-4"],
+        identity: {
+          issuer: "https://issuer.example",
+          tenantId: "tenant-a",
+          objectId: "ignored",
+        },
+      },
+    ]);
+  });
+
+  test("holds provider identities duplicated across existing users", () => {
+    const duplicateUser = {
+      _id: "u-7",
+      uEmail: "other@example.edu",
+      identity: { ...users[3].identity },
+    };
+    const report = reportFor([users[3], duplicateUser], [
+      { userId: "u-4", ...users[3].identity },
+    ]);
+
+    assert.deepEqual(report.mappings, []);
+    assert.deepEqual(report.holds.duplicateProviderIdentities, [
+      { ...users[3].identity, userIds: ["u-4", "u-7"] },
+    ]);
+  });
+
+  test("holds a known mapping when an unknown user claims the same identity", () => {
+    const identity = { ...users[3].identity };
+    const report = reportFor([users[3]], [
+      { userId: "u-4", ...identity },
+      { userId: "u-unknown", ...identity },
+    ]);
+
+    assert.deepEqual(report.mappings, []);
+    assert.deepEqual(report.holds.unknownUserIds, ["u-unknown"]);
+    assert.deepEqual(report.holds.duplicateProviderIdentities, [
+      { ...identity, userIds: ["u-4", "u-unknown"] },
+    ]);
+  });
+
+  test("preserves repeated email-only evidence and conflicting identities", () => {
+    const report = reportFor([users[3]], [
+      { email: "carol@example.edu", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "first" },
+      { email: "CAROL@example.edu", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "second" },
+    ]);
+
+    assert.deepEqual(report.holds.emailOnly, [
+      {
+        index: 0,
+        normalizedEmail: "carol@example.edu",
+        candidateUserIds: ["u-4"],
+        identity: {
+          issuer: "https://issuer.example",
+          tenantId: "tenant-a",
+          objectId: "first",
+        },
+      },
+      {
+        index: 1,
+        normalizedEmail: "carol@example.edu",
+        candidateUserIds: ["u-4"],
+        identity: {
+          issuer: "https://issuer.example",
+          tenantId: "tenant-a",
+          objectId: "second",
+        },
+      },
+    ]);
+    assert.equal(report.counts.reviewHolds, 1);
+  });
+
+  test("counts unmatched email-only evidence as an unowned review hold", () => {
+    const report = reportFor([], [
+      { email: "missing@example.edu", issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "unowned" },
+    ]);
+
+    assert.equal(report.counts.reviewHolds, 1);
+  });
+
+  test("reports malformed and incomplete directory rows by index", () => {
+    const report = reportFor([users[3]], [
+      {},
+      { userId: 42, issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-4" },
+      { userId: "u-4", issuer: "https://issuer.example" },
+    ]);
+
+    assert.deepEqual(report.holds.malformedDirectoryRows, [{ index: 0 }, { index: 1 }]);
+    assert.deepEqual(report.holds.incompleteDirectoryRows, [{ index: 2, userId: "u-4" }]);
+    assert.equal(report.counts.reviewHolds, 3);
+  });
+  test("projects only IDs, normalized emails, and exact identity values", () => {
+    const report = reportFor();
+    const serialized = JSON.stringify(report);
+    assert.doesNotMatch(serialized, /redacted-access-token|redacted-id-token|Alice|One|Two|shouldNot|arbitraryExtra/);
+    assert.deepEqual(report.users, [
+      { userId: "u-1", normalizedEmail: "alice@example.edu", identity: { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-1" } },
+      { userId: "u-2", normalizedEmail: "alice@example.edu", identity: null },
+      { userId: "u-3", normalizedEmail: "bob@example.edu", identity: { issuer: "https://issuer.example", tenantId: "tenant-a" } },
+      { userId: "u-4", normalizedEmail: "carol@example.edu", identity: { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-4" } },
+      { userId: "u-5", normalizedEmail: "dave@example.edu", identity: { issuer: "https://issuer.example", tenantId: "tenant-a", objectId: "oid-5" } },
+      { userId: "u-6", normalizedEmail: "erin@example.edu", identity: null },
+    ]);
+  });
+
+  test("does not mutate user or directory fixtures", () => {
+    const originalUsers = structuredClone(users);
+    const originalDirectory = structuredClone(directory);
+    reportFor();
+    assert.deepEqual(users, originalUsers);
+    assert.deepEqual(directory, originalDirectory);
+  });
+});


### PR DESCRIPTION
## Rationale

Commerce ownership cannot safely depend on mutable email addresses. Before changing login or persisting a tenant-scoped identity, operators need a deterministic way to distinguish exact authoritative mappings from ambiguous records that require human review.

This PR introduces only the pure analysis boundary. It does not read MongoDB, modify users, or enable commerce ownership.

## Observable Behavior

Given existing users and an independently verified directory export, the analyzer returns:

- exact `userId` to `(issuer, tenantId, objectId)` mapping candidates
- normalized-email groups for investigation, never account linking
- review holds for missing, incomplete, malformed, duplicate, conflicting, unknown, or cross-source identity evidence
- deterministic counts and ordering
- projections limited to internal IDs, normalized emails, and identity fields

Email-only evidence is retained for review but cannot create or override an exact mapping. A provider identity claimed by multiple existing or unknown users blocks every affected mapping.

## Verification

- Pure analyzer tests: 16 passed
- Combined identity slice tests: 24 passed
- Backend suite: 109 passed
- Frontend suite: 73 passed
- Production frontend build: passed

## Stack Context

- Parent: #151 — fail-closed checkout readiness
- This PR: pure identity migration evidence analyzer
- Child: #153 — read-only operational CLI
- Schema/index/login migration remains blocked on D07/D09 and schema-owner approval
