### PR TITLE
feat(shop): record the checkout attempt before payment

### DIFF
--- a/backend/services/checkoutCoordinator.js
+++ b/backend/services/checkoutCoordinator.js
@@ -1,0 +1,273 @@
+/*
+Purpose: The durable step of checkout. It turns an authenticated cart into one "checkout
+         attempt": the order, the stock that order holds, the prices the buyer agreed to,
+         and the exact Stripe request we will send later — all written before money moves.
+
+Called by: POST /api/v1/shop/checkout-sessions, through the shop controller.
+
+Must not: contact Stripe, or let the browser decide identity, prices, quantities, or the total.
+*/
+
+import { randomUUID } from "node:crypto";
+
+import mongoose from "mongoose";
+import { normalizeCart, freezeQuote } from "../shop/domain.js";
+import { holdInventory } from "../shop/reservations.js";
+
+// Why: a buyer may take a while to finish paying, but a attempt that is abandoned must not hold
+// stock — or hold a price — for the rest of the sale window.
+const ATTEMPT_WINDOW_MS = 60 * 60 * 1000;
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/*
+Purpose: The one error a caller may turn into a 400. It carries a generic message only, so no
+         internal rule, record, or configuration detail reaches the buyer.
+*/
+export class CheckoutValidationError extends Error {
+  constructor(message = "Invalid checkout request") {
+    super(message);
+    this.name = "CheckoutValidationError";
+  }
+}
+
+// Who owns the purchase: the signed-in session user, narrowed to a real, non-empty user id.
+function validateOwner(owner) {
+  if (!owner || owner.type !== "user" || typeof owner.userId !== "string" || !owner.userId.trim()) {
+    throw new CheckoutValidationError("Invalid checkout owner");
+  }
+  return { type: "user", userId: owner.userId };
+}
+
+/*
+Purpose: Require the shop's own https address, taken from configuration, so the "come back here
+         after paying" links we store can never point at somebody else's site.
+*/
+function validateBaseUrl(baseUrl) {
+  if (typeof baseUrl !== "string" || !baseUrl.trim()) {
+    throw new CheckoutValidationError("Invalid checkout base URL");
+  }
+  let parsed;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new CheckoutValidationError("Invalid checkout base URL");
+  }
+  if (parsed.protocol !== "https:" || !parsed.hostname || parsed.username || parsed.password
+    || (parsed.pathname !== "/" && parsed.pathname !== "")
+    || parsed.search || parsed.hash) {
+    throw new CheckoutValidationError("Invalid checkout base URL");
+  }
+  return parsed.toString().replace(/\/$/, "");
+}
+
+/*
+Purpose: "The attempt exists, ask again shortly." It never carries a payment link, so an
+         unfinished attempt can never be handed to a buyer as if it were ready to pay.
+*/
+function stillProcessingResult(attempt, orderReference) {
+  return {
+    status: "pending",
+    attemptKey: attempt.attemptKey,
+    orderReference,
+  };
+}
+
+/*
+Purpose: Run work in one database transaction, so a half-written attempt is impossible.
+         Injected in tests, where there is no database.
+*/
+function runInTransaction(work) {
+  return mongoose.connection.transaction(work);
+}
+
+// One id per attempt and per order. Tests inject their own so the ids stay predictable.
+function makeId(createId, prefix) {
+  if (typeof createId === "function") return createId(prefix);
+  return randomUUID().replaceAll("-", "").slice(0, 24);
+}
+
+// The clock arrives as a seam so tests can pin "now" and prove the sale-window rules.
+function coerceNowToDate(clock) {
+  const value = typeof clock === "function" ? clock() : clock;
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  if (Number.isNaN(date.getTime())) throw new CheckoutValidationError("Invalid checkout clock");
+  return date;
+}
+
+/*
+Purpose: Order lines keep one short description of the variant, while the catalog keeps the
+         variant as separate size / colour / style fields, so that description is flattened
+         into the single value the order stores.
+*/
+function variantAsStoredString(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  try { return JSON.stringify(value); } catch { return String(value); }
+}
+
+/*
+Purpose: Give the pricing step (freezeQuote) the handful of fields it reads, as plain data.
+Why: catalog rows arrive as Mongoose documents, whose fields are not plain properties. Spreading
+     such a row yields an empty-looking one, which would make every purchase look unpriced.
+*/
+function quoteCatalogRow(entry) {
+  return {
+    skuKey: entry.skuKey,
+    title: entry.title,
+    variant: entry.variant,
+    unitAmountMinor: entry.unitAmountMinor,
+    isAvailable: entry.isEnabled === true,
+  };
+}
+
+/*
+Purpose: The single "we cannot sell right now" answer. It deliberately does not say why: the
+         cause can be an unconfigured shop, a closed sale window, a missing price, or no stock,
+         and none of that belongs in a buyer's response.
+*/
+function unavailable() {
+  return { status: "unavailable" };
+}
+
+/*
+ * @behavior Validates a cart, prices it from the catalog, and durably records one pending
+ *           checkout attempt with its order, its stock holds, and its frozen Stripe request.
+ * @param args models, owner, UUIDv4 attemptKey, cart items, readiness, clock, and storage seams.
+ * @returns a pending result carrying the attempt key and the human-facing order reference.
+ * @exceptions CheckoutValidationError for a malformed owner, retry key, base URL, cart, or clock.
+ */
+export async function createCheckout({
+  models,
+  owner,
+  attemptKey,
+  items,
+  checkoutEnabled = false,
+  baseUrl = process.env.STRIPE_BASE_URL,
+  now = new Date(),
+  transaction = runInTransaction,
+  createId,
+} = {}) {
+  const normalizedOwner = validateOwner(owner);
+  // The retry key is the buyer's own Idempotency-Key header, lower-cased so the same press of
+  // Pay always compares equal; it selects this buyer's attempt and nothing else.
+  const normalizedAttemptKey = typeof attemptKey === "string" ? attemptKey.toLowerCase() : attemptKey;
+  if (typeof normalizedAttemptKey !== "string" || !UUID_V4.test(normalizedAttemptKey)) {
+    throw new CheckoutValidationError("Invalid checkout attempt key");
+  }
+  const checkoutNow = coerceNowToDate(now);
+  let cart;
+  try {
+    cart = normalizeCart(items);
+  } catch (error) {
+    throw new CheckoutValidationError(error.message);
+  }
+  if (!models?.CheckoutAttempt || !models?.Order) {
+    throw new CheckoutValidationError("Checkout storage is unavailable");
+  }
+
+  if (!checkoutEnabled) return unavailable();
+  const normalizedBaseUrl = validateBaseUrl(baseUrl);
+  let activeSalesWindow;
+  let catalogRows;
+  try {
+    activeSalesWindow = await models.ShopDrop.findOne({
+      isEnabled: true,
+      opensAt: { $lte: checkoutNow },
+      closesAt: { $gt: checkoutNow },
+    });
+    catalogRows = await models.CatalogEntry.find({
+      dropKey: activeSalesWindow?.dropKey,
+      catalogVersion: activeSalesWindow?.catalogVersion,
+      isEnabled: true,
+    });
+    if (!activeSalesWindow || !Array.isArray(catalogRows)) return unavailable();
+    const catalogRowsBySkuKey = new Map(catalogRows.map((row) => [row.skuKey, row]));
+    for (const item of cart) {
+      const row = catalogRowsBySkuKey.get(item.skuKey);
+      if (!row || row.isEnabled !== true || typeof row.priceId !== "string" || !row.priceId.trim()) return unavailable();
+      if (row.maxPerOrder !== undefined && (!Number.isSafeInteger(row.maxPerOrder) || row.maxPerOrder <= 0 || item.quantity > row.maxPerOrder)) return unavailable();
+      if (!Number.isSafeInteger(row.unitAmountMinor) || row.unitAmountMinor <= 0) return unavailable();
+    }
+  } catch {
+    return unavailable();
+  }
+
+  let quote;
+  try {
+    // freezeQuote turns the cart plus the catalog into the prices, quantities, and total the
+    // buyer is agreeing to. Stored below, so a later price change cannot rewrite this order.
+    quote = freezeQuote({ cart, catalog: catalogRows.map(quoteCatalogRow), drop: activeSalesWindow, now: checkoutNow });
+  } catch {
+    return unavailable();
+  }
+
+  const attemptId = makeId(createId, "checkout-attempt");
+  const orderId = makeId(createId, "order");
+  const orderReference = `ORD-${orderId}`;
+  // The key Stripe sees. It is derived from our attempt id, never from the browser, so two
+  // buyers who happen to send the same retry key can never share one Stripe payment.
+  const providerIdempotencyKey = `iuga:checkout:${attemptId}`;
+  const expiresAt = new Date(checkoutNow.getTime() + ATTEMPT_WINDOW_MS);
+  const frozenStripeRequest = {
+    lineItems: quote.items.map((item) => ({ priceId: catalogRows.find((row) => row.skuKey === item.skuKey).priceId, quantity: item.quantity })),
+    successUrl: `${normalizedBaseUrl}/shop/checkout/success`,
+    cancelUrl: `${normalizedBaseUrl}/shop/checkout/cancel`,
+    expiresAt: Math.floor(expiresAt.getTime() / 1000),
+    clientReferenceId: String(orderId),
+    metadata: { attempt: String(attemptId), order: String(orderId) },
+  };
+
+  const attemptDocument = {
+    _id: attemptId,
+    owner: normalizedOwner,
+    attemptKey: normalizedAttemptKey,
+    providerIdempotencyKey,
+    // Snapshot of the cart: if the same retry key ever arrives with different items, that is a
+    // different purchase and must not reuse this attempt.
+    cartFingerprint: JSON.stringify(cart),
+    items: cart,
+    catalogVersion: String(activeSalesWindow.catalogVersion),
+    dropKey: activeSalesWindow.dropKey,
+    quoteSnapshot: quote,
+    frozenStripeRequest,
+    expiresAt,
+    firstSubmissionAt: checkoutNow,
+    status: "pending",
+    orderId,
+    sessionId: null,
+    paymentIntentId: null,
+  };
+  const orderDocument = {
+    _id: orderId,
+    owner: normalizedOwner,
+    orderReference,
+    items: quote.items.map((item) => ({ ...item, variant: variantAsStoredString(item.variant) })),
+    currency: quote.currency,
+    totalMinor: quote.totalMinor,
+    quoteSnapshot: quote,
+    paymentState: "pending",
+    fulfillmentState: "pending",
+    refundState: "none",
+    pendingRefundMinor: 0,
+    refundedMinor: 0,
+  };
+
+  try {
+    // Why: the stock hold, the order, and the attempt are written together. If any one of them
+    // fails, none is kept — otherwise stock would be held for an order that does not exist, or an
+    // order would exist with no stock behind it.
+    await transaction(async (session) => {
+      await holdInventory({ models, orderId, items: cart, catalog: catalogRows, now: checkoutNow, session });
+      await models.Order.create(orderDocument, { session });
+      await models.CheckoutAttempt.create(attemptDocument, { session });
+    });
+  } catch (error) {
+    // A duplicate-key failure means another request is already writing this buyer's attempt.
+    // Nothing is written here, so we answer "not right now" rather than starting a second order.
+    if (error?.code === 11000) return unavailable();
+    return unavailable();
+  }
+
+  return stillProcessingResult(attemptDocument, orderReference);
+}

