### PR TITLE
feat(shop): add native Stripe checkout provider client

### DIFF
--- a/backend/services/stripeProviderClient.js
+++ b/backend/services/stripeProviderClient.js
@@ -1,0 +1,226 @@
+/*
+Purpose: The only place that talks to Stripe. It turns one already-priced purchase into a
+         hosted Checkout Session the buyer can pay, and reads that Session back so the
+         checkout flow can tell whether the payment link is still worth sending again.
+
+Called by: checkoutCoordinator, which owns the buyer, the prices, and the retry key this
+           file passes along unchanged.
+
+Must not: decide money, quantities, or identity — those arrive already decided. Never let a
+          Stripe error body, our API key, or an internal identifier reach a caller or a log.
+*/
+
+/*
+ * Stripe's REST API speaks snake_case form fields, so this file is the single translation
+ * point between our names and Stripe's: lineItems[].priceId -> line_items[0][price],
+ * expiresAt -> expires_at, clientReferenceId -> client_reference_id.
+ */
+const CHECKOUT_SESSIONS_URL = "https://api.stripe.com/v1/checkout/sessions";
+
+/*
+Purpose: One safe failure type for every way this file can fail — unusable configuration, a
+         dead network, a rejection from Stripe, or a response we cannot trust. Callers catch
+         it and record "we do not know what Stripe did"; Stripe's own message can echo keys
+         and payment details, so it never reaches them.
+*/
+class StripeProviderError extends Error {
+  constructor() {
+    super("Stripe provider request failed");
+    this.name = "StripeProviderError";
+  }
+}
+
+// Every validation below funnels into this, so no failed path can leak a reason to a caller.
+function failSafely() {
+  throw new StripeProviderError();
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+// Stripe reports expiry as whole seconds since 1970 ("epoch seconds"), never milliseconds.
+function isEpochSeconds(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+/*
+Purpose: Refuse to build a client unless we have a real key, a pinned API version, and a
+         transport, so a misconfigured deployment fails here instead of at the first sale.
+*/
+function validateConfiguration({ secretKey, apiVersion, fetchImpl }) {
+  if (!/^sk_(?:test|live)_.+$/u.test(secretKey ?? "")) failSafely();
+  const versionMatch = /^(\d{4}-\d{2}-\d{2})\.[A-Za-z0-9-]+$/u.exec(apiVersion ?? "");
+  if (!versionMatch) failSafely();
+  const parsedDate = new Date(`${versionMatch[1]}T00:00:00.000Z`);
+  if (Number.isNaN(parsedDate.valueOf()) || !parsedDate.toISOString().startsWith(versionMatch[1])) failSafely();
+  if (typeof fetchImpl !== "function") failSafely();
+}
+
+function validateMetadata(metadata) {
+  if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) failSafely();
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!isNonEmptyString(key) || !isNonEmptyString(value)) failSafely();
+  }
+}
+
+/*
+Purpose: Check the locked-in purchase request before it leaves the process. Every value here
+         was decided and stored earlier by checkoutCoordinator, so a failure means the stored
+         record is damaged — we stop rather than send Stripe a half-valid order.
+*/
+function validateFrozenRequest(frozenStripeRequest) {
+  if (frozenStripeRequest === null || typeof frozenStripeRequest !== "object" || Array.isArray(frozenStripeRequest)) failSafely();
+  const {
+    lineItems,
+    successUrl,
+    cancelUrl,
+    expiresAt,
+    clientReferenceId,
+    metadata,
+  } = frozenStripeRequest;
+  if (!Array.isArray(lineItems) || lineItems.length === 0) failSafely();
+  for (const item of lineItems) {
+    if (item === null || typeof item !== "object" || Array.isArray(item)
+      || !isNonEmptyString(item.priceId)
+      || !Number.isSafeInteger(item.quantity) || item.quantity <= 0) failSafely();
+  }
+  if (!isNonEmptyString(successUrl) || !isNonEmptyString(cancelUrl)
+    || !isEpochSeconds(expiresAt) || !isNonEmptyString(clientReferenceId)) failSafely();
+  validateMetadata(metadata);
+}
+
+/*
+ * Purpose: Translate Stripe's payload into the five facts the checkout flow actually uses.
+ * @exceptions StripeProviderError when the payload lacks an id, a payment URL, a status, an
+ *             expiry, or carries a PaymentIntent value that is neither a string nor null.
+ */
+function normalizeStripeSession(payload) {
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)
+    || !isNonEmptyString(payload.id)
+    || !isNonEmptyString(payload.url)
+    || !isNonEmptyString(payload.status)
+    || !isEpochSeconds(payload.expires_at)
+    || (payload.payment_intent !== null && !isNonEmptyString(payload.payment_intent))) failSafely();
+  return {
+    id: payload.id,
+    url: payload.url,
+    expiresAt: payload.expires_at,
+    paymentIntentId: payload.payment_intent,
+    status: payload.status,
+  };
+}
+
+/*
+ * Purpose: Read exactly one Stripe response, or fail safely.
+ * Why: a rejected response body is never read — it can echo our key or the buyer's payment
+ *      details, so we throw it away and report a generic failure instead.
+ */
+async function readStripeSessionResponse(response) {
+  if (response === null || typeof response !== "object" || response.ok !== true) failSafely();
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    failSafely();
+  }
+  return normalizeStripeSession(payload);
+}
+
+/*
+ * Purpose: Build the client the checkout flow uses for two jobs — create one hosted Checkout
+ *          Session for a locked-in purchase, and read a Session back to see whether its
+ *          payment link is still usable.
+ *
+ * @param options.secretKey — the Stripe key: `sk_test_…` for test mode, `sk_live_…` for real.
+ * @param options.apiVersion — the Stripe API version we pinned, e.g. 2026-08-27.basil.
+ * @param options.fetchImpl — the HTTP transport, injected so tests run without Stripe.
+ * @returns a client whose two methods never throw anything but StripeProviderError.
+ * @exceptions StripeProviderError when the configuration is unusable.
+ */
+export function createStripeProviderClient(options = {}) {
+  if (options === null || typeof options !== "object" || Array.isArray(options)) failSafely();
+  const { secretKey, apiVersion, fetchImpl } = options;
+  validateConfiguration({ secretKey, apiVersion, fetchImpl });
+  const headers = {
+    Authorization: `Bearer ${secretKey}`,
+    "Stripe-Version": apiVersion,
+  };
+
+  async function request(url, init) {
+    let response;
+    try {
+      response = await fetchImpl(url, init);
+    } catch {
+      failSafely();
+    }
+    return readStripeSessionResponse(response);
+  }
+
+  return {
+    /*
+     * Purpose: Create the payment page the buyer is sent to. Retries reuse the same retry key
+     *          so Stripe can tell a retry apart from a second purchase.
+     * @param options.frozenStripeRequest — the locked-in purchase: line items with their
+     *        Stripe prices and quantities, the return URLs, the expiry, and the attempt/order
+     *        ids we attach for later reconciliation.
+     * @param options.idempotencyKey — our server-made key, `iuga:checkout:<attemptId>`.
+     * @returns the created Session, normalized: id, payment URL, expiry, PaymentIntent, status.
+     * @exceptions StripeProviderError on a damaged request, a transport failure, or any
+     *             response we cannot trust.
+     */
+    async createCheckoutSession(options = {}) {
+      if (options === null || typeof options !== "object" || Array.isArray(options)) failSafely();
+      const { frozenStripeRequest, idempotencyKey } = options;
+      if (!isNonEmptyString(idempotencyKey)) failSafely();
+      validateFrozenRequest(frozenStripeRequest);
+      const fields = new URLSearchParams();
+      // One card payment, nothing saved: the buyer cannot pick a method or quantity we did
+      // not price, and no customer record is requested from Stripe.
+      fields.set("mode", "payment");
+      fields.set("payment_method_types[0]", "card");
+      fields.set("success_url", frozenStripeRequest.successUrl);
+      fields.set("cancel_url", frozenStripeRequest.cancelUrl);
+      // Stripe wants whole epoch seconds and refuses an expiry under 30 minutes or over 24 hours.
+      fields.set("expires_at", String(frozenStripeRequest.expiresAt));
+      fields.set("client_reference_id", frozenStripeRequest.clientReferenceId);
+      frozenStripeRequest.lineItems.forEach((item, index) => {
+        fields.set(`line_items[${index}][price]`, item.priceId);
+        fields.set(`line_items[${index}][quantity]`, String(item.quantity));
+      });
+      // Why: the same ids go on the Session and on the PaymentIntent, because the later payment
+      //      webhook arrives as a PaymentIntent event and must find the attempt it belongs to.
+      for (const [key, value] of Object.entries(frozenStripeRequest.metadata)) {
+        fields.set(`metadata[${key}]`, value);
+        fields.set(`payment_intent_data[metadata][${key}]`, value);
+      }
+      // Why: promotion codes, quantity changes on Stripe's page, and saved-customer creation are
+      //      deliberately not requested — the buyer must not be able to change what we priced.
+      return request(CHECKOUT_SESSIONS_URL, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Idempotency-Key": idempotencyKey,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: fields.toString(),
+      });
+    },
+    /*
+     * Purpose: Read a Session we already created, to check whether its payment link is still
+     *          open and unexpired before we hand it to the buyer again.
+     * @param options.sessionId — Stripe's Session id, escaped into the URL path.
+     * @returns the same normalized shape as createCheckoutSession.
+     * @exceptions StripeProviderError on a transport failure or an untrustworthy response.
+     */
+    async retrieveCheckoutSession(options = {}) {
+      if (options === null || typeof options !== "object" || Array.isArray(options)) failSafely();
+      const { sessionId } = options;
+      if (!isNonEmptyString(sessionId)) failSafely();
+      return request(`${CHECKOUT_SESSIONS_URL}/${encodeURIComponent(sessionId)}`, {
+        method: "GET",
+        headers,
+      });
+    },
+  };
+}

