### PR TITLE
feat(events): persist event host metadata and gate participant privacy

### DIFF
--- a/backend/routes/api/v1/controllers/eventRequests.js
+++ b/backend/routes/api/v1/controllers/eventRequests.js
@@ -67,6 +67,36 @@ function defaultCheckpoints() {
   return CHECKPOINT_KEYS.map((key) => ({ key, status: "pending" }));
 }
 
+function readHost(value) {
+  if (value === undefined || value === null) return { fields: null };
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return { error: "eHost must be an object" };
+  }
+  const unknown = Object.keys(value).filter(
+    (key) => key !== "name" && key !== "userId",
+  );
+  if (unknown.length > 0) {
+    return {
+      error: `eHost contains unsupported field${unknown.length > 1 ? "s" : ""}: ${unknown.join(", ")}`,
+    };
+  }
+  if (typeof value.name !== "string" || value.name.trim() === "") {
+    return { error: "eHost.name is required" };
+  }
+  const name = value.name.trim();
+  if (name.length > 120) {
+    return { error: "eHost.name must be 120 characters or fewer" };
+  }
+  if (
+    value.userId !== undefined &&
+    value.userId !== null &&
+    !mongoose.isValidObjectId(String(value.userId))
+  ) {
+    return { error: "eHost.userId must be a valid user id" };
+  }
+  return { fields: { name, userId: value.userId ?? null } };
+}
+
 function readRequestFields(body = {}) {
   body ??= {};
   if (typeof body !== "object" || Array.isArray(body)) {
@@ -119,6 +149,17 @@ function readRequestFields(body = {}) {
     const questions = readRsvpQuestions(body.rsvpQuestions);
     if (questions.error) return questions;
     fields.rsvpQuestions = questions.fields;
+  }
+  if (body.eHost !== undefined) {
+    const eHost = readHost(body.eHost);
+    if (eHost.error) return eHost;
+    fields.eHost = eHost.fields;
+  }
+  if (body.eShowParticipants !== undefined) {
+    if (typeof body.eShowParticipants !== "boolean") {
+      return { error: "eShowParticipants must be a boolean" };
+    }
+    fields.eShowParticipants = body.eShowParticipants;
   }
   if (body.slideTemplate !== undefined) {
     const template = body.slideTemplate;
@@ -367,6 +408,8 @@ router.post("/:id/approve", requireOfficerRolePermission("events.leadership.appr
       eDescription: eventRequest.description,
       eRsvpEnabled: eventRequest.rsvpEnabled,
       rsvpQuestions: eventRequest.rsvpQuestions || [],
+      eShowParticipants: eventRequest.eShowParticipants ?? false,
+      eHost: eventRequest.eHost || null,
     });
     const updated = await transitionRequest(req, req.params.id, LEADERSHIP_STATUSES, {
       status: "approved",

--- a/backend/routes/api/v1/controllers/events.js
+++ b/backend/routes/api/v1/controllers/events.js
@@ -91,6 +91,7 @@ router.get("/", async function (req, res) {
             eOrganizers: event.eOrganizers,
             eDescription: event.eDescription,
             eLabels: event.eLabels,
+            eHost: event.eHost ?? null,
             hasRSVPd: hasRSVPd,
           };
         }),
@@ -110,6 +111,7 @@ router.get("/", async function (req, res) {
             eOrganizers: event.eOrganizers,
             eDescription: event.eDescription,
             eLabels: event.eLabels,
+            eHost: event.eHost ?? null,
             hasRSVPd: false,
           };
         }),
@@ -142,9 +144,10 @@ Expected Response Information:
             eOrganizers: Array of String event organizer(s),
             eDescription: String event description,
             eLabels: Array of String event category label(s),
-            ePics: Array of Image event pics,
+            eHost: Object canonical event host snapshot or null,
             qList: Array of key:value pairs representing RSVP question number and question string,
-            participants: Array of participant ids,
+            participants: Number of participants or null when not authenticated or not shown,
+            showParticipants: Boolean whether participant details are exposed,
             eThumbnail: a Image of event
         }]
 */
@@ -179,6 +182,9 @@ router.get("/id/:eId", async function (req, res) {
       }
     }
 
+    const showParticipants =
+      Boolean(req.session.isAuthenticated) && Boolean(event.eShowParticipants);
+
     const eventData = {
       eId: event._id,
       eName: event.eName,
@@ -187,12 +193,12 @@ router.get("/id/:eId", async function (req, res) {
       eEndDate: event.eEndDate,
       eLocation: event.eLocation,
       eDescription: event.eDescription,
-      ePics: event.ePics,
       eLabels: event.eLabels,
+      eHost: event.eHost ?? null,
       rsvpQuestions: event.rsvpQuestions,
       rsvpAnswers,
-      participants: event.eShowParticipants ? event.eParticipants.length : null,
-      showParticipants: event.eShowParticipants,
+      participants: showParticipants ? event.eParticipants.length : null,
+      showParticipants,
       eThumbnailPath: event.eThumbnailPath,
       rsvpEnabled: event.eRsvpEnabled,
       eAltLink: event.eAltLink,

--- a/backend/test/event-requests.test.js
+++ b/backend/test/event-requests.test.js
@@ -200,6 +200,75 @@ describe("event request API", () => {
     assert.equal(result.body.event.eName, "IUGA Workshop");
   });
 
+  it("rejects malformed host metadata and a non-boolean privacy flag", async () => {
+    const base = {
+      eventName: "IUGA Workshop",
+      requestingGroup: "Tech Committee",
+      description: "A useful workshop",
+      proposedStartDate: "2026-09-01T18:00:00Z",
+    };
+
+    const hostWithoutName = await api.request(
+      "POST",
+      "/api/v1/event-requests",
+      { ...base, eHost: { userId: organizerId } },
+      { models: makeModels() },
+    );
+    assert.equal(hostWithoutName.status, 400);
+
+    const hostWithUnknownField = await api.request(
+      "POST",
+      "/api/v1/event-requests",
+      { ...base, eHost: { name: "Ada", bogus: "nope" } },
+      { models: makeModels() },
+    );
+    assert.equal(hostWithUnknownField.status, 400);
+
+    const badFlag = await api.request(
+      "POST",
+      "/api/v1/event-requests",
+      { ...base, eShowParticipants: "yes" },
+      { models: makeModels() },
+    );
+    assert.equal(badFlag.status, 400);
+  });
+
+  it("copies host metadata and participant privacy into the published event on approval", async () => {
+    const eHost = {
+      name: "Ada Lovelace",
+      userId: organizerId,
+    };
+    const request = {
+      ...submittedRequest,
+      eHost,
+      eShowParticipants: true,
+    };
+
+    const result = await api.request(
+      "POST",
+      `/api/v1/event-requests/${requestId}/approve`,
+      {},
+      { models: makeModels({ request, permissions: ["events.leadership.approve"] }) },
+    );
+
+    assert.equal(result.status, 200);
+    assert.deepEqual(result.body.event.eHost, eHost);
+    assert.equal(result.body.event.eShowParticipants, true);
+  });
+
+  it("defaults published events to hidden participants when the request omits the flag", async () => {
+    const result = await api.request(
+      "POST",
+      `/api/v1/event-requests/${requestId}/approve`,
+      {},
+      { models: makeModels({ permissions: ["events.leadership.approve"] }) },
+    );
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.event.eShowParticipants, false);
+    assert.equal(result.body.event.eHost, null);
+  });
+
   it("records the external review link and receipt actor", async () => {
     const result = await api.request(
       "PATCH",

--- a/backend/test/events.test.js
+++ b/backend/test/events.test.js
@@ -77,6 +77,7 @@ describe("event Mongoose boundaries", () => {
         eOrganizers: "IUGA",
         eDescription: "A baseline event",
         eLabels: ["community"],
+        eHost: null,
         hasRSVPd: true,
       },
     ]);
@@ -124,5 +125,93 @@ describe("event Mongoose boundaries", () => {
     assert.equal(savedParticipant.eID, eventId);
     assert.equal(event.eParticipants[0]._id, participantId);
     assert.equal(eventSaved, true);
+  });
+});
+
+describe("event detail metadata and participant privacy", () => {
+  let api;
+
+  before(async () => {
+    api = await makeTestApi({
+      router: eventsRouter,
+      mountPath: "/api/v1/events",
+      models: {},
+      session: { isAuthenticated: true, userId },
+    });
+  });
+
+  after(async () => {
+    await api.close();
+  });
+
+  function detailApi(event, isAuthenticated) {
+    return api.request(
+      "GET",
+      `/api/v1/events/id/${eventId}`,
+      undefined,
+      {
+        session: { isAuthenticated },
+        models: {
+          Events: { findById: () => query(event) },
+          Participants: {
+            findOne: () => ({ async exec() { return null; } }),
+          },
+        },
+      },
+    );
+  }
+
+  const eHost = {
+    name: "Ada Lovelace",
+    userId,
+  };
+
+  it("hides participant details for anonymous visitors", async () => {
+    const event = makeEvent({ eShowParticipants: true });
+    const result = await detailApi(event, false);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.showParticipants, false);
+    assert.equal(result.body.participants, null);
+    assert.equal(result.body.eHost, null);
+    assert.equal("ePics" in result.body, false);
+    assert.equal("pastEventPhotos" in result.body, false);
+  });
+
+  it("exposes the participant count only to authenticated viewers when opted in", async () => {
+    const event = makeEvent({
+      eShowParticipants: true,
+      eParticipants: [
+        { pUID: new mongoose.Types.ObjectId() },
+        { pUID: new mongoose.Types.ObjectId() },
+      ],
+    });
+    const result = await detailApi(event, true);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.showParticipants, true);
+    assert.equal(result.body.participants, 2);
+    assert.equal("ePics" in result.body, false);
+  });
+
+  it("keeps participant details hidden for authenticated viewers when the organizer opts out", async () => {
+    const event = makeEvent({
+      eShowParticipants: false,
+      eParticipants: [{ pUID: new mongoose.Types.ObjectId() }],
+    });
+    const result = await detailApi(event, true);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.showParticipants, false);
+    assert.equal(result.body.participants, null);
+  });
+
+  it("serializes the host snapshot on event detail", async () => {
+    const event = makeEvent({ eHost });
+    const result = await detailApi(event, false);
+
+    assert.equal(result.status, 200);
+    assert.deepEqual(result.body.eHost, eHost);
+    assert.equal("pastEventPhotos" in result.body, false);
   });
 });

--- a/backend/test/models.test.js
+++ b/backend/test/models.test.js
@@ -1,7 +1,63 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import mongoose from "mongoose";
 import { connectToDatabase } from "../models.js";
+import { eventsSchema, eventRequestsSchema } from "../schemas/schemas.js";
+
+const TestEvents = mongoose.model("TestEvents", eventsSchema);
+const TestEventRequests = mongoose.model("TestEventRequests", eventRequestsSchema);
+
+const eventDefaults = {
+    eName: "Baseline event",
+    eOrganizers: "IUGA",
+    eStartDate: new Date("2026-09-01T18:00:00Z"),
+    eLocation: "Campus",
+    eDescription: "A baseline event",
+};
+const requestDefaults = {
+    requesterId: "507f1f77bcf86cd799439011",
+    organizerId: "507f1f77bcf86cd799439011",
+    eventName: "Baseline event",
+    requestingGroup: "Tech Committee",
+    description: "A baseline event request",
+    proposedStartDate: new Date("2026-09-01T18:00:00Z"),
+    submittedBy: "507f1f77bcf86cd799439011",
+};
 
 test("model registry module loads shared schemas", () => {
     assert.equal(typeof connectToDatabase, "function");
+});
+
+test("events and event requests default to hidden participants and no host", async () => {
+    const event = new TestEvents(eventDefaults);
+    assert.equal(event.eShowParticipants, false);
+    assert.equal(event.eHost, null);
+    await event.validate();
+
+    const request = new TestEventRequests(requestDefaults);
+    assert.equal(request.eShowParticipants, false);
+    assert.equal(request.eHost, null);
+    await request.validate();
+});
+
+test("a host snapshot without a name is rejected", async () => {
+    const event = new TestEvents({
+        ...eventDefaults,
+        eHost: { userId: "507f1f77bcf86cd799439011" },
+    });
+    await assert.rejects(
+        () => event.validate(),
+        (error) => error.name === "ValidationError" && /eHost\.name/.test(error.message),
+    );
+});
+
+test("a valid host snapshot passes validation", async () => {
+    const event = new TestEvents({
+        ...eventDefaults,
+        eHost: { name: "Ada Lovelace", userId: "507f1f77bcf86cd799439011" },
+    });
+    await event.validate();
+
+    assert.equal(event.eHost.name, "Ada Lovelace");
+    assert.equal(event.eHost.userId.toString(), "507f1f77bcf86cd799439011");
 });


### PR DESCRIPTION
## Rationale

Host details entered on an event request were lost at approval time because the published `Events` document had nowhere to store them and the approval mapping never copied them. At the same time, `GET /api/v1/events/id/:eId` exposed attendee counts to anonymous internet visitors, and emitted a phantom `ePics` field that was never persisted.

The field is `eHost`, not "leader": a host is not necessarily an IUGA officer (affiliate RSOs and other student groups host events), and "leader" collides with the existing `events.leadership` approval vocabulary. The snapshot stays minimal — a required `name` plus an optional `userId` — so no redundant role/photo keys are stored; officer decoration and event imagery are separate concerns.

This change makes the events contract real end-to-end: host metadata survives the request -> approval -> published-event lifecycle, the API exposes a uniform shape, and participant data is private-by-default and opt-in.

## Observable Behavior

- Event requests accept and validate an optional `eHost` (`name` required, `userId` optional) and a boolean `eShowParticipants`; malformed payloads (unknown fields, missing name, invalid `userId`, non-boolean flag) are rejected with `400` instead of persisting.
- Approving a request copies the host and privacy flag into the published event. Requests that omit them publish `eHost: null` and `eShowParticipants: false`.
- Calendar list and event detail responses return `eHost` (`null` when unset), and the unpersisted `ePics` field is gone.
- `GET /api/v1/events/id/:eId` returns participant details only to an authenticated viewer when the organizer opted in; anonymous requests always receive `showParticipants: false` and `participants: null`.

## Verification

Behavioral tests added/updated in the backend suite:

- `event-requests.test.js`: approving a request persists host + privacy flag; omitting them defaults to hidden participants; nameless/unknown-field host payloads and a non-boolean privacy flag return `400`.
- `events.test.js`: detail gates participants across anonymous / authenticated-opted-in / authenticated-opted-out and serializes the host snapshot; the list response carries `eHost`; `ePics` is absent.
- `models.test.js`: schema defaults, required host name, and valid host snapshot.

Ran `npm test` in `backend`: **86 passed / 0 failed**.

## Stack Context

- Position: 1 of 6 (bottom of the events-redesign stack; #132–#136 not yet opened)
- Base PR: N/A (targets `dev`)
- Depends on: UW-IUGA/iuga-web-schemas#10

Closes #131
