### PR TITLE
feat(identity): add read-only migration report CLI

### DIFF
--- a/backend/scripts/report-identity-migration.js
+++ b/backend/scripts/report-identity-migration.js
@@ -1,0 +1,239 @@
+import { open, readFile, realpath, unlink } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import mongoose from "mongoose";
+import { buildReport } from "../identityMigrationReport.js";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(SCRIPT_DIR, "../..");
+
+
+function reportError(reportCode, message, cause) {
+  const error = new Error(message, cause ? { cause } : undefined);
+  error.reportCode = reportCode;
+  return error;
+}
+
+function safeReportCode(error) {
+  return typeof error?.reportCode === "string"
+    ? error.reportCode
+    : "unexpected_error";
+}
+
+/**
+ * @behavior Write one private report outside the repository without overwriting.
+ * @param report — JSON-safe report returned by buildReport
+ * @param outputPath — absolute operator-selected destination
+ * @param options — repository boundary used to reject in-repository output
+ * @returns nothing after the complete report is written and closed
+ * @exceptions Error for invalid paths, existing files, serialization, or writes
+ */
+export async function writeReport(
+  report,
+  outputPath,
+  { repositoryRoot = REPOSITORY_ROOT } = {},
+) {
+  if (!path.isAbsolute(outputPath)) {
+    throw reportError("output_path_invalid", "output path must be absolute");
+  }
+
+  const target = path.resolve(outputPath);
+  let root;
+  let parent;
+  try {
+    root = await realpath(path.resolve(repositoryRoot));
+    parent = await realpath(path.dirname(target));
+  } catch (error) {
+    throw reportError("output_path_invalid", "output parent is unavailable", error);
+  }
+  const relative = path.relative(root, path.join(parent, path.basename(target)));
+  const insideRepository = relative === ""
+    || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+  if (insideRepository) {
+    throw reportError("output_path_invalid", "output must be outside repository");
+  }
+
+  let serialized;
+  try {
+    serialized = JSON.stringify(report, null, 2);
+  } catch (error) {
+    throw reportError("output_serialize_failed", "report cannot be serialized", error);
+  }
+  if (typeof serialized !== "string") {
+    throw reportError("output_serialize_failed", "report cannot be serialized");
+  }
+
+  let handle;
+  try {
+    handle = await open(target, "wx", 0o600);
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      throw reportError("output_exists", "output already exists; overwrite refused", error);
+    }
+    throw reportError("output_write_failed", "output file could not be created", error);
+  }
+
+  let failure;
+  try {
+    await handle.writeFile(`${serialized}\n`, "utf8");
+    await handle.chmod(0o600);
+  } catch (error) {
+    failure = reportError("output_write_failed", "report output failed", error);
+  }
+
+  try {
+    await handle.close();
+  } catch (error) {
+    failure ??= reportError("output_write_failed", "report output could not be closed", error);
+  }
+  if (failure) {
+    try {
+      await unlink(target);
+    } catch (error) {
+      throw reportError(
+        "output_cleanup_failed",
+        "failed report output could not be removed",
+        error,
+      );
+    }
+    throw failure;
+  }
+}
+
+/**
+ * @behavior Read the minimum user projection without model or index initialization.
+ * @param dbUri — operator-provided MongoDB connection string
+ * @param options — injectable connection factory for focused tests
+ * @returns raw user records needed by buildReport
+ * @exceptions Error with a safe report code when configuration or reading fails
+ */
+export async function loadUsers(
+  dbUri,
+  { createConnection = (uri, options) => mongoose.createConnection(uri, options) } = {},
+) {
+  if (typeof dbUri !== "string" || !dbUri.trim()) {
+    throw reportError("database_configuration_invalid", "DB_URI is required");
+  }
+
+  let connection;
+  try {
+    connection = createConnection(dbUri, {
+      autoCreate: false,
+      autoIndex: false,
+    });
+  } catch (error) {
+    throw reportError("database_unavailable", "database connection failed", error);
+  }
+
+  let users;
+  let failure;
+  try {
+    await connection.asPromise();
+  } catch (error) {
+    failure = reportError("database_unavailable", "database connection failed", error);
+  }
+  if (!failure) {
+    try {
+      users = await connection
+        .collection("users")
+        .find({}, { projection: { _id: 1, uEmail: 1, identity: 1 } })
+        .toArray();
+    } catch (error) {
+      failure = reportError("database_read_failed", "user report query failed", error);
+    }
+  }
+
+  try {
+    await connection.close();
+  } catch (error) {
+    failure ??= reportError("database_close_failed", "database connection close failed", error);
+  }
+  if (failure) throw failure;
+  return users;
+}
+
+function parseArgs(argv) {
+  let outputPath;
+  let directoryPath;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--output" && !outputPath) {
+      outputPath = argv[++index];
+    } else if (argument === "--directory" && !directoryPath) {
+      directoryPath = argv[++index];
+    } else {
+      throw reportError("invalid_arguments", "unknown or malformed arguments");
+    }
+  }
+  if (
+    !outputPath
+    || !path.isAbsolute(outputPath)
+    || (directoryPath !== undefined && !directoryPath)
+  ) {
+    throw reportError("invalid_arguments", "--output requires an absolute path");
+  }
+  return { outputPath, directoryPath };
+}
+
+async function readDirectoryFile(directoryPath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(directoryPath, "utf8"));
+  } catch (error) {
+    throw reportError(
+      "directory_input_invalid",
+      "directory JSON is malformed or unreadable",
+      error,
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw reportError("directory_input_invalid", "directory JSON must be an array");
+  }
+  return parsed;
+}
+
+/**
+ * @behavior Orchestrate one report-only command with injectable I/O boundaries.
+ * @param input — CLI arguments, environment, repository root, and dependencies
+ * @returns safe aggregate counts for operator output
+ * @exceptions Error with a non-secret report code for every failure boundary
+ */
+export async function runReport({
+  argv = [],
+  env = {},
+  repositoryRoot = REPOSITORY_ROOT,
+  dependencies = {},
+} = {}) {
+  const { outputPath, directoryPath } = parseArgs(argv);
+  const readDirectory = dependencies.readDirectory ?? readDirectoryFile;
+  const loadUserRecords = dependencies.loadUsers ?? loadUsers;
+  const writeReportFile = dependencies.writeReport ?? writeReport;
+
+  const directory = directoryPath ? await readDirectory(directoryPath) : [];
+  const users = await loadUserRecords(env.DB_URI);
+  const report = buildReport({ users, directory });
+  await writeReportFile(report, outputPath, { repositoryRoot });
+  return {
+    users: report.counts.users,
+    mappings: report.counts.completeMappings,
+    reviewHolds: report.counts.reviewHolds,
+  };
+}
+
+async function main() {
+  const result = await runReport({
+    argv: process.argv.slice(2),
+    env: process.env,
+  });
+  console.log(
+    `identity migration report written: users=${result.users} `
+    + `mappings=${result.mappings} holds=${result.reviewHolds}`,
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`identity migration report failed: ${safeReportCode(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/backend/test/identity-migration-cli.test.js
+++ b/backend/test/identity-migration-cli.test.js
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile as writeTempFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { buildReport } from "../identityMigrationReport.js";
+import {
+  loadUsers,
+  runReport,
+  writeReport,
+} from "../scripts/report-identity-migration.js";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const scriptPath = fileURLToPath(new URL("../scripts/report-identity-migration.js", import.meta.url));
+const issuer = "https://issuer.example";
+const identity = (objectId) => ({ issuer, tenantId: "tenant-a", objectId });
+const users = [
+  { _id: "u-1", uEmail: "alice@example.edu", identity: identity("oid-1") },
+  { _id: "u-2", uEmail: "alice@example.edu", identity: null },
+  { _id: "u-3", uEmail: "bob@example.edu", identity: { issuer, tenantId: "tenant-a" } },
+  { _id: "u-4", uEmail: "carol@example.edu", identity: identity("oid-4") },
+  { _id: "u-5", uEmail: "dave@example.edu", identity: identity("oid-5") },
+  { _id: "u-6", uEmail: "erin@example.edu", identity: null },
+];
+const directory = [
+  { userId: "u-1", ...identity("oid-1") },
+  { email: "alice@example.edu", ...identity("oid-2") },
+  { userId: "u-3", issuer, tenantId: "tenant-a" },
+  { userId: "u-4", ...identity("oid-shared") },
+  { userId: "u-5", ...identity("oid-shared") },
+  { userId: "u-5", ...identity("oid-other") },
+  { userId: "u-unknown", ...identity("oid-unknown") },
+  { userId: "u-6", ...identity("oid-6") },
+  { userId: "u-1", ...identity("oid-1") },
+];
+
+function reportFor() {
+  return buildReport({ users, directory });
+}
+
+describe("identity migration report output", () => {
+  let tempRoot;
+  test.beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), "iuga-identity-report-"));
+  });
+  test.afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  test("writes JSON only to an absolute operator-selected path with mode 0600", async () => {
+    const outputPath = path.join(tempRoot, "migration.json");
+    const report = reportFor();
+    await writeReport(report, outputPath, { repositoryRoot });
+    assert.deepEqual(JSON.parse(await readFile(outputPath, "utf8")), report);
+    assert.equal((await stat(outputPath)).mode & 0o777, 0o600);
+  });
+
+  test("refuses relative paths and paths inside the repository", async () => {
+    await assert.rejects(() => writeReport(reportFor(), "migration.json", { repositoryRoot }), /absolute/i);
+    await assert.rejects(
+      () => writeReport(reportFor(), path.join(repositoryRoot, "backend", "migration.json"), { repositoryRoot }),
+      /outside|repository/i,
+    );
+  });
+
+  test("refuses to overwrite an existing output file", async () => {
+    const outputPath = path.join(tempRoot, "existing.json");
+    await writeTempFile(outputPath, "operator data", { mode: 0o600 });
+    await assert.rejects(() => writeReport(reportFor(), outputPath, { repositoryRoot }), /exist|overwrite/i);
+    assert.equal(await readFile(outputPath, "utf8"), "operator data");
+  });
+
+  test("does not leave an output file when the report cannot be serialized", async () => {
+    const outputPath = path.join(tempRoot, "invalid.json");
+    const circularReport = {};
+    circularReport.self = circularReport;
+
+    await assert.rejects(
+      () => writeReport(circularReport, outputPath, { repositoryRoot }),
+      /circular|serialize/i,
+    );
+    await assert.rejects(() => stat(outputPath), { code: "ENOENT" });
+  });
+});
+
+describe("identity migration report command", () => {
+  test("reads users through a connection that cannot auto-create indexes", async () => {
+    const calls = [];
+    const expectedUsers = [{ _id: "u-1", uEmail: "user@example.edu" }];
+    const connection = {
+      async asPromise() {
+        calls.push(["asPromise"]);
+        return this;
+      },
+      collection(name) {
+        calls.push(["collection", name]);
+        return {
+          find(filter, options) {
+            calls.push(["find", filter, options]);
+            return { toArray: async () => expectedUsers };
+          },
+        };
+      },
+      async close() {
+        calls.push(["close"]);
+      },
+    };
+
+    const result = await loadUsers("mongodb://database.example/iuga", {
+      createConnection(uri, options) {
+        calls.push(["createConnection", uri, options]);
+        return connection;
+      },
+    });
+
+    assert.deepEqual(result, expectedUsers);
+    assert.deepEqual(calls, [
+      ["createConnection", "mongodb://database.example/iuga", {
+        autoCreate: false,
+        autoIndex: false,
+      }],
+      ["asPromise"],
+      ["collection", "users"],
+      ["find", {}, { projection: { _id: 1, uEmail: 1, identity: 1 } }],
+      ["close"],
+    ]);
+  });
+
+  test("closes the read-only connection when its handshake fails", async () => {
+    let closed = false;
+    const connection = {
+      async asPromise() {
+        throw new Error("credential must not escape");
+      },
+      async close() {
+        closed = true;
+      },
+    };
+
+    await assert.rejects(
+      () => loadUsers("mongodb://database.example/iuga", {
+        createConnection: () => connection,
+      }),
+      (error) => {
+        assert.equal(error.reportCode, "database_unavailable");
+        assert.doesNotMatch(error.message, /credential must not escape/);
+        return true;
+      },
+    );
+    assert.equal(closed, true);
+  });
+
+  test("orchestrates directory input, read-only loading, and report output", async () => {
+    const calls = [];
+    const outputPath = path.join(os.tmpdir(), "operator-report.json");
+    const result = await runReport({
+      argv: ["--directory", "/operator/directory.json", "--output", outputPath],
+      env: { DB_URI: "mongodb://database.example/iuga" },
+      repositoryRoot,
+      dependencies: {
+        async readDirectory(inputPath) {
+          calls.push(["readDirectory", inputPath]);
+          return directory;
+        },
+        async loadUsers(dbUri) {
+          calls.push(["loadUsers", dbUri]);
+          return users;
+        },
+        async writeReport(report, target, options) {
+          calls.push(["writeReport", target, options, report.counts]);
+        },
+      },
+    });
+
+    assert.deepEqual(result, {
+      users: 6,
+      mappings: 1,
+      reviewHolds: 6,
+    });
+    assert.deepEqual(calls, [
+      ["readDirectory", "/operator/directory.json"],
+      ["loadUsers", "mongodb://database.example/iuga"],
+      ["writeReport", outputPath, { repositoryRoot }, {
+        users: 6,
+        emailGroups: 5,
+        emailCollisions: 1,
+        directoryRows: 9,
+        completeMappings: 1,
+        reviewHolds: 6,
+        duplicateRows: 1,
+      }],
+    ]);
+  });
+
+  test("reports a safe actionable code for malformed directory input", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "iuga-identity-cli-"));
+    try {
+      const directoryPath = path.join(tempRoot, "directory.json");
+      const outputPath = path.join(tempRoot, "report.json");
+      const secret = "must-not-appear";
+      await writeTempFile(directoryPath, `{${secret}`, { mode: 0o600 });
+
+      const result = spawnSync(
+        process.execPath,
+        [scriptPath, "--directory", directoryPath, "--output", outputPath],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            DB_URI: `mongodb://user:${secret}@database.example/iuga`,
+          },
+        },
+      );
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      assert.notEqual(result.status, 0);
+      assert.match(output, /directory_input_invalid/);
+      assert.doesNotMatch(output, new RegExp(secret, "u"));
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -17,6 +17,7 @@
 | `bin/www.cjs` | HTTP server bootstrap — imports `app.js`, listens on `PORT` (default 7777) |
 | `app.js` | Express application setup — middleware stack, static serving, API mount |
 | `models.js` | MongoDB connection + Mongoose model registration |