--- a/backend/test/stripe-provider-client.test.js
+++ b/backend/test/stripe-provider-client.test.js
@@ -1,0 +1,210 @@
+/*
+Purpose: Prove the Stripe boundary can be trusted with a real purchase: it sends exactly the
+         fields we decided, reuses our retry key so a retry cannot become a second charge,
+         and every failure — bad key, dead network, Stripe rejection — comes back as one
+         generic error that leaks neither our API key nor Stripe's response body.
+*/
+
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { createStripeProviderClient } from "../services/stripeProviderClient.js";
+
+const SECRET_KEY = "sk_test_never-send-this-real-secret";
+const API_VERSION = "2026-08-27.basil";
+const SESSION_RESPONSE = {
+  id: "cs_test_123",
+  url: "https://checkout.stripe.com/c/pay/cs_test_123",
+  status: "open",
+  expires_at: 1_900_003_600,
+  payment_intent: "pi_test_123",
+};
+
+// A stand-in for the fetch response Stripe would give us.
+function response({ status = 200, json, text } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      if (json instanceof Error) throw json;
+      return json;
+    },
+    async text() {
+      if (text instanceof Error) throw text;
+      return text ?? JSON.stringify(json);
+    },
+  };
+}
+
+function validClient(overrides = {}) {
+  return createStripeProviderClient({
+    secretKey: SECRET_KEY,
+    apiVersion: API_VERSION,
+    fetchImpl: async () => response({ json: SESSION_RESPONSE }),
+    ...overrides,
+  });
+}
+
+// Every failure must look identical from the outside and carry no secret material.
+function assertSafeFailure(error) {
+  assert.match(error, /Stripe provider request failed/u);
+  assert.doesNotMatch(error, new RegExp(SECRET_KEY, "u"));
+  assert.doesNotMatch(error, /provider-body-secret|raw-provider-body/u);
+}
+
+describe("createStripeProviderClient", () => {
+  test("creates a hosted card-only Checkout Session from the locked-in purchase", async () => {
+    let request;
+    const client = validClient({
+      fetchImpl: async (url, init) => {
+        request = { url: String(url), init };
+        return response({ json: SESSION_RESPONSE });
+      },
+    });
+
+    const result = await client.createCheckoutSession({
+      idempotencyKey: "iuga:checkout:attempt_123",
+      frozenStripeRequest: {
+        lineItems: [
+          { priceId: "price_hoodie", quantity: 2 },
+          { priceId: "price_tote", quantity: 1 },
+        ],
+        successUrl: "https://shop.example.test/checkout/success",
+        cancelUrl: "https://shop.example.test/checkout/cancel",
+        expiresAt: 1_900_003_600,
+        clientReferenceId: "order_opaque_123",
+        metadata: {
+          attempt: "attempt_123",
+          order: "order_opaque_123",
+        },
+      },
+    });
+
+    assert.deepEqual(result, {
+      id: "cs_test_123",
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+      expiresAt: 1_900_003_600,
+      paymentIntentId: "pi_test_123",
+      status: "open",
+    });
+    assert.equal(request.url, "https://api.stripe.com/v1/checkout/sessions");
+    assert.equal(request.init.method, "POST");
+    assert.equal(request.init.headers.Authorization, `Bearer ${SECRET_KEY}`);
+    assert.equal(request.init.headers["Stripe-Version"], API_VERSION);
+    assert.equal(request.init.headers["Idempotency-Key"], "iuga:checkout:attempt_123");
+    assert.equal(request.init.headers["Content-Type"], "application/x-www-form-urlencoded");
+
+    const fields = new URLSearchParams(request.init.body);
+    assert.equal(fields.get("mode"), "payment");
+    assert.equal(fields.get("payment_method_types[0]"), "card");
+    assert.equal(fields.get("success_url"), "https://shop.example.test/checkout/success");
+    assert.equal(fields.get("cancel_url"), "https://shop.example.test/checkout/cancel");
+    assert.equal(fields.get("expires_at"), "1900003600");
+    assert.equal(fields.get("client_reference_id"), "order_opaque_123");
+    assert.equal(fields.get("line_items[0][price]"), "price_hoodie");
+    assert.equal(fields.get("line_items[0][quantity]"), "2");
+    assert.equal(fields.get("line_items[1][price]"), "price_tote");
+    assert.equal(fields.get("line_items[1][quantity]"), "1");
+    assert.equal(fields.get("metadata[attempt]"), "attempt_123");
+    assert.equal(fields.get("metadata[order]"), "order_opaque_123");
+    assert.equal(fields.get("payment_intent_data[metadata][attempt]"), "attempt_123");
+    assert.equal(fields.get("payment_intent_data[metadata][order]"), "order_opaque_123");
+    // Why: these stay absent so the buyer cannot change a quantity or apply a discount we did
+    //      not price, and no Stripe customer record is created for a one-off purchase.
+    assert.equal(fields.get("customer_creation"), null);
+    assert.equal(fields.get("allow_promotion_codes"), null);
+    assert.equal(fields.get("adjustable_quantity[enabled]"), null);
+  });
+
+  test("normalizes a successful response with no PaymentIntent", async () => {
+    const client = validClient({
+      fetchImpl: async () => response({
+        json: { ...SESSION_RESPONSE, payment_intent: null },
+      }),
+    });
+
+    assert.deepEqual(
+      await client.createCheckoutSession({
+        idempotencyKey: "iuga:checkout:attempt_null-pi",
+        frozenStripeRequest: {
+          lineItems: [{ priceId: "price_tee", quantity: 1 }],
+          successUrl: "https://shop.example.test/success",
+          cancelUrl: "https://shop.example.test/cancel",
+          expiresAt: 1_900_003_600,
+          clientReferenceId: "order_opaque_456",
+          metadata: { attempt: "attempt_null-pi" },
+        },
+      }),
+      {
+        id: "cs_test_123",
+        url: "https://checkout.stripe.com/c/pay/cs_test_123",
+        expiresAt: 1_900_003_600,
+        paymentIntentId: null,
+        status: "open",
+      },
+    );
+  });
+
+  test("reads a Session back by id, escaping the id into the URL", async () => {
+    let request;
+    const client = validClient({
+      fetchImpl: async (url, init) => {
+        request = { url: String(url), init };
+        return response({ json: SESSION_RESPONSE });
+      },
+    });
+
+    const result = await client.retrieveCheckoutSession({ sessionId: "cs_test/opaque?value" });
+
+    assert.deepEqual(result, {
+      id: "cs_test_123",
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+      expiresAt: 1_900_003_600,
+      paymentIntentId: "pi_test_123",
+      status: "open",
+    });
+    assert.equal(request.url, "https://api.stripe.com/v1/checkout/sessions/cs_test%2Fopaque%3Fvalue");
+    assert.equal(request.init.method, "GET");
+    assert.equal(request.init.headers.Authorization, `Bearer ${SECRET_KEY}`);
+    assert.equal(request.init.headers["Stripe-Version"], API_VERSION);
+    assert.equal(request.init.headers["Idempotency-Key"], undefined);
+  });
+
+  test("rejects missing or malformed configuration before using transport", async () => {
+    for (const config of [
+      { apiVersion: API_VERSION },
+      { secretKey: SECRET_KEY },
+      { secretKey: SECRET_KEY, apiVersion: "latest" },
+      { secretKey: "not-a-stripe-key", apiVersion: API_VERSION },
+    ]) {
+      let calls = 0;
+      assert.throws(
+        () => createStripeProviderClient({ ...config, fetchImpl: async () => { calls += 1; } }),
+        (error) => {
+          assertSafeFailure(error.message);
+          return true;
+        },
+      );
+      assert.equal(calls, 0);
+    }
+  });
+
+  test("fails safely for transport, non-JSON, malformed, and non-2xx responses", async () => {
+    const cases = [
+      { fetchImpl: async () => { throw new Error(`network contains ${SECRET_KEY}`); } },
+      { fetchImpl: async () => response({ status: 200, text: "raw-provider-body-secret", json: new Error("not json") }) },
+      { fetchImpl: async () => response({ json: { id: "cs_missing_fields" } }) },
+      { fetchImpl: async () => response({ status: 402, text: "provider-body-secret", json: { error: { message: "provider-body-secret" } } }) },
+    ];
+
+    for (const options of cases) {
+      const client = validClient(options);
+      await assert.rejects(
+        client.retrieveCheckoutSession({ sessionId: "cs_test_123" }),
+        (error) => {
+          assertSafeFailure(error.message);
+          return true;
+        },
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary & Rationale

This PR gives IUGA one safe place to talk to Stripe. It turns a purchase that IUGA has already priced and validated into a hosted Stripe Checkout Session, then reads that Session back when the checkout flow needs to know whether the payment link is still usable.

```text
IUGA validated purchase → PR 164 → Stripe Checkout URL
                                      ↓
                              read Session status
```

The provider client is deliberately small: it translates IUGA’s field names into Stripe’s API format and keeps Stripe-specific errors, headers, and response shapes out of the rest of the shop.

## What This PR Does

- Creates a Stripe Checkout Session from a frozen purchase request.
- Sends the server-selected line items, quantities, return URLs, expiry, order/attempt references, and metadata.
- Copies correlation metadata onto both the Checkout Session and PaymentIntent so a later payment event can find the correct attempt.
- Retrieves an existing Checkout Session by id so the checkout flow can check whether its link is still open and unexpired.
- Reuses the server-generated idempotency key supplied by the checkout flow, allowing safe retries without treating a retry as a new purchase.
- Locks the Stripe request to card-only, USD-compatible checkout rules established by the upstream shop layers; buyers cannot change quantities or add promotion codes on Stripe’s page.
- Validates the pinned Stripe API version and request/response shape before trusting or forwarding data.
- Converts configuration, transport, non-success, malformed-response, and provider failures into one generic safe error. Stripe response bodies and secrets never reach callers or logs.

## What This PR Does Not Do

This adapter does not:

- calculate prices or totals;
- decide identity, quantities, catalog eligibility, or inventory;
- create the public checkout endpoint;
- record orders or inventory reservations;
- consume or release inventory;
- process Stripe webhooks or confirm payment.

Those responsibilities belong to the surrounding checkout layers and later payment-event integration.

## Architectural Decision

Use native `fetch` instead of adding the Stripe SDK. This keeps one narrow provider boundary with no new dependency or transitive SDK surface. If Stripe changes its wire format or error behavior, the translation and sanitization stay localized here.

## Verification

- `node --test test/stripe-provider-client.test.js` — 5 passed.
- Coverage includes exact form encoding, card-only checkout, URLs, expiry, line items, metadata on Session and PaymentIntent, idempotent retries, Session retrieval, pinned configuration validation, URL-escaping, malformed responses, transport failures, and safe error handling.
- `npm test --prefix backend` — full suite passed.

## Stack Context

- Position: 5 of 11
- Base PR: #161
- Depends on: #161