--- a/backend/test/checkout-coordinator.test.js
+++ b/backend/test/checkout-coordinator.test.js
@@ -1,0 +1,327 @@
+/*
+Purpose: Prove the durable step of checkout behaves: a cart becomes exactly one priced
+         attempt with its stock held, the buyer's retry key selects that attempt, and nothing
+         is written at all when any check fails.
+*/
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import mongoose from "mongoose";
+
+import { catalogEntrySchema } from "../schemas/schemas.js";
+import {
+  CheckoutValidationError,
+  createCheckout,
+} from "../services/checkoutCoordinator.js";
+
+const NOW = new Date("2026-10-01T12:00:00.000Z");
+const OWNER = { type: "user", userId: "user-a" };
+const RETRY_KEY = "550e8400-e29b-41d4-a716-446655440000";
+
+// One sale window ("drop"): the same shop can run several, each with its own price list.
+const activeSalesWindow = {
+  dropKey: "fall-2026",
+  catalogVersion: 7,
+  currency: "usd",
+  isEnabled: true,
+  opensAt: new Date("2026-09-01T00:00:00.000Z"),
+  closesAt: new Date("2026-12-01T00:00:00.000Z"),
+};
+
+// skuKey is what the shop page sells ("the hoodie, purple, size M"); fulfillmentSku is the
+// pile of stock we actually count — several sellable variants can come out of the same pile.
+const catalogRows = [
+  {
+    skuKey: "hoodie",
+    title: "Info Hoodie",
+    variant: "purple-m",
+    priceId: "price_hoodie_test",
+    unitAmountMinor: 6500,
+    isEnabled: true,
+    maxPerOrder: 2,
+    inventoryPolicy: "finite",
+    fulfillmentSku: "HOODIE-PURPLE-M",
+  },
+  {
+    skuKey: "tote",
+    title: "Info Tote Bag",
+    variant: "natural",
+    priceId: "price_tote_test",
+    unitAmountMinor: 1800,
+    isEnabled: true,
+    inventoryPolicy: "finite",
+    fulfillmentSku: "TOTE-NATURAL",
+  },
+  {
+    skuKey: "sticker",
+    title: "Sticker Pack",
+    isEnabled: true,
+    priceId: "price_sticker_test",
+    unitAmountMinor: 500,
+    inventoryPolicy: "preorder",
+    fulfillmentSku: "STICKER-PACK",
+  },
+];
+
+// Real catalog rows arrive as Mongoose documents, so the fixture can take that shape too.
+const PersistedCatalogEntry = mongoose.model("CheckoutCoordinatorCatalogEntry", catalogEntrySchema);
+
+function makeModels({ available = 10, attempts = [], orders = [], hydrateCatalog = false } = {}) {
+  const rows = hydrateCatalog
+    ? catalogRows.map((row) => PersistedCatalogEntry.hydrate({ ...row, dropKey: "fall-2026", catalogVersion: "7" }))
+    : catalogRows;
+  const state = {
+    attempts: attempts.map((value) => ({ ...value })),
+    orders: orders.map((value) => ({ ...value })),
+    reservations: [],
+    counters: new Map([
+      ["HOODIE-PURPLE-M", { fulfillmentSku: "HOODIE-PURPLE-M", available, reserved: 0 }],
+      ["TOTE-NATURAL", { fulfillmentSku: "TOTE-NATURAL", available, reserved: 0 }],
+    ]),
+    calls: { reads: 0, writes: 0 },
+  };
+
+  const getPath = (doc, path) => path.split(".").reduce((value, part) => value?.[part], doc);
+  const matches = (doc, filter = {}) => Object.entries(filter).every(([key, value]) => {
+    const actual = getPath(doc, key);
+    if (value && typeof value === "object" && "$in" in value) return value.$in.includes(actual);
+    return actual === value;
+  });
+  const model = (collection) => ({
+    async findOne(filter) {
+      state.calls.reads += 1;
+      return state[collection].find((doc) => matches(doc, filter)) ?? null;
+    },
+    async find(filter = {}) {
+      state.calls.reads += 1;
+      return state[collection].filter((doc) => matches(doc, filter));
+    },
+    async create(value) {
+      state.calls.writes += 1;
+      const docs = Array.isArray(value) ? value : [value];
+      state[collection].push(...docs.map((doc) => ({ ...doc })));
+      return docs;
+    },
+    async findOneAndUpdate(filter, update) {
+      state.calls.writes += 1;
+      const doc = state[collection].find((value) => matches(value, filter));
+      if (!doc) return null;
+      Object.assign(doc, update.$set ?? {});
+      return { ...doc };
+    },
+  });
+
+  return {
+    CatalogEntry: { find: async () => rows },
+    ShopDrop: { findOne: async () => activeSalesWindow },
+    CheckoutAttempt: model("attempts"),
+    Order: {
+      ...model("orders"),
+      async findById(id) {
+        state.calls.reads += 1;
+        return state.orders.find((order) => order._id === id) ?? null;
+      },
+    },
+    InventoryCounter: {
+      async findOneAndUpdate(filter, update) {
+        const counter = state.counters.get(filter.fulfillmentSku);
+        if (!counter || counter.available < filter.available.$gte) return null;
+        counter.available += update.$inc.available;
+        counter.reserved += update.$inc.reserved;
+        return { ...counter };
+      },
+    },
+    InventoryReservation: {
+      async create(docs) {
+        const values = Array.isArray(docs) ? docs : [docs];
+        state.reservations.push(...values.map((doc) => ({ ...doc })));
+        return values;
+      },
+    },
+    _state: state,
+  };
+}
+
+function makeHarness(options = {}) {
+  const models = options.models ?? makeModels(options);
+  let id = 0;
+  return {
+    models,
+    checkout(args) {
+      return createCheckout({
+        models,
+        owner: OWNER,
+        attemptKey: RETRY_KEY,
+        items: [{ skuKey: "hoodie", quantity: 1 }],
+        checkoutEnabled: true,
+        baseUrl: "https://shop.test",
+        now: () => NOW,
+        transaction: async (work) => work({ transactionId: "tx_test" }),
+        createId: (prefix) => `${prefix}_test_${++id}`,
+        ...args,
+      });
+    },
+  };
+}
+
+describe("createCheckout: recording one checkout attempt", () => {
+  it("rejects a malformed retry key or cart before reading or writing anything", async () => {
+    const cases = [
+      { attemptKey: "not-a-uuid" },
+      { items: null },
+      { items: [] },
+      { items: [{ skuKey: "hoodie", quantity: 0 }] },
+      { items: [{ skuKey: "hoodie", quantity: 1 }, { skuKey: "hoodie", quantity: 2 }] },
+      { items: [{ skuKey: "", quantity: 1 }] },
+    ];
+
+    for (const invalid of cases) {
+      const harness = makeHarness();
+      await assert.rejects(harness.checkout(invalid), CheckoutValidationError);
+      assert.equal(harness.models._state.calls.reads, 0);
+      assert.equal(harness.models._state.calls.writes, 0);
+    }
+  });
+
+  it("records the pending order, its stock holds, and the attempt together", async () => {
+    const harness = makeHarness();
+    const result = await harness.checkout();
+    const [attempt] = harness.models._state.attempts;
+    const [order] = harness.models._state.orders;
+
+    assert.equal(result.status, "pending");
+    assert.equal(result.checkoutUrl, undefined);
+    assert.equal(result.attemptKey, RETRY_KEY);
+    assert.equal(result.orderReference, order.orderReference);
+
+    // One attempt, one order, one held hoodie — the hold exists because the order does.
+    assert.equal(harness.models._state.attempts.length, 1);
+    assert.equal(harness.models._state.orders.length, 1);
+    assert.equal(harness.models._state.reservations.length, 1);
+    assert.equal(harness.models._state.counters.get("HOODIE-PURPLE-M").available, 9);
+
+    assert.equal(attempt.status, "pending");
+    assert.equal(attempt.orderId, order._id);
+    assert.equal(attempt.expiresAt.getTime(), NOW.getTime() + 60 * 60 * 1000);
+    assert.equal(attempt.providerIdempotencyKey, "iuga:checkout:checkout-attempt_test_1");
+    assert.equal(attempt.frozenStripeRequest.successUrl, "https://shop.test/shop/checkout/success");
+    assert.equal(attempt.frozenStripeRequest.cancelUrl, "https://shop.test/shop/checkout/cancel");
+    assert.equal(attempt.frozenStripeRequest.clientReferenceId, order._id);
+
+    // The order carries the prices the buyer saw, in whole cents.
+    assert.equal(order.totalMinor, 6500);
+    assert.equal(order.currency, "usd");
+    assert.equal(order.paymentState, "pending");
+    assert.equal(order.fulfillmentState, "pending");
+  });
+
+  it("answers unavailable when checkout is switched off, writing nothing", async () => {
+    const harness = makeHarness();
+    const result = await harness.checkout({ checkoutEnabled: false });
+
+    assert.equal(result.status, "unavailable");
+    assert.equal(harness.models._state.calls.writes, 0);
+  });
+
+  it("rejects a catalog, price, or stock failure without writing anything", async () => {
+    for (const breakRow of [
+      (row) => { row.isEnabled = false; },
+      (row) => { row.priceId = undefined; },
+    ]) {
+      const models = makeModels();
+      const broken = catalogRows.map((row) => ({ ...row }));
+      breakRow(broken[0]);
+      models.CatalogEntry.find = async () => broken;
+      const harness = makeHarness({ models });
+
+      const result = await harness.checkout({ items: [{ skuKey: "hoodie", quantity: 1 }] });
+
+      assert.equal(result.status, "unavailable");
+      assert.equal(models._state.orders.length, 0);
+      assert.equal(models._state.attempts.length, 0);
+      assert.equal(models._state.reservations.length, 0);
+    }
+
+    // Nothing left on the shelf: the hold fails, so no order and no attempt may survive.
+    const soldOut = makeHarness({ available: 0 });
+    const result = await soldOut.checkout({ items: [{ skuKey: "hoodie", quantity: 1 }] });
+    assert.equal(result.status, "unavailable");
+    assert.equal(soldOut.models._state.orders.length, 0);
+    assert.equal(soldOut.models._state.attempts.length, 0);
+
+    // A preorder item is sold before we own it, so nothing is held for it.
+    const preorder = makeHarness({ available: 0 });
+    const preorderResult = await preorder.checkout({ items: [{ skuKey: "sticker", quantity: 3 }] });
+    assert.equal(preorderResult.status, "pending");
+    assert.equal(preorder.models._state.reservations.length, 0);
+  });
+
+  it("rejects a quantity above the per-order limit before writing anything", async () => {
+    const harness = makeHarness();
+    const result = await harness.checkout({ items: [{ skuKey: "hoodie", quantity: 3 }] });
+
+    assert.equal(result.status, "unavailable");
+    assert.equal(harness.models._state.orders.length, 0);
+    assert.equal(harness.models._state.calls.writes, 0);
+  });
+
+  it("prices the purchase from persisted catalog documents", async () => {
+    const harness = makeHarness({ hydrateCatalog: true });
+    const result = await harness.checkout();
+
+    assert.equal(result.status, "pending");
+    assert.equal(harness.models._state.orders[0].totalMinor, 6500);
+    assert.equal(harness.models._state.attempts[0].frozenStripeRequest.lineItems[0].priceId, "price_hoodie_test");
+  });
+
+  it("prices from the active catalog revision, ignoring older rows for the same variant", async () => {
+    const models = makeModels();
+    const currentRow = { ...catalogRows[0], catalogVersion: 7, priceId: "price_current" };
+    const staleRow = { ...catalogRows[0], catalogVersion: 6, priceId: "price_stale" };
+    models.CatalogEntry.find = async (filter = {}) => (filter.catalogVersion === 7 ? [currentRow] : [staleRow]);
+    const harness = makeHarness({ models });
+
+    const result = await harness.checkout();
+
+    assert.equal(result.status, "pending");
+    assert.equal(models._state.attempts[0].frozenStripeRequest.lineItems[0].priceId, "price_current");
+  });
+
+  it("prices from the sale window that is open right now", async () => {
+    const closed = { ...activeSalesWindow, dropKey: "closed", opensAt: new Date("2026-01-01T00:00:00.000Z"), closesAt: new Date("2026-02-01T00:00:00.000Z") };
+    const openNow = { ...activeSalesWindow, dropKey: "open-now", opensAt: new Date("2026-09-01T00:00:00.000Z"), closesAt: new Date("2026-12-01T00:00:00.000Z") };
+    const later = { ...activeSalesWindow, dropKey: "later", opensAt: new Date("2026-11-01T00:00:00.000Z"), closesAt: new Date("2027-01-01T00:00:00.000Z") };
+    const models = makeModels();
+    let catalogFilter;
+    models.CatalogEntry.find = async (filter = {}) => {
+      catalogFilter = filter;
+      return catalogRows;
+    };
+    models.ShopDrop.findOne = async (filter = {}) => (filter.opensAt?.$lte && filter.closesAt?.$gt ? openNow : closed);
+    const harness = makeHarness({ models });
+
+    const result = await harness.checkout();
+
+    assert.equal(result.status, "pending");
+    assert.equal(catalogFilter.dropKey, openNow.dropKey);
+    assert.notEqual(catalogFilter.dropKey, later.dropKey);
+    assert.equal(models._state.attempts[0].dropKey, "open-now");
+  });
+
+  it("answers unavailable when the same retry key is already being written", async () => {
+    const models = makeModels();
+    models.CheckoutAttempt.create = async () => {
+      throw Object.assign(new Error("duplicate key"), { code: 11000 });
+    };
+    const harness = makeHarness({ models });
+
+    const result = await harness.checkout();
+
+    assert.equal(result.status, "unavailable");
+    assert.equal(result.orderReference, undefined);
+    // The order and the attempt are written in one database transaction, so the database
+    // discards the order when the attempt insert loses the race; this fake has no rollback.
+    assert.equal(models._state.attempts.length, 0);
+  });
+});


### PR DESCRIPTION
## Rationale

A payment link is worthless if the shop does not know what the buyer is paying for. This layer is the moment a cart becomes a real, durable commitment: the sale window is found, the cart is priced from our catalog, stock is taken off the shelf, and one **checkout attempt** is written down — the order, its stock holds, the prices the buyer is agreeing to, and the exact Stripe request we will send later.

The ordering is the whole point. Everything durable is written **before** any contact with Stripe, in one transaction: if pricing or stock fails, nothing is kept, and if the write fails, no money can move. The browser's role is deliberately tiny — it sends a cart and a retry key; identity, prices, quantities, totals, and return URLs are resolved server-side from the session, the catalog, and configuration.

The retry key is what makes a double press harmless. It is stored lower-cased and scoped to the buyer, so the same press of Pay always resolves to the same attempt, and two different buyers who happen to send the same key can never share an order.

## Observable Behavior

For a signed-in buyer with a valid cart, the flow now:

- selects the sale window that is open **right now** and the catalog revision that window uses;
- refuses anything unpriced, disabled, above its per-order limit, or without stock — without writing anything;
- takes stock off the shelf for the finite items (preorder items hold nothing) and writes a reservation whose lifetime matches the attempt;
- records a pending order with the frozen price snapshot in whole cents, plus a pending attempt holding the frozen Stripe request;
- answers `pending` — "recorded, ask again shortly" — because no payment link exists yet at this layer.

Stock and order are written together, so a half-finished attempt is impossible; a losing duplicate request answers `unavailable` rather than writing a second order (the next layer resolves it to the winner instead).

## Verification

- `node --test test/checkout-coordinator.test.js` — 9 passed. Coverage: malformed keys and carts rejected before any read or write; the order, its holds, and the attempt recorded together with the correct prices and hold; checkout switched off writing nothing; catalog, price, stock, and per-order-limit refusals leaving no durable state; pricing from persisted Mongoose catalog documents; active catalog revision; active sale window; and the duplicate-key loser.
- `npm test --prefix backend` — full suite passed.

## Stack Context

- Position: 6 of 11
- Base PR: #164
- Depends on: #164