+| `scripts/report-identity-migration.js` | Report-only identity migration CLI; requires an absolute `--output` path outside the repository and optionally accepts `--directory <json>` |
 
 ---
 
@@ -29,6 +30,8 @@ backend/
 ├── httpBoundaryConfig.js    ← Shared body-size and browser-origin policy
 ├── httpErrorHandler.js      ← Safe JSON responses for parser/server errors
 ├── models.js                ← Database connection + model registration
+├── scripts/
+│   └── report-identity-migration.js ← Read-only identity migration report CLI
 ├── schemas/                 ← Git submodule → UW-IUGA/iuga-web-schemas
 ├── routes/
 │   └── api/v1/
@@ -48,6 +51,29 @@ backend/
 ├── env/                    ← Ignored runtime environment files
 └── package.json            ← ES module ("type": "module")
 ```
+
+## Identity migration report
+
+Run from `backend/` with a configured `DB_URI`:
+
+```bash
+node scripts/report-identity-migration.js --output /absolute/path/migration-report.json
+node scripts/report-identity-migration.js --directory /absolute/path/directory.json --output /absolute/path/migration-report.json
+```
+
+The command reads only `_id`, `uEmail`, and the undeclared `identity` field
+through a dedicated raw MongoDB connection with automatic collection and index
+creation disabled. It never updates MongoDB, has no apply mode, refuses
+repository paths and existing output files, and writes a private JSON report
+with mode `0600`.
+
+Directory input must be a JSON array. Rows are authoritative only when they
+include an explicit `userId` and complete `issuer`/`tenantId`/`objectId`
+values. Email-only and malformed rows retain their source index and normalized
+identity evidence for review. `reviewHolds` counts distinct affected local or
+unknown user IDs plus evidence rows that cannot be associated with a user; it
+is not a directory-row count. Review holds are not migration instructions and
+must be resolved by an identity owner.
 
 ---
 


### PR DESCRIPTION
## Rationale

The identity owner needs a safe operator command to run the analyzer against real user records and an optional authoritative directory export. Reusing the application model bootstrap could implicitly initialize collections or indexes, so the report requires a deliberately read-only database boundary.

## Observable Behavior

The command:

```bash
node scripts/report-identity-migration.js --directory /absolute/directory.json --output /absolute/report.json
```

- reads only `_id`, `uEmail`, and `identity`
- uses a dedicated raw MongoDB connection with `autoCreate:false` and `autoIndex:false`
- always closes the connection
- never updates users and has no apply mode
- refuses relative output paths, repository paths, and existing files
- writes exclusive JSON with mode `0600`
- removes incomplete output after write failure
- prints safe actionable failure codes without credentials or source payloads

## Verification

- CLI/output tests: 8 passed
- Combined identity slice tests: 24 passed
- Backend suite: 109 passed
- Frontend suite: 73 passed
- Production frontend build: passed
- Two complete adversarial review/adjudication cycles; all verified findings fixed
- Final post-split reviewer attempt was blocked by external model usage limits

## Stack Context

- Parent: #152 — pure identity migration evidence analyzer
- This PR: read-only MongoDB and file-output CLI
- Grandparent: #151 — fail-closed checkout readiness
- This report produces review evidence only; it does not authorize schema or login migration
