### PR TITLE
feat(shop): prevent overselling with inventory reservations

### DIFF
--- a/backend/shop/reservations.js
+++ b/backend/shop/reservations.js
@@ -1,0 +1,273 @@
+/**
+ * Inventory reservation and fencing repository for the IUGA Stripe merchandise store.
+ * Manages atomic holds, consumptions, and verified non-payable releases against InventoryCounter.
+ */
+
+export class InsufficientInventoryError extends Error {
+  constructor({ skuKey, fulfillmentSku, requestedQuantity, availableQuantity }) {
+    super(`Insufficient inventory for SKU ${skuKey} (${fulfillmentSku}): requested ${requestedQuantity}, available ${availableQuantity ?? 0}`);
+    this.name = "InsufficientInventoryError";
+    this.skuKey = skuKey;
+    this.fulfillmentSku = fulfillmentSku;
+    this.requestedQuantity = requestedQuantity;
+    this.availableQuantity = availableQuantity ?? 0;
+  }
+}
+
+/*
+ * @behavior  Holds inventory for finite catalog items in a cart, rolling back on failure.
+ * @param     models — Mongoose model registry or injected mock models
+ * @param     orderId — internal order identifier
+ * @param     items — normalized cart items [{ skuKey, quantity }]
+ * @param     catalog — list of catalog entries
+ * @param     now — current timestamp for reservation
+ * @param     ttlMs — reservation lifetime in milliseconds
+ * @param     session — optional Mongoose client session for multi-document transaction
+ * @returns   array of created InventoryReservation records
+ * @exceptions throws InsufficientInventoryError if any item lacks available stock
+ */
+export async function holdInventory({
+  models,
+  orderId,
+  items,
+  catalog,
+  now = new Date(),
+  ttlMs = 15 * 60 * 1000,
+  session = null,
+}) {
+  if (!orderId || typeof orderId !== "string") {
+    throw new Error("orderId must be a non-empty string");
+  }
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error("items must be a non-empty array");
+  }
+
+  const catalogMap = new Map((catalog || []).map((entry) => [entry.skuKey, entry]));
+  const successfulHolds = [];
+  const reservationsToCreate = [];
+
+  const expiresAt = new Date(now.getTime() + ttlMs);
+
+  for (const item of items) {
+    const entry = catalogMap.get(item.skuKey);
+    if (!entry) {
+      throw new Error(`Catalog entry not found for SKU ${item.skuKey}`);
+    }
+
+    // Preorder items do not reserve finite inventory
+    if (entry.inventoryPolicy === "preorder") {
+      continue;
+    }
+
+    const fulfillmentSku = entry.fulfillmentSku || item.skuKey;
+    const quantity = item.quantity;
+
+    // Atomically decrement available stock and increment reserved stock
+    const updatedCounter = await models.InventoryCounter.findOneAndUpdate(
+      {
+        fulfillmentSku,
+        available: { $gte: quantity },
+      },
+      {
+        $inc: {
+          available: -quantity,
+          reserved: quantity,
+          version: 1,
+        },
+      },
+      { session, new: true },
+    );
+
+    if (!updatedCounter) {
+      // Roll back previously successful holds in this batch
+      for (const hold of successfulHolds) {
+        await models.InventoryCounter.findOneAndUpdate(
+          { fulfillmentSku: hold.fulfillmentSku },
+          {
+            $inc: {
+              available: hold.quantity,
+              reserved: -hold.quantity,
+              version: 1,
+            },
+          },
+          { session },
+        );
+      }
+
+      throw new InsufficientInventoryError({
+        skuKey: item.skuKey,
+        fulfillmentSku,
+        requestedQuantity: quantity,
+        availableQuantity: 0,
+      });
+    }
+
+    successfulHolds.push({ fulfillmentSku, quantity });
+    reservationsToCreate.push({
+      orderId,
+      skuKey: item.skuKey,
+      fulfillmentSku,
+      quantity,
+      state: "reserved",
+      expiresAt,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  if (reservationsToCreate.length > 0) {
+    try {
+      await models.InventoryReservation.create(reservationsToCreate, { session });
+    } catch (err) {
+      // Compensate all previously held counters if reservation document persistence fails
+      for (const hold of successfulHolds) {
+        await models.InventoryCounter.findOneAndUpdate(
+          { fulfillmentSku: hold.fulfillmentSku },
+          {
+            $inc: {
+              available: hold.quantity,
+              reserved: -hold.quantity,
+              version: 1,
+            },
+          },
+          { session },
+        );
+      }
+      throw err;
+    }
+  }
+
+  return reservationsToCreate;
+}
+
+/*
+ * @behavior  Consumes reserved inventory upon verified payment confirmation.
+ * @param     models — Mongoose model registry or injected mock models
+ * @param     orderId — internal order identifier
+ * @param     session — optional Mongoose client session
+ * @param     now — current timestamp
+ * @returns   object with consumedCount
+ * @exceptions throws on database error or if counter fence is lost
+ */
+export async function consumeInventory({
+  models,
+  orderId,
+  session = null,
+  now = new Date(),
+}) {
+  const reservations = await models.InventoryReservation.find(
+    { orderId, state: "reserved" },
+    null,
+    { session },
+  );
+
+  const successfulConsumes = [];
+
+  for (const res of reservations) {
+    const updatedCounter = await models.InventoryCounter.findOneAndUpdate(
+      {
+        fulfillmentSku: res.fulfillmentSku,
+        reserved: { $gte: res.quantity },
+      },
+      {
+        $inc: {
+          reserved: -res.quantity,
+          consumed: res.quantity,
+          version: 1,
+        },
+      },
+      { session, new: true },
+    );
+
+    if (!updatedCounter) {
+      throw new Error(`Failed to consume inventory: counter fence lost for ${res.fulfillmentSku}`);
+    }
+
+    successfulConsumes.push(res);
+  }
+
+  for (const res of successfulConsumes) {
+    await models.InventoryReservation.updateMany(
+      { orderId, skuKey: res.skuKey, state: "reserved" },
+      {
+        $set: {
+          state: "consumed",
+          updatedAt: now,
+        },
+      },
+      { session },
+    );
+  }
+
+  return { consumedCount: successfulConsumes.length };
+}
+
+/*
+ * @behavior  Releases reserved inventory back to available stock only when proof of non-payable session is verified.
+ * @param     models — Mongoose model registry or injected mock models
+ * @param     orderId — internal order identifier
+ * @param     proofOfNonPayable — boolean indicating verified non-payable status (expired/canceled)
+ * @param     reason — reason for releasing hold
+ * @param     session — optional Mongoose client session
+ * @param     now — current timestamp
+ * @returns   object with releasedCount
+ * @exceptions throws if proofOfNonPayable is not explicitly true or if counter fence is lost
+ */
+export async function releaseInventory({
+  models,
+  orderId,
+  proofOfNonPayable,
+  reason = "unspecified",
+  session = null,
+  now = new Date(),
+}) {
+  if (proofOfNonPayable !== true) {
+    throw new Error("Cannot release inventory without verified proof of non-payable session");
+  }
+
+  const reservations = await models.InventoryReservation.find(
+    { orderId, state: "reserved" },
+    null,
+    { session },
+  );
+
+  const successfulReleases = [];
+
+  for (const res of reservations) {
+    const updatedCounter = await models.InventoryCounter.findOneAndUpdate(
+      {
+        fulfillmentSku: res.fulfillmentSku,
+        reserved: { $gte: res.quantity },
+      },
+      {
+        $inc: {
+          available: res.quantity,
+          reserved: -res.quantity,
+          version: 1,
+        },
+      },
+      { session, new: true },
+    );
+
+    if (!updatedCounter) {
+      throw new Error(`Failed to release inventory: counter fence lost for ${res.fulfillmentSku}`);
+    }
+
+    successfulReleases.push(res);
+  }
+
+  for (const res of successfulReleases) {
+    await models.InventoryReservation.updateMany(
+      { orderId, skuKey: res.skuKey, state: "reserved" },
+      {
+        $set: {
+          state: "released",
+          updatedAt: now,
+        },
+      },
+      { session },
+    );
+  }
+
+  return { releasedCount: successfulReleases.length };
+}

--- a/backend/test/shop-reservations.test.js
+++ b/backend/test/shop-reservations.test.js
@@ -1,0 +1,340 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  holdInventory,
+  consumeInventory,
+  releaseInventory,
+  InsufficientInventoryError,
+} from "../shop/reservations.js";
+
+function makeFakeModels(initialCounters = [], initialReservations = []) {
+  const counters = new Map(initialCounters.map((c) => [c.fulfillmentSku, { ...c }]));
+  const reservations = [...initialReservations.map((r) => ({ ...r }))];
+
+  return {
+    InventoryCounter: {
+      async findOneAndUpdate(filter, update, options = {}) {
+        const doc = counters.get(filter.fulfillmentSku);
+        if (!doc) return null;
+
+        if (filter.available && filter.available.$gte !== undefined) {
+          if (doc.available < filter.available.$gte) {
+            return null;
+          }
+        }
+        if (filter.reserved && filter.reserved.$gte !== undefined) {
+          if (doc.reserved < filter.reserved.$gte) {
+            return null;
+          }
+        }
+
+        if (update.$inc) {
+          for (const [key, val] of Object.entries(update.$inc)) {
+            doc[key] = (doc[key] || 0) + val;
+          }
+        }
+
+        return { ...doc };
+      },
+      _getCounters() {
+        return Array.from(counters.values());
+      },
+    },
+    InventoryReservation: {
+      async create(docs, options = {}) {
+        const toAdd = Array.isArray(docs) ? docs : [docs];
+        for (const doc of toAdd) {
+          reservations.push({ ...doc });
+        }
+        return toAdd;
+      },
+      async find(filter = {}) {
+        return reservations.filter((r) => {
+          if (filter.orderId && r.orderId !== filter.orderId) return false;
+          if (filter.state && r.state !== filter.state) return false;
+          return true;
+        });
+      },
+      async updateMany(filter, update, options = {}) {
+        let count = 0;
+        for (const r of reservations) {
+          if (filter.orderId && r.orderId !== filter.orderId) continue;
+          if (filter.state && r.state !== filter.state) continue;
+          if (update.$set) {
+            Object.assign(r, update.$set);
+          }
+          count++;
+        }
+        return { modifiedCount: count };
+      },
+      _getReservations() {
+        return reservations;
+      },
+    },
+  };
+}
+
+describe("Shop Inventory Reservations and Fencing", () => {
+  const sampleCatalog = [
+    {
+      skuKey: "info-hoodie-purple-m",
+      fulfillmentSku: "HOODIE-PURPLE-M",
+      inventoryPolicy: "finite",
+    },
+    {
+      skuKey: "info-tote-bag-natural",
+      fulfillmentSku: "TOTE-NATURAL",
+      inventoryPolicy: "finite",
+    },
+    {
+      skuKey: "info-sticker-pack",
+      fulfillmentSku: "STICKER-PACK",
+      inventoryPolicy: "preorder",
+    },
+  ];
+
+  describe("holdInventory", () => {
+    it("reserves finite stock and records reservation documents", async () => {
+      const models = makeFakeModels([
+        { fulfillmentSku: "HOODIE-PURPLE-M", available: 10, reserved: 0, consumed: 0, version: 1 },
+      ]);
+
+      const items = [{ skuKey: "info-hoodie-purple-m", quantity: 2 }];
+      const now = new Date("2026-10-01T12:00:00.000Z");
+
+      const reservations = await holdInventory({
+        models,
+        orderId: "ord_1",
+        items,
+        catalog: sampleCatalog,
+        now,
+        ttlMs: 15 * 60 * 1000,
+      });
+
+      assert.equal(reservations.length, 1);
+      assert.equal(reservations[0].skuKey, "info-hoodie-purple-m");
+      assert.equal(reservations[0].quantity, 2);
+      assert.equal(reservations[0].state, "reserved");
+      assert.deepEqual(reservations[0].expiresAt, new Date("2026-10-01T12:15:00.000Z"));
+
+      const counter = models.InventoryCounter._getCounters()[0];
+      assert.equal(counter.available, 8);
+      assert.equal(counter.reserved, 2);
+    });
+
+    it("skips inventory deduction for preorder items", async () => {
+      const models = makeFakeModels([
+        { fulfillmentSku: "STICKER-PACK", available: 0, reserved: 0, consumed: 0, version: 1 },
+      ]);
+
+      const items = [{ skuKey: "info-sticker-pack", quantity: 5 }];
+      const reservations = await holdInventory({
+        models,
+        orderId: "ord_preorder",
+        items,
+        catalog: sampleCatalog,
+      });
+
+      assert.equal(reservations.length, 0);
+      const counter = models.InventoryCounter._getCounters()[0];
+      assert.equal(counter.available, 0);
+      assert.equal(counter.reserved, 0);
+    });
+
+    it("rejects reservation when available stock is insufficient without underflowing", async () => {
+      const models = makeFakeModels([
+        { fulfillmentSku: "HOODIE-PURPLE-M", available: 1, reserved: 0, consumed: 0, version: 1 },
+      ]);
+
+      const items = [{ skuKey: "info-hoodie-purple-m", quantity: 2 }];
+
+      await assert.rejects(
+        async () => {
+          await holdInventory({
+            models,
+            orderId: "ord_fail",
+            items,
+            catalog: sampleCatalog,
+          });
+        },
+        (err) => {
+          assert.ok(err instanceof InsufficientInventoryError);
+          assert.equal(err.skuKey, "info-hoodie-purple-m");
+          return true;
+        },
+      );
+
+      const counter = models.InventoryCounter._getCounters()[0];
+      assert.equal(counter.available, 1); // Unchanged, never underflowed
+      assert.equal(counter.reserved, 0);
+    });
+
+    it("rolls back partial holds if subsequent item in cart is out of stock", async () => {
+      const models = makeFakeModels([
+        { fulfillmentSku: "HOODIE-PURPLE-M", available: 5, reserved: 0, consumed: 0, version: 1 },
+        { fulfillmentSku: "TOTE-NATURAL", available: 0, reserved: 0, consumed: 0, version: 1 },
+      ]);
+
+      const items = [
+        { skuKey: "info-hoodie-purple-m", quantity: 2 },
+        { skuKey: "info-tote-bag-natural", quantity: 1 }, // Will fail
+      ];
+
+      await assert.rejects(
+        async () => {
+          await holdInventory({
+            models,
+            orderId: "ord_multi_fail",
+            items,
+            catalog: sampleCatalog,
+          });
+        },
+        InsufficientInventoryError,
+      );
+
+      // Hoodie stock must be rolled back
+      const hoodie = models.InventoryCounter._getCounters().find((c) => c.fulfillmentSku === "HOODIE-PURPLE-M");
+      assert.equal(hoodie.available, 5);
+      assert.equal(hoodie.reserved, 0);
+    });
+
+    it("rolls back counter holds if InventoryReservation creation throws", async () => {
+      const models = makeFakeModels([
+        { fulfillmentSku: "HOODIE-PURPLE-M", available: 5, reserved: 0, consumed: 0, version: 1 },
+      ]);
+      models.InventoryReservation.create = async () => {
+        throw new Error("Simulated database write failure");
+      };
+
+      const items = [{ skuKey: "info-hoodie-purple-m", quantity: 2 }];
+
+      await assert.rejects(
+        async () => {
+          await holdInventory({
+            models,
+            orderId: "ord_insert_fail",
+            items,
+            catalog: sampleCatalog,
+          });
+        },
+        /Simulated database write failure/,
+      );
+
+      const hoodie = models.InventoryCounter._getCounters().find((c) => c.fulfillmentSku === "HOODIE-PURPLE-M");
+      assert.equal(hoodie.available, 5); // Counter compensated!
+      assert.equal(hoodie.reserved, 0);
+    });
+  });
+
+  describe("consumeInventory", () => {
+    it("transitions reserved stock to consumed upon verified payment", async () => {
+      const models = makeFakeModels(
+        [{ fulfillmentSku: "HOODIE-PURPLE-M", available: 8, reserved: 2, consumed: 0, version: 2 }],
+        [{ orderId: "ord_paid", skuKey: "info-hoodie-purple-m", fulfillmentSku: "HOODIE-PURPLE-M", quantity: 2, state: "reserved" }],
+      );
+
+      const result = await consumeInventory({
+        models,
+        orderId: "ord_paid",
+      });
+
+      assert.equal(result.consumedCount, 1);
+
+      const counter = models.InventoryCounter._getCounters()[0];
+      assert.equal(counter.available, 8);
+      assert.equal(counter.reserved, 0);
+      assert.equal(counter.consumed, 2);
+
+      const res = models.InventoryReservation._getReservations()[0];
+      assert.equal(res.state, "consumed");
+    });
+
+    it("refuses to consume reservation if counter conditional update fails", async () => {
+      const models = makeFakeModels(
+        [{ fulfillmentSku: "HOODIE-PURPLE-M", available: 8, reserved: 0, consumed: 2, version: 2 }], // reserved is 0, not 2!
+        [{ orderId: "ord_lost_fence", skuKey: "info-hoodie-purple-m", fulfillmentSku: "HOODIE-PURPLE-M", quantity: 2, state: "reserved" }],
+      );
+
+      await assert.rejects(
+        async () => {
+          await consumeInventory({
+            models,
+            orderId: "ord_lost_fence",
+          });
+        },
+        /counter fence lost/i,
+      );
+
+      const res = models.InventoryReservation._getReservations()[0];
+      assert.equal(res.state, "reserved"); // Not marked consumed
+    });
+  });
+
+  describe("releaseInventory", () => {
+    it("refuses to release stock without verified proof of non-payable session", async () => {
+      const models = makeFakeModels(
+        [{ fulfillmentSku: "HOODIE-PURPLE-M", available: 8, reserved: 2, consumed: 0, version: 2 }],
+        [{ orderId: "ord_open", skuKey: "info-hoodie-purple-m", fulfillmentSku: "HOODIE-PURPLE-M", quantity: 2, state: "reserved" }],
+      );
+
+      await assert.rejects(
+        async () => {
+          await releaseInventory({
+            models,
+            orderId: "ord_open",
+            proofOfNonPayable: false, // Session might still be payable!
+          });
+        },
+        /proof of non-payable/i,
+      );
+
+      const counter = models.InventoryCounter._getCounters()[0];
+      assert.equal(counter.reserved, 2); // Held safely
+    });
+
+    it("releases reserved stock back to available when proof of non-payable is provided", async () => {
+      const models = makeFakeModels(
+        [{ fulfillmentSku: "HOODIE-PURPLE-M", available: 8, reserved: 2, consumed: 0, version: 2 }],
+        [{ orderId: "ord_expired", skuKey: "info-hoodie-purple-m", fulfillmentSku: "HOODIE-PURPLE-M", quantity: 2, state: "reserved" }],
+      );
+
+      const result = await releaseInventory({
+        models,
+        orderId: "ord_expired",
+        proofOfNonPayable: true,
+        reason: "checkout_session_expired",
+      });
+
+      assert.equal(result.releasedCount, 1);
+
+      const counter = models.InventoryCounter._getCounters()[0];
+      assert.equal(counter.available, 10);
+      assert.equal(counter.reserved, 0);
+
+      const res = models.InventoryReservation._getReservations()[0];
+      assert.equal(res.state, "released");
+    });
+
+    it("refuses to release reservation if counter conditional update fails", async () => {
+      const models = makeFakeModels(
+        [{ fulfillmentSku: "HOODIE-PURPLE-M", available: 8, reserved: 0, consumed: 2, version: 2 }], // reserved is 0, not 2!
+        [{ orderId: "ord_lost_fence_rel", skuKey: "info-hoodie-purple-m", fulfillmentSku: "HOODIE-PURPLE-M", quantity: 2, state: "reserved" }],
+      );
+
+      await assert.rejects(
+        async () => {
+          await releaseInventory({
+            models,
+            orderId: "ord_lost_fence_rel",
+            proofOfNonPayable: true,
+          });
+        },
+        /counter fence lost/i,
+      );
+
+      const res = models.InventoryReservation._getReservations()[0];
+      assert.equal(res.state, "reserved"); // Not marked released
+    });
+  });
+});


### PR DESCRIPTION
## Summary & Rationale

Adds the server-side inventory reservation primitives needed to prevent overselling during Stripe checkout. Finite inventory is held before a checkout session is created, then either consumed after verified payment or released only after verified proof that the session is no longer payable.

This PR establishes the inventory-integrity boundary; it does not implement the Stripe checkout route or payment-event orchestration.

## Observable Behavior

- `holdInventory` atomically decrements available stock only when sufficient quantity exists.
- Finite items move from `available` to `reserved`; preorder items do not consume finite inventory.
- A multi-item hold compensates earlier holds if a later item is unavailable or reservation persistence fails.
- `consumeInventory` moves reserved stock to consumed only when the reservation fence still holds.
- `releaseInventory` returns reserved stock to available only when `proofOfNonPayable: true`; open or still-payable sessions cannot release stock.
- Reservations receive a **15-minute default TTL** (`ttlMs = 15 * 60 * 1000`) and an `expiresAt` timestamp. The later checkout flow aligns the effective hold lifetime with the payment-link lifetime.

## Checkout Lifecycle

```text
cart → reserve inventory → create Stripe Checkout session
                         ├─ verified payment → consume reservation
                         └─ verified non-payment → release reservation
```

## Verification

- Focused reservation tests: 10 scenarios passing
- Backend suite: 135/135 passing
- Frontend suite: 73/73 passing
- Frontend production build passing

## Follow-up Status Across the Stack

| Follow-up | Status | Addressed in |
|---|---|---|
| Stripe Checkout Session creation and retrieval | Addressed | [PR 164](https://github.com/UW-IUGA/iuga-web-app/pull/164) |
| Record order, attempt, and inventory hold before payment | Addressed | [PR 165](https://github.com/UW-IUGA/iuga-web-app/pull/165) |
| One Stripe payment link per attempt and uncertain-outcome reconciliation | Addressed | [PR 166](https://github.com/UW-IUGA/iuga-web-app/pull/166) |
| HTTP checkout endpoint | Addressed | [PR 167](https://github.com/UW-IUGA/iuga-web-app/pull/167) |
| Hold lifetime aligned with the payment-link lifetime | Addressed | [PR 170](https://github.com/UW-IUGA/iuga-web-app/pull/170) |
| Checkout-flow documentation and known-gap tracking | Addressed | [PR 169](https://github.com/UW-IUGA/iuga-web-app/pull/169) |
| Verified Stripe payment-event/webhook handling | Not addressed yet | — |
| Automatic expiration and release worker | Not addressed yet | — |
| Verified release enforcement | Partially defined here; production caller/status verification still required | PR 161, follow-up integration pending |
| Enforced MongoDB transaction orchestration for every multi-record reservation operation | Partially addressed for checkout-attempt recording in PR 165; reservation lifecycle wiring remains | PR 165, follow-up integration pending |

## Scope Boundary

PR 161 provides the inventory reservation and overselling-protection layer plus focused tests. Its default TTL is a recorded expiration timestamp, not automatic expiry enforcement. Stock must not be released solely because a timer elapsed or because the browser reports failure; the server must verify that the Stripe session is expired or canceled and then call `releaseInventory` with explicit proof of non-payment.

## Stack Context

- Position: 4 of 11
- Base PR: #160 (`feat/stripe-commerce-schemas`)
- Depends on: #160