### PR TITLE
feat(shop): keep one Stripe payment link per attempt

### DIFF
--- a/backend/services/checkoutCoordinator.js
+++ b/backend/services/checkoutCoordinator.js
@@ -1,11 +1,13 @@
 /*
-Purpose: The durable step of checkout. It turns an authenticated cart into one "checkout
-         attempt": the order, the stock that order holds, the prices the buyer agreed to,
-         and the exact Stripe request we will send later — all written before money moves.
+Purpose: The whole checkout flow for one buyer. It records the attempt (order, stock holds,
+         agreed prices), asks Stripe for a payment link, and keeps the answer — so that
+         pressing Pay twice, retrying after a timeout, or reloading the page always lands on
+         the same attempt and never on a second charge.
 
 Called by: POST /api/v1/shop/checkout-sessions, through the shop controller.
 
-Must not: contact Stripe, or let the browser decide identity, prices, quantities, or the total.
+Must not: contact Stripe before the attempt is written down, trust a browser-supplied price,
+          quantity, or identity, or retry an attempt whose outcome we cannot explain.
 */
 
 import { randomUUID } from "node:crypto";
@@ -14,9 +16,13 @@ import mongoose from "mongoose";
 import { normalizeCart, freezeQuote } from "../shop/domain.js";
 import { holdInventory } from "../shop/reservations.js";
 
-// Why: a buyer may take a while to finish paying, but a attempt that is abandoned must not hold
-// stock — or hold a price — for the rest of the sale window.
+// Why: a buyer may take a while to finish paying, but an abandoned attempt must not hold stock
+// — or hold a price — for the rest of the sale window.
 const ATTEMPT_WINDOW_MS = 60 * 60 * 1000;
+
+// Why: 23 hours, not 24. Stripe retires a payment link after 24 hours, so anything older may
+// already be dead there and a human has to check before we try again.
+const MAX_RETRY_AGE_MS = 23 * 60 * 60 * 1000;
 
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -61,6 +67,20 @@ function validateBaseUrl(baseUrl) {
   return parsed.toString().replace(/\/$/, "");
 }
 
+// The buyer-facing order id, shown instead of our internal database id.
+async function readOrderReference(models, attempt) {
+  const order = await models.Order.findById(attempt.orderId);
+  return order?.orderReference ?? null;
+}
+
+/*
+Purpose: "Here is the link to pay." This is the only result that carries a payment link, and it
+         carries one only because the caller just confirmed the link still works.
+*/
+function readyResult(attemptKey, orderReference, checkoutUrl, isNew) {
+  return { status: "ready", isNew, attemptKey, orderReference, checkoutUrl };
+}
+
 /*
 Purpose: "The attempt exists, ask again shortly." It never carries a payment link, so an
          unfinished attempt can never be handed to a buyer as if it were ready to pay.
@@ -74,11 +94,56 @@ function stillProcessingResult(attempt, orderReference) {
 }
 
 /*
+Purpose: "A human must look at Stripe before we touch this order." Used whenever we cannot say
+         whether a payment link exists — a timeout, an unclear answer, or an attempt left alone
+         for too long. Retrying automatically could create a second charge.
+*/
+function needsManualCheckResult(attempt, orderReference) {
+  return {
+    status: "reconciliation_required",
+    attemptKey: attempt.attemptKey,
+    orderReference,
+  };
+}
+
+/*
+Purpose: The single "we cannot sell right now" answer. It deliberately does not say why: the
+         cause can be an unconfigured shop, a closed sale window, a missing price, or no stock,
+         and none of that belongs in a buyer's response.
+*/
+function unavailable() {
+  return { status: "unavailable" };
+}
+
+// The buyer reused their retry key with a different cart: that is a different purchase.
+function conflictResult() {
+  return { status: "conflict" };
+}
+
+// An attempt that ended for good keeps its own status, so a client can stop asking.
+function terminalResult(attempt, orderReference) {
+  return { status: attempt.status, attemptKey: attempt.attemptKey, orderReference };
+}
+
+/*
 Purpose: Run work in one database transaction, so a half-written attempt is impossible.
          Injected in tests, where there is no database.
 */
 function runInTransaction(work) {
   return mongoose.connection.transaction(work);
+}
+
+/*
+Purpose: Reach Stripe with the credentials this deployment is configured with. Callers may
+         inject their own (tests, and the shop controller, always do).
+*/
+async function defaultProvider() {
+  const { createStripeProviderClient } = await import("./stripeProviderClient.js");
+  return createStripeProviderClient({
+    secretKey: process.env.STRIPE_SECRET_KEY,
+    apiVersion: process.env.STRIPE_API_VERSION,
+    fetchImpl: globalThis.fetch,
+  });
 }
 
 // One id per attempt and per order. Tests inject their own so the ids stay predictable.
@@ -122,19 +187,35 @@ function quoteCatalogRow(entry) {
 }
 
 /*
-Purpose: The single "we cannot sell right now" answer. It deliberately does not say why: the
-         cause can be an unconfigured shop, a closed sale window, a missing price, or no stock,
-         and none of that belongs in a buyer's response.
+Purpose: Can we still send this buyer back to the payment link Stripe gave us?
+Why: Stripe reports the expiry in epoch seconds while the stored attempt may hold either shape,
+     and a link that is no longer open must never be handed out again.
 */
-function unavailable() {
-  return { status: "unavailable" };
+function isReusableStripeSession(session, now) {
+  const expiresAt = typeof session?.expiresAt === "number"
+    ? session.expiresAt * 1000
+    : new Date(session?.expiresAt).getTime();
+  return session?.status === "open" && session.url && Number.isFinite(expiresAt) && expiresAt > now.getTime();
 }
 
 /*
- * @behavior Validates a cart, prices it from the catalog, and durably records one pending
- *           checkout attempt with its order, its stock holds, and its frozen Stripe request.
- * @param args models, owner, UUIDv4 attemptKey, cart items, readiness, clock, and storage seams.
- * @returns a pending result carrying the attempt key and the human-facing order reference.
+Purpose: Attach the payment link to the attempt, but only while the attempt is still waiting.
+Why: two requests can race (a double press, a retry). The first to arrive wins; whoever loses
+     keeps the winner's answer instead of overwriting a usable payment link.
+*/
+async function attachReadySession(models, attemptFilter, session) {
+  return models.CheckoutAttempt.findOneAndUpdate(
+    { ...attemptFilter, status: "pending" },
+    { $set: { status: "ready", sessionId: session.id, paymentIntentId: session.paymentIntentId ?? null } },
+  );
+}
+
+/*
+ * @behavior Replays an existing attempt for this buyer and retry key, or creates one, prices
+ *           it, dispatches it to Stripe, and attaches the payment link — resolving it from
+ *           durable state instead of creating a second charge whenever the outcome is unclear.
+ * @param args models, owner, UUIDv4 attemptKey, cart items, readiness, provider and clock seams.
+ * @returns ready (with a payment link), pending, conflict, terminal, or unavailable.
  * @exceptions CheckoutValidationError for a malformed owner, retry key, base URL, cart, or clock.
  */
 export async function createCheckout({
@@ -143,6 +224,7 @@ export async function createCheckout({
   attemptKey,
   items,
   checkoutEnabled = false,
+  getProvider = defaultProvider,
   baseUrl = process.env.STRIPE_BASE_URL,
   now = new Date(),
   transaction = runInTransaction,
@@ -164,6 +246,64 @@ export async function createCheckout({
   }
   if (!models?.CheckoutAttempt || !models?.Order) {
     throw new CheckoutValidationError("Checkout storage is unavailable");
+  }
+
+  // Everything below is scoped to this buyer, so one buyer's retry key can never reach another
+  // buyer's attempt, order, or payment link.
+  const attemptFilter = {
+    "owner.type": normalizedOwner.type,
+    "owner.userId": normalizedOwner.userId,
+    attemptKey: normalizedAttemptKey,
+  };
+  const cartFingerprint = JSON.stringify(cart);
+
+  // Look for this buyer's earlier attempt before doing any new work. A retry, a refresh, or a
+  // double press must find its own attempt even when checkout has since been switched off.
+  const existing = await models.CheckoutAttempt.findOne(attemptFilter);
+  if (existing) {
+    if (existing.cartFingerprint !== cartFingerprint) return conflictResult();
+    const orderReference = await readOrderReference(models, existing);
+    if (!orderReference) return unavailable();
+
+    if (existing.status === "ready" && existing.sessionId) {
+      try {
+        const provider = await getProvider();
+        const session = await provider.retrieveCheckoutSession({ sessionId: existing.sessionId });
+        if (!isReusableStripeSession(session, checkoutNow)) return stillProcessingResult(existing, orderReference);
+        return readyResult(normalizedAttemptKey, orderReference, session.url, false);
+      } catch {
+        return stillProcessingResult(existing, orderReference);
+      }
+    }
+    if (existing.status === "reconciliation_required") return needsManualCheckResult(existing, orderReference);
+    if (existing.status === "expired" || existing.status === "failed") return terminalResult(existing, orderReference);
+    // A stale attempt stops here: past its own window, or past the age Stripe would still honour.
+    if (existing.expiresAt && checkoutNow >= new Date(existing.expiresAt)) return needsManualCheckResult(existing, orderReference);
+    if (existing.firstSubmissionAt && checkoutNow.getTime() >= new Date(existing.firstSubmissionAt).getTime() + MAX_RETRY_AGE_MS) {
+      return needsManualCheckResult(existing, orderReference);
+    }
+    if (!checkoutEnabled) return stillProcessingResult(existing, orderReference);
+    if (!existing.frozenStripeRequest) return stillProcessingResult(existing, orderReference);
+
+    // The earlier request never reached Stripe (it died after writing the attempt). Safe to send
+    // the same request again, with the same key, before either cutoff above is reached.
+    try {
+      const provider = await getProvider();
+      const session = await provider.createCheckoutSession({
+        frozenStripeRequest: existing.frozenStripeRequest,
+        idempotencyKey: existing.providerIdempotencyKey,
+      });
+      if (!isReusableStripeSession(session, checkoutNow)) return stillProcessingResult(existing, orderReference);
+      const attached = await attachReadySession(models, attemptFilter, session);
+      if (!attached) return stillProcessingResult(existing, orderReference);
+      return readyResult(normalizedAttemptKey, orderReference, session.url, false);
+    } catch {
+      await models.CheckoutAttempt.findOneAndUpdate(
+        { ...attemptFilter, status: "pending" },
+        { $set: { status: "reconciliation_required" } },
+      );
+      return needsManualCheckResult(existing, orderReference);
+    }
   }
 
   if (!checkoutEnabled) return unavailable();
@@ -223,9 +363,7 @@ export async function createCheckout({
     owner: normalizedOwner,
     attemptKey: normalizedAttemptKey,
     providerIdempotencyKey,
-    // Snapshot of the cart: if the same retry key ever arrives with different items, that is a
-    // different purchase and must not reuse this attempt.
-    cartFingerprint: JSON.stringify(cart),
+    cartFingerprint,
     items: cart,
     catalogVersion: String(activeSalesWindow.catalogVersion),
     dropKey: activeSalesWindow.dropKey,
@@ -264,10 +402,32 @@ export async function createCheckout({
     });
   } catch (error) {
     // A duplicate-key failure means another request is already writing this buyer's attempt.
-    // Nothing is written here, so we answer "not right now" rather than starting a second order.
-    if (error?.code === 11000) return unavailable();
+    // Answer from that attempt rather than starting a second order.
+    if (error?.code === 11000) {
+      const raced = await models.CheckoutAttempt.findOne(attemptFilter);
+      if (raced) {
+        if (raced.cartFingerprint !== cartFingerprint) return conflictResult();
+        const racedReference = await readOrderReference(models, raced);
+        if (racedReference) return stillProcessingResult(raced, racedReference);
+      }
+    }
     return unavailable();
   }
 
-  return stillProcessingResult(attemptDocument, orderReference);
+  // Only now do we involve money: the attempt is written down, so a failure here is recoverable
+  // by looking the attempt up again instead of by charging anyone twice.
+  try {
+    const provider = await getProvider();
+    const session = await provider.createCheckoutSession({ frozenStripeRequest, idempotencyKey: providerIdempotencyKey });
+    if (!isReusableStripeSession(session, checkoutNow)) return stillProcessingResult(attemptDocument, orderReference);
+    const attached = await attachReadySession(models, attemptFilter, session);
+    if (!attached) return stillProcessingResult(attemptDocument, orderReference);
+    return readyResult(normalizedAttemptKey, orderReference, session.url, true);
+  } catch {
+    await models.CheckoutAttempt.findOneAndUpdate(
+      { ...attemptFilter, status: "pending" },
+      { $set: { status: "reconciliation_required" } },
+    );
+    return needsManualCheckResult(attemptDocument, orderReference);
+  }
 }

--- a/backend/test/checkout-coordinator.test.js
+++ b/backend/test/checkout-coordinator.test.js
@@ -1,7 +1,7 @@
 /*
-Purpose: Prove the durable step of checkout behaves: a cart becomes exactly one priced
-         attempt with its stock held, the buyer's retry key selects that attempt, and nothing
-         is written at all when any check fails.
+Purpose: Prove the two promises this flow makes to the shop and to the buyer: a purchase is
+         written down before any money moves, and one press of Pay — however many times it is
+         retried — can only ever produce one attempt and one Stripe payment link.
 */
 
 import assert from "node:assert/strict";
@@ -16,8 +16,11 @@ import {
 } from "../services/checkoutCoordinator.js";
 
 const NOW = new Date("2026-10-01T12:00:00.000Z");
-const OWNER = { type: "user", userId: "user-a" };
-const RETRY_KEY = "550e8400-e29b-41d4-a716-446655440000";
+const OWNER_A = { type: "user", userId: "user-a" };
+const OWNER_B = { type: "user", userId: "user-b" };
+const RETRY_KEY_A = "550e8400-e29b-41d4-a716-446655440000";
+const RETRY_KEY_B = "550e8400-e29b-41d4-a716-446655440001";
+const ONE_HOODIE = [{ skuKey: "hoodie", quantity: 1 }];
 
 // One sale window ("drop"): the same shop can run several, each with its own price list.
 const activeSalesWindow = {
@@ -145,18 +148,45 @@ function makeModels({ available = 10, attempts = [], orders = [], hydrateCatalog
 
 function makeHarness(options = {}) {
   const models = options.models ?? makeModels(options);
+  const providerCalls = [];
+  const providerRetrievals = [];
+  const provider = options.provider ?? {
+    async createCheckoutSession(request) {
+      providerCalls.push(request);
+      return {
+        id: `cs_test_${providerCalls.length}`,
+        url: `https://checkout.test/${providerCalls.length}`,
+        expiresAt: new Date(NOW.getTime() + 60 * 60 * 1000),
+        paymentIntentId: `pi_test_${providerCalls.length}`,
+        status: "open",
+      };
+    },
+    async retrieveCheckoutSession(request) {
+      providerRetrievals.push(request);
+      return {
+        id: request.sessionId,
+        url: "https://checkout.test/retrieved",
+        expiresAt: new Date(NOW.getTime() + 60 * 60 * 1000),
+        paymentIntentId: "pi_retrieved",
+        status: "open",
+      };
+    },
+  };
   let id = 0;
   return {
     models,
+    providerCalls,
+    providerRetrievals,
     checkout(args) {
       return createCheckout({
         models,
-        owner: OWNER,
-        attemptKey: RETRY_KEY,
-        items: [{ skuKey: "hoodie", quantity: 1 }],
+        owner: OWNER_A,
+        attemptKey: RETRY_KEY_A,
+        items: ONE_HOODIE,
         checkoutEnabled: true,
         baseUrl: "https://shop.test",
         now: () => NOW,
+        getProvider: async () => provider,
         transaction: async (work) => work({ transactionId: "tx_test" }),
         createId: (prefix) => `${prefix}_test_${++id}`,
         ...args,
@@ -165,7 +195,32 @@ function makeHarness(options = {}) {
   };
 }
 
-describe("createCheckout: recording one checkout attempt", () => {
+// A buyer's attempt that already exists and was never answered by Stripe.
+function pendingAttemptFixture({ id = "attempt-seeded", reference = "ORD-SEEDED" } = {}) {
+  return {
+    _id: id,
+    owner: OWNER_A,
+    attemptKey: RETRY_KEY_A,
+    cartFingerprint: '[{"skuKey":"hoodie","quantity":1}]',
+    status: "pending",
+    orderId: `order-${id}`,
+    sessionId: null,
+    providerIdempotencyKey: `iuga:checkout:${id}`,
+    frozenStripeRequest: {
+      lineItems: [{ priceId: "price_hoodie_test", quantity: 1 }],
+      successUrl: "https://shop.test/shop/checkout/success",
+      cancelUrl: "https://shop.test/shop/checkout/cancel",
+      expiresAt: Math.floor(NOW.getTime() / 1000) + 3600,
+      clientReferenceId: `order-${id}`,
+      metadata: { attempt: id, order: `order-${id}` },
+    },
+    expiresAt: new Date(NOW.getTime() + 60 * 60 * 1000),
+    firstSubmissionAt: NOW,
+    orderReference: reference,
+  };
+}
+
+describe("createCheckout: one attempt, one payment link", () => {
   it("rejects a malformed retry key or cart before reading or writing anything", async () => {
     const cases = [
       { attemptKey: "not-a-uuid" },
@@ -181,18 +236,20 @@ describe("createCheckout: recording one checkout attempt", () => {
       await assert.rejects(harness.checkout(invalid), CheckoutValidationError);
       assert.equal(harness.models._state.calls.reads, 0);
       assert.equal(harness.models._state.calls.writes, 0);
+      assert.equal(harness.providerCalls.length, 0);
     }
   });
 
-  it("records the pending order, its stock holds, and the attempt together", async () => {
+  it("returns a payment link for a new purchase and records the attempt behind it", async () => {
     const harness = makeHarness();
     const result = await harness.checkout();
     const [attempt] = harness.models._state.attempts;
     const [order] = harness.models._state.orders;
 
-    assert.equal(result.status, "pending");
-    assert.equal(result.checkoutUrl, undefined);
-    assert.equal(result.attemptKey, RETRY_KEY);
+    assert.equal(result.status, "ready");
+    assert.equal(result.isNew, true);
+    assert.equal(result.checkoutUrl, "https://checkout.test/1");
+    assert.equal(result.attemptKey, RETRY_KEY_A);
     assert.equal(result.orderReference, order.orderReference);
 
     // One attempt, one order, one held hoodie — the hold exists because the order does.
@@ -201,12 +258,11 @@ describe("createCheckout: recording one checkout attempt", () => {
     assert.equal(harness.models._state.reservations.length, 1);
     assert.equal(harness.models._state.counters.get("HOODIE-PURPLE-M").available, 9);
 
-    assert.equal(attempt.status, "pending");
-    assert.equal(attempt.orderId, order._id);
+    assert.equal(attempt.status, "ready");
+    assert.equal(attempt.sessionId, "cs_test_1");
     assert.equal(attempt.expiresAt.getTime(), NOW.getTime() + 60 * 60 * 1000);
     assert.equal(attempt.providerIdempotencyKey, "iuga:checkout:checkout-attempt_test_1");
     assert.equal(attempt.frozenStripeRequest.successUrl, "https://shop.test/shop/checkout/success");
-    assert.equal(attempt.frozenStripeRequest.cancelUrl, "https://shop.test/shop/checkout/cancel");
     assert.equal(attempt.frozenStripeRequest.clientReferenceId, order._id);
 
     // The order carries the prices the buyer saw, in whole cents.
@@ -222,6 +278,7 @@ describe("createCheckout: recording one checkout attempt", () => {
 
     assert.equal(result.status, "unavailable");
     assert.equal(harness.models._state.calls.writes, 0);
+    assert.equal(harness.providerCalls.length, 0);
   });
 
   it("rejects a catalog, price, or stock failure without writing anything", async () => {
@@ -235,25 +292,27 @@ describe("createCheckout: recording one checkout attempt", () => {
       models.CatalogEntry.find = async () => broken;
       const harness = makeHarness({ models });
 
-      const result = await harness.checkout({ items: [{ skuKey: "hoodie", quantity: 1 }] });
+      const result = await harness.checkout({ items: ONE_HOODIE });
 
       assert.equal(result.status, "unavailable");
       assert.equal(models._state.orders.length, 0);
       assert.equal(models._state.attempts.length, 0);
       assert.equal(models._state.reservations.length, 0);
+      assert.equal(harness.providerCalls.length, 0);
     }
 
     // Nothing left on the shelf: the hold fails, so no order and no attempt may survive.
     const soldOut = makeHarness({ available: 0 });
-    const result = await soldOut.checkout({ items: [{ skuKey: "hoodie", quantity: 1 }] });
+    const result = await soldOut.checkout({ items: ONE_HOODIE });
     assert.equal(result.status, "unavailable");
     assert.equal(soldOut.models._state.orders.length, 0);
     assert.equal(soldOut.models._state.attempts.length, 0);
+    assert.equal(soldOut.providerCalls.length, 0);
 
     // A preorder item is sold before we own it, so nothing is held for it.
     const preorder = makeHarness({ available: 0 });
     const preorderResult = await preorder.checkout({ items: [{ skuKey: "sticker", quantity: 3 }] });
-    assert.equal(preorderResult.status, "pending");
+    assert.equal(preorderResult.status, "ready");
     assert.equal(preorder.models._state.reservations.length, 0);
   });
 
@@ -270,9 +329,9 @@ describe("createCheckout: recording one checkout attempt", () => {
     const harness = makeHarness({ hydrateCatalog: true });
     const result = await harness.checkout();
 
-    assert.equal(result.status, "pending");
+    assert.equal(result.status, "ready");
     assert.equal(harness.models._state.orders[0].totalMinor, 6500);
-    assert.equal(harness.models._state.attempts[0].frozenStripeRequest.lineItems[0].priceId, "price_hoodie_test");
+    assert.equal(harness.providerCalls[0].frozenStripeRequest.lineItems[0].priceId, "price_hoodie_test");
   });
 
   it("prices from the active catalog revision, ignoring older rows for the same variant", async () => {
@@ -284,8 +343,8 @@ describe("createCheckout: recording one checkout attempt", () => {
 
     const result = await harness.checkout();
 
-    assert.equal(result.status, "pending");
-    assert.equal(models._state.attempts[0].frozenStripeRequest.lineItems[0].priceId, "price_current");
+    assert.equal(result.status, "ready");
+    assert.equal(harness.providerCalls[0].frozenStripeRequest.lineItems[0].priceId, "price_current");
   });
 
   it("prices from the sale window that is open right now", async () => {
@@ -303,25 +362,231 @@ describe("createCheckout: recording one checkout attempt", () => {
 
     const result = await harness.checkout();
 
-    assert.equal(result.status, "pending");
+    assert.equal(result.status, "ready");
     assert.equal(catalogFilter.dropKey, openNow.dropKey);
     assert.notEqual(catalogFilter.dropKey, later.dropKey);
     assert.equal(models._state.attempts[0].dropKey, "open-now");
   });
 
-  it("answers unavailable when the same retry key is already being written", async () => {
+  it("replays the same attempt when the buyer presses Pay again", async () => {
+    const harness = makeHarness();
+    const first = await harness.checkout({ items: [{ skuKey: "tote", quantity: 1 }, { skuKey: "hoodie", quantity: 2 }] });
+    const second = await harness.checkout({ items: [{ skuKey: "hoodie", quantity: 2 }, { skuKey: "tote", quantity: 1 }] });
+
+    assert.equal(first.status, "ready");
+    assert.equal(first.isNew, true);
+    assert.equal(second.status, "ready");
+    assert.equal(second.isNew, false);
+    assert.equal(second.orderReference, first.orderReference);
+    assert.equal(harness.models._state.orders.length, 1);
+    assert.equal(harness.models._state.attempts.length, 1);
+    assert.equal(harness.models._state.reservations.length, 2);
+    assert.equal(harness.providerCalls.length, 1);
+    assert.equal(harness.providerRetrievals.length, 1);
+    assert.equal(harness.providerRetrievals[0].sessionId, harness.models._state.attempts[0].sessionId);
+    assert.equal(second.checkoutUrl, "https://checkout.test/retrieved");
+  });
+
+  it("treats the same retry key with a different cart as a conflict", async () => {
+    const harness = makeHarness();
+    await harness.checkout();
+    const result = await harness.checkout({ items: [{ skuKey: "tote", quantity: 1 }] });
+
+    assert.equal(result.status, "conflict");
+    assert.equal(harness.models._state.orders.length, 1);
+    assert.equal(harness.models._state.attempts.length, 1);
+    assert.equal(harness.providerCalls.length, 1);
+  });
+
+  it("keeps one buyer's retry key out of another buyer's attempt", async () => {
+    const harness = makeHarness();
+    const first = await harness.checkout({ owner: OWNER_A, attemptKey: RETRY_KEY_B });
+    const second = await harness.checkout({ owner: OWNER_B, attemptKey: RETRY_KEY_B });
+
+    assert.equal(first.status, "ready");
+    assert.equal(second.status, "ready");
+    assert.equal(harness.models._state.orders.length, 2);
+    assert.equal(harness.models._state.attempts.length, 2);
+    assert.notEqual(harness.providerCalls[0].idempotencyKey, harness.providerCalls[1].idempotencyKey);
+  });
+
+  it("replays an existing attempt even when checkout has been switched off", async () => {
+    const harness = makeHarness();
+    const created = await harness.checkout();
+    harness.models._state.attempts[0].status = "pending";
+    const replay = await harness.checkout({ checkoutEnabled: false });
+
+    assert.equal(replay.status, "pending");
+    assert.equal(replay.orderReference, created.orderReference);
+    assert.equal(replay.checkoutUrl, undefined);
+    assert.equal(harness.providerCalls.length, 1);
+    assert.equal(harness.models._state.orders.length, 1);
+
+    const fresh = makeHarness();
+    const unavailable = await fresh.checkout({ checkoutEnabled: false, attemptKey: RETRY_KEY_B });
+    assert.equal(unavailable.status, "unavailable");
+    assert.equal(fresh.models._state.calls.writes, 0);
+    assert.equal(fresh.providerCalls.length, 0);
+  });
+
+  it("replays durable state before checking the shop's own address", async () => {
+    const harness = makeHarness();
+    await harness.checkout();
+    harness.models._state.attempts[0].status = "pending";
+
+    const result = await harness.checkout({ checkoutEnabled: false, baseUrl: undefined });
+
+    assert.equal(result.status, "pending");
+    assert.equal(harness.providerCalls.length, 1);
+  });
+
+  it("asks for a human check when Stripe's answer cannot be explained", async () => {
+    const provider = {
+      async createCheckoutSession() {
+        throw new Error("timeout");
+      },
+    };
+    const harness = makeHarness({ provider });
+    const first = await harness.checkout();
+    const second = await harness.checkout();
+
+    assert.equal(first.status, "reconciliation_required");
+    assert.equal(first.checkoutUrl, undefined);
+    assert.equal(second.status, "reconciliation_required");
+    assert.equal(harness.models._state.attempts[0].status, "reconciliation_required");
+    assert.equal(harness.models._state.orders.length, 1);
+    assert.equal(harness.models._state.reservations.length, 1);
+  });
+
+  it("keeps a payment link that a concurrent duplicate request attached", async () => {
+    const fixture = pendingAttemptFixture();
+    const models = makeModels({
+      attempts: [fixture],
+      orders: [{ _id: fixture.orderId, orderReference: fixture.orderReference }],
+    });
+    let attachWinner = async () => {};
+    const harness = makeHarness({
+      models,
+      provider: {
+        async createCheckoutSession() {
+          await attachWinner();
+          throw new Error("transport failure");
+        },
+        async retrieveCheckoutSession({ sessionId }) {
+          return {
+            id: sessionId,
+            url: "https://checkout.test/winner",
+            expiresAt: new Date(NOW.getTime() + 60 * 60 * 1000),
+            paymentIntentId: "pi_winner",
+            status: "open",
+          };
+        },
+      },
+    });
+    attachWinner = () => models.CheckoutAttempt.findOneAndUpdate(
+      { "owner.userId": OWNER_A.userId, attemptKey: RETRY_KEY_A, status: "pending" },
+      { $set: { status: "ready", sessionId: "cs_winner", paymentIntentId: "pi_winner" } },
+    );
+
+    // This request cannot tell whether Stripe created a link, but the winner already stored one.
+    const failed = await harness.checkout();
+    assert.equal(failed.status, "reconciliation_required");
+    assert.equal(models._state.attempts[0].status, "ready");
+    assert.equal(models._state.attempts[0].sessionId, "cs_winner");
+
+    const replay = await harness.checkout();
+    assert.equal(replay.status, "ready");
+    assert.equal(replay.checkoutUrl, "https://checkout.test/winner");
+  });
+
+  it("re-reads the winner when another request is writing the same attempt", async () => {
     const models = makeModels();
+    const winner = {
+      _id: "attempt-winner",
+      owner: OWNER_A,
+      attemptKey: RETRY_KEY_A,
+      cartFingerprint: JSON.stringify(ONE_HOODIE),
+      orderId: "order-winner",
+      status: "pending",
+    };
+    let lookups = 0;
+    models.CheckoutAttempt.findOne = async () => {
+      lookups += 1;
+      return lookups === 1 ? null : winner;
+    };
     models.CheckoutAttempt.create = async () => {
       throw Object.assign(new Error("duplicate key"), { code: 11000 });
     };
+    models.Order.findById = async () => ({ _id: "order-winner", orderReference: "ORD-WINNER" });
     const harness = makeHarness({ models });
 
     const result = await harness.checkout();
 
-    assert.equal(result.status, "unavailable");
-    assert.equal(result.orderReference, undefined);
-    // The order and the attempt are written in one database transaction, so the database
-    // discards the order when the attempt insert loses the race; this fake has no rollback.
-    assert.equal(models._state.attempts.length, 0);
+    assert.equal(result.status, "pending");
+    assert.equal(result.orderReference, "ORD-WINNER");
+    assert.equal(harness.providerCalls.length, 0);
+  });
+
+  it("stops acting on an attempt that is finished or too old", async () => {
+    for (const status of ["reconciliation_required", "expired", "failed"]) {
+      const harness = makeHarness();
+      await harness.checkout();
+      harness.providerCalls.length = 0;
+      harness.models._state.attempts[0].status = status;
+
+      const result = await harness.checkout();
+
+      assert.equal(result.status, status);
+      assert.equal(result.checkoutUrl, undefined);
+      assert.equal(harness.providerCalls.length, 0);
+    }
+
+    for (const age of [
+      (attempt) => { attempt.expiresAt = new Date(NOW.getTime() - 1); },
+      (attempt) => { attempt.firstSubmissionAt = new Date(NOW.getTime() - 23 * 60 * 60 * 1000 - 1); },
+    ]) {
+      const harness = makeHarness();
+      await harness.checkout();
+      harness.providerCalls.length = 0;
+      harness.models._state.attempts[0].status = "pending";
+      age(harness.models._state.attempts[0]);
+
+      const result = await harness.checkout();
+
+      assert.equal(result.status, "reconciliation_required");
+      assert.equal(harness.providerCalls.length, 0);
+    }
+  });
+
+  it("never hands out a payment link that is closed or already expired", async () => {
+    for (const session of [
+      { id: "cs_complete", url: "https://checkout.test/complete", status: "complete", expiresAt: new Date(NOW.getTime() + 1000) },
+      { id: "cs_expired", url: "https://checkout.test/expired", status: "open", expiresAt: NOW },
+    ]) {
+      const harness = makeHarness({ provider: { createCheckoutSession: async () => session } });
+
+      const result = await harness.checkout();
+
+      assert.notEqual(result.status, "ready");
+      assert.equal(result.checkoutUrl, undefined);
+      assert.notEqual(harness.models._state.attempts[0]?.sessionId, session.id);
+    }
+  });
+
+  it("accepts a Stripe expiry reported in epoch seconds", async () => {
+    const session = {
+      id: "cs_epoch",
+      url: "https://checkout.test/epoch",
+      expiresAt: Math.floor(NOW.getTime() / 1000) + 3600,
+      paymentIntentId: "pi_epoch",
+      status: "open",
+    };
+    const harness = makeHarness({ provider: { createCheckoutSession: async () => session } });
+
+    const result = await harness.checkout();
+
+    assert.equal(result.status, "ready");
+    assert.equal(result.checkoutUrl, session.url);
+    assert.equal(harness.models._state.attempts[0].sessionId, session.id);
   });
 });


### PR DESCRIPTION
## Rationale

Money is irreversible, so the promise this layer makes is narrow and absolute: **one press of Pay becomes exactly one Stripe payment link, no matter how many times the browser retries.** Retries happen constantly in the real world — a flaky connection, a double tap, a page refresh after a timeout — and each one is an opportunity to charge a student twice.

Two failures make that hard. The first is a provider whose answer we never receive: if Stripe created a link and the reply was lost, retrying with a fresh key would create a second link, and the buyer could pay twice. The second is a race: two requests for the same attempt arriving at once, each attaching a different payment link.

This layer closes both. Unknown outcomes are recorded as `reconciliation_required` and never re-dispatched automatically — a person checks Stripe first. The link is attached conditionally, so only the first request to arrive wins and whoever loses keeps the winner's answer instead of overwriting a usable link.

## Observable Behavior

- A first press returns `201` with the payment link; pressing Pay again with the same retry key returns `200` with **the same** link and creates no second Stripe session.
- The same retry key with a different cart is a `409 conflict`: a different purchase cannot reuse an attempt.
- Two buyers who happen to send equal retry keys get separate attempts and separate Stripe keys (the key sent to Stripe is derived from our attempt id).
- A retry replays the recorded attempt even when checkout has since been switched off.
- A Stripe timeout or unreadable answer returns `202 reconciliation_required` with no link, and the attempt stays marked for a human.
- An attempt that is finished (`expired`/`failed`) reports its own status with `200` and never a link; an attempt past its own hour, or past Stripe's 23-hour window, stops dispatching rather than guessing.
- A link that is closed or expired is never handed out again.

## Verification

- `node --test test/checkout-coordinator.test.js` — 19 passed. Coverage: replay of a reordered cart from one durable attempt, conflict on a changed cart, owner-scoped retry keys, replay while checkout is disabled, `reconciliation_required` with no re-creation, a payment link surviving a concurrent duplicate request, re-reading the winner after losing the duplicate-key race, terminal and too-old attempts not dispatching, closed/expired links never handed out, and epoch-second expiries accepted.
- `npm test --prefix backend` — full suite passed.

## Stack Context

- Position: 7 of 11
- Base PR: #165
- Depends on: #165
