### PR TITLE
feat(shop): expose checkout session creation endpoint

### DIFF
--- a/backend/routes/api/v1/apiv1.js
+++ b/backend/routes/api/v1/apiv1.js
@@ -6,12 +6,14 @@ import eventsRouter from "./controllers/events.js";
 import feedbackRouter from "./controllers/feedback.js";
 import rolesRouter from "./controllers/roles.js";
 import eventRequestsRouter from "./controllers/eventRequests.js";
+import shopRouter from "./controllers/shop.js";
 
 router.use("/user", usersRouter);
 router.use("/events", eventsRouter);
 router.use("/feedback", feedbackRouter);
 router.use("/roles", rolesRouter);
 router.use("/event-requests", eventRequestsRouter);
+router.use("/shop", shopRouter);
 
 export default router;
 

--- a/backend/routes/api/v1/controllers/shop.js
+++ b/backend/routes/api/v1/controllers/shop.js
@@ -1,0 +1,165 @@
+/*
+Purpose: The shop's HTTP entry point. It answers one question for the browser — "what is the
+         payment link for this cart, if there is one?" — and refuses anything the browser
+         should not be deciding (who the buyer is, what things cost, how many are left).
+
+Authentication/Authorization Requirements: A signed-in UW session. State-changing requests must
+    also come from a trusted shop origin and are rate limited; both are enforced globally in
+    app.js before this router runs.
+
+Expected Request Information:
+- header `Idempotency-Key` — a UUIDv4 the browser repeats when it retries the same purchase.
+- body `{ "items": [ { "skuKey": <catalog variant>, "quantity": <whole number, 1 or more> } ] }`
+- nothing else: no buyer, no prices, no totals.
+
+Expected Response Information:
+- 201 { attemptKey, orderReference, status: "ready", checkoutUrl }   a new attempt, ready to pay
+- 200 { attemptKey, orderReference, status: "ready", checkoutUrl }   the same attempt, asked again
+- 200 { attemptKey, orderReference, status: "expired" | "failed" }   finished, no link to give
+- 202 { attemptKey, orderReference, status: "pending" }              recorded, ask again shortly
+- 202 { attemptKey, orderReference, status: "reconciliation_required" } a human must check Stripe
+- 400 the request was not usable
+- 401 nobody is signed in
+- 409 the same retry key arrived with a different cart
+- 503 checkout is switched off, misconfigured, or unavailable for now
+*/
+
+import express from "express";
+import { requireAuth } from "../utils/auth.js";
+import { sendError } from "../helpers/sendError.js";
+import { normalizeCart } from "../../../../shop/domain.js";
+import { createCheckout, CheckoutValidationError } from "../../../../services/checkoutCoordinator.js";
+import { createStripeProviderClient } from "../../../../services/stripeProviderClient.js";
+import { evaluateCheckoutReadiness } from "../../../../checkoutReadiness.js";
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const INVALID_REQUEST_MESSAGE = "Invalid checkout request";
+const CHECKOUT_UNAVAILABLE_MESSAGE = "Checkout is currently unavailable";
+const CHECKOUT_CONFLICT_MESSAGE = "Checkout request conflicts with an existing attempt";
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/*
+Purpose: Read the buyer's request, or reject it with a message that reveals nothing.
+Why: the body must be exactly { items }. Anything else — a buyer, a price, a total — is refused
+     rather than ignored, because the server owns identity and money, and a silently ignored
+     field is how a client ends up believing it decided the price.
+*/
+function readCheckoutRequest(body, idempotencyKeyHeader) {
+  if (typeof idempotencyKeyHeader !== "string" || !UUID_V4.test(idempotencyKeyHeader)) {
+    throw new CheckoutValidationError(INVALID_REQUEST_MESSAGE);
+  }
+  if (!isPlainObject(body) || Object.keys(body).length !== 1 || !Object.hasOwn(body, "items")) {
+    throw new CheckoutValidationError(INVALID_REQUEST_MESSAGE);
+  }
+  if (!Array.isArray(body.items)) {
+    throw new CheckoutValidationError(INVALID_REQUEST_MESSAGE);
+  }
+  for (const item of body.items) {
+    if (!isPlainObject(item) || Object.keys(item).length !== 2 ||
+        !Object.hasOwn(item, "skuKey") || !Object.hasOwn(item, "quantity")) {
+      throw new CheckoutValidationError(INVALID_REQUEST_MESSAGE);
+    }
+  }
+  // The retry key is stored lower-cased, so the same press of Pay always compares equal.
+  return { attemptKey: idempotencyKeyHeader.toLowerCase(), items: normalizeCart(body.items) };
+}
+
+// Reach Stripe with this deployment's credentials; the coordinator owns when to call it.
+function stripeProviderFromEnvironment() {
+  return createStripeProviderClient({
+    secretKey: process.env.STRIPE_SECRET_KEY,
+    apiVersion: process.env.STRIPE_API_VERSION,
+    fetchImpl: globalThis.fetch,
+  });
+}
+
+/*
+Purpose: Decide whether checkout may run at all, right now.
+Why: production passes nothing here, so the fail-closed readiness gate is asked on every request
+     and cannot be sidestepped by a running process. Tests pass a boolean to choose an answer.
+*/
+function resolveCheckoutEnabled(override) {
+  if (typeof override === "boolean") return override;
+  return evaluateCheckoutReadiness({ env: process.env }).checkoutEnabled;
+}
+
+/*
+ * Purpose: Build the shop's router. Injectable so tests can drive the endpoint without a
+ *          database or Stripe.
+ * @param options.checkout — the checkout flow to delegate to; defaults to the real one.
+ * @param options.checkoutEnabled — a boolean readiness override for tests.
+ * @returns an Express router mounted at /api/v1/shop.
+ */
+export function createShopRouter({ checkout = createCheckout, checkoutEnabled } = {}) {
+  const router = express.Router();
+  router.post("/checkout-sessions", requireAuth, async (req, res) => {
+    // requireAuth only tells us somebody is signed in; the buyer identity we trust is this id.
+    const sessionUserId = req.session?.userId;
+    if (
+      sessionUserId === null ||
+      sessionUserId === undefined ||
+      String(sessionUserId).trim() === ""
+    ) {
+      return sendError(res, 401, "Not authenticated");
+    }
+
+    let request;
+    try {
+      request = readCheckoutRequest(req.body, req.get("Idempotency-Key"));
+    } catch {
+      return sendError(res, 400, INVALID_REQUEST_MESSAGE);
+    }
+
+    try {
+      const result = await checkout({
+        models: req.models,
+        // The owner comes from the session only; the browser never names the buyer.
+        owner: { type: "user", userId: String(req.session.userId) },
+        attemptKey: request.attemptKey,
+        items: request.items,
+        checkoutEnabled: resolveCheckoutEnabled(checkoutEnabled),
+        baseUrl: process.env.STRIPE_BASE_URL,
+        getProvider: stripeProviderFromEnvironment,
+      });
+
+      if (result?.status === "ready") {
+        const body = {
+          attemptKey: result.attemptKey,
+          orderReference: result.orderReference,
+          status: "ready",
+          checkoutUrl: result.checkoutUrl,
+        };
+        return res.status(result.isNew === false ? 200 : 201).json(body);
+      }
+      // The attempt is over. Answer 200 so a client stops asking, and hand back no link.
+      if (result?.status === "expired" || result?.status === "failed") {
+        return res.status(200).json({
+          attemptKey: result.attemptKey,
+          orderReference: result.orderReference,
+          status: result.status,
+        });
+      }
+      // Still in progress, or waiting for a human: no link either way.
+      if (result?.status === "pending" || result?.status === "reconciliation_required") {
+        return res.status(202).json({
+          attemptKey: result.attemptKey,
+          orderReference: result.orderReference,
+          status: result.status,
+        });
+      }
+      if (result?.status === "conflict") return sendError(res, 409, CHECKOUT_CONFLICT_MESSAGE);
+      return sendError(res, 503, CHECKOUT_UNAVAILABLE_MESSAGE);
+    } catch (error) {
+      if (error instanceof CheckoutValidationError) return sendError(res, 400, INVALID_REQUEST_MESSAGE);
+      return sendError(res, 503, CHECKOUT_UNAVAILABLE_MESSAGE);
+    }
+  });
+
+  return router;
+}
+
+const router = createShopRouter();
+export default router;

--- a/backend/test/shop-checkout-contract.test.js
+++ b/backend/test/shop-checkout-contract.test.js
@@ -1,0 +1,282 @@
+/*
+Purpose: Pin the promise this endpoint makes to the browser: only a signed-in buyer can call it,
+         it decides everything about money itself, and every answer is exactly the shape the
+         client was told to expect — with no internal detail, retry key, or Stripe identifier
+         leaking into a response.
+*/
+
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { createShopRouter } from "../routes/api/v1/controllers/shop.js";
+import { makeTestApi } from "./testApi.js";
+
+const OWNER = { type: "user", userId: "user-123" };
+const UPPERCASE_KEY = "550E8400-E29B-41D4-A716-446655440000";
+const NORMALIZED_KEY = UPPERCASE_KEY.toLowerCase();
+const ITEMS = [{ skuKey: "info-hoodie", quantity: 2 }];
+
+function fakeCheckout(result, calls) {
+  return async (args) => {
+    calls.push(args);
+    return result;
+  };
+}
+
+async function makeApi({ checkout, checkoutEnabled, session = { isAuthenticated: true, userId: OWNER.userId } } = {}) {
+  return makeTestApi({
+    router: createShopRouter({ checkout, checkoutEnabled }),
+    mountPath: "/api/v1/shop",
+    models: { injected: true },
+    session,
+  });
+}
+
+async function request(api, body = { items: ITEMS }, options = {}) {
+  return api.request("POST", "/api/v1/shop/checkout-sessions", body, {
+    headers: { "Idempotency-Key": UPPERCASE_KEY, ...options.headers },
+    ...options,
+  });
+}
+
+describe("POST /api/v1/shop/checkout-sessions", () => {
+  test("refuses a caller who is not signed in, before any checkout work", async () => {
+    const calls = [];
+    const api = await makeApi({
+      checkout: fakeCheckout({ status: "unavailable" }, calls),
+      session: {},
+    });
+
+    try {
+      const result = await request(api);
+
+      assert.equal(result.status, 401);
+      assert.deepEqual(result.body, { status: "error", message: "Not authenticated" });
+      assert.equal(calls.length, 0);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("refuses a missing or malformed retry key, before any checkout work", async () => {
+    for (const key of [undefined, "not-a-uuid", "550e8400-e29b-11d4-a716-446655440000"]) {
+      const calls = [];
+      const api = await makeApi({ checkout: fakeCheckout({ status: "ready" }, calls) });
+      try {
+        const result = await api.request("POST", "/api/v1/shop/checkout-sessions", { items: ITEMS }, {
+          headers: key === undefined ? {} : { "Idempotency-Key": key },
+        });
+        assert.equal(result.status, 400, String(key));
+        assert.equal(calls.length, 0, String(key));
+      } finally {
+        await api.close();
+      }
+    }
+  });
+
+  test("refuses an unknown body field, a missing cart, a duplicate variant, and a bad quantity", async () => {
+    const invalidBodies = [
+      // A client trying to decide identity, money, or status itself is refused, not ignored.
+      { items: ITEMS, owner: OWNER, amount: 100, price: "price_browser", url: "https://evil.example", status: "ready" },
+      {},
+      { items: [{ skuKey: "info-hoodie", quantity: 1 }, { skuKey: "info-hoodie", quantity: 2 }] },
+      { items: [{ skuKey: "info-hoodie", quantity: 0 }] },
+    ];
+
+    for (const body of invalidBodies) {
+      const calls = [];
+      const api = await makeApi({ checkout: fakeCheckout({ status: "ready" }, calls) });
+      try {
+        const result = await request(api, body);
+        assert.equal(result.status, 400);
+        assert.equal(calls.length, 0);
+      } finally {
+        await api.close();
+      }
+    }
+  });
+
+  test("hands the checkout flow the session buyer and never the browser's claims", async () => {
+    const calls = [];
+    const checkout = fakeCheckout({
+      status: "ready",
+      isNew: true,
+      attemptKey: NORMALIZED_KEY,
+      orderReference: "ORD-123",
+      checkoutUrl: "https://checkout.stripe.test/session",
+      providerSessionId: "cs_test_provider",
+      catalogPriceMinor: 9999,
+      owner: OWNER,
+      frozenStripeRequest: { line_items: [{ price: "price_browser" }] },
+      internalError: new Error("secret internal error"),
+    }, calls);
+    const api = await makeApi({ checkout, checkoutEnabled: false });
+
+    try {
+      const result = await request(api);
+
+      assert.equal(result.status, 201);
+      assert.equal(calls.length, 1);
+      assert.deepEqual(calls[0].owner, OWNER);
+      assert.equal(calls[0].attemptKey, NORMALIZED_KEY);
+      assert.deepEqual(calls[0].items, ITEMS);
+      assert.equal(calls[0].checkoutEnabled, false);
+      assert.equal(typeof calls[0].getProvider, "function");
+      // Why: none of the internal names the checkout flow works with may reach the browser.
+      assert.doesNotMatch(JSON.stringify(result.body), /cs_test_provider|price_\w+|user-123|frozen|internal/i);
+      assert.equal(calls[0].price, undefined);
+      assert.equal(calls[0].url, undefined);
+      assert.equal(calls[0].status, undefined);
+      assert.deepEqual(result.body, {
+        attemptKey: NORMALIZED_KEY,
+        orderReference: "ORD-123",
+        status: "ready",
+        checkoutUrl: "https://checkout.stripe.test/session",
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("answers 200 with the same link when the buyer asks again", async () => {
+    const calls = [];
+    const api = await makeApi({
+      checkout: fakeCheckout({
+        status: "ready", isNew: false, attemptKey: NORMALIZED_KEY, orderReference: "ORD-123", checkoutUrl: "https://checkout.stripe.test/replay",
+      }, calls),
+    });
+
+    try {
+      const result = await request(api);
+      assert.equal(result.status, 200);
+      assert.deepEqual(result.body, {
+        attemptKey: NORMALIZED_KEY,
+        orderReference: "ORD-123",
+        status: "ready",
+        checkoutUrl: "https://checkout.stripe.test/replay",
+      });
+      assert.equal(calls.length, 1);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("answers 202 without a payment link while the attempt is still in progress", async () => {
+    const calls = [];
+    const api = await makeApi({ checkout: fakeCheckout({ status: "pending", attemptKey: NORMALIZED_KEY, orderReference: "ORD-123" }, calls) });
+    try {
+      const result = await request(api);
+      assert.equal(result.status, 202);
+      assert.deepEqual(result.body, { attemptKey: NORMALIZED_KEY, orderReference: "ORD-123", status: "pending" });
+      assert.equal(Object.hasOwn(result.body, "checkoutUrl"), false);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("answers 202 without a payment link when a human must check Stripe", async () => {
+    const calls = [];
+    const api = await makeApi({
+      checkout: fakeCheckout({
+        status: "reconciliation_required",
+        attemptKey: NORMALIZED_KEY,
+        orderReference: "ORD-123",
+        // Even if the flow hands one over, this state must never publish a link.
+        checkoutUrl: "https://checkout.stripe.test/should-not-leak",
+      }, calls),
+    });
+    try {
+      const result = await request(api);
+      assert.equal(result.status, 202);
+      assert.deepEqual(result.body, {
+        attemptKey: NORMALIZED_KEY,
+        orderReference: "ORD-123",
+        status: "reconciliation_required",
+      });
+      assert.equal(Object.hasOwn(result.body, "checkoutUrl"), false);
+      assert.equal(calls.length, 1);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("reports a finished attempt as 200 with its status and no payment link", async () => {
+    for (const status of ["expired", "failed"]) {
+      const calls = [];
+      const api = await makeApi({
+        checkout: fakeCheckout({
+          status,
+          attemptKey: NORMALIZED_KEY,
+          orderReference: "ORD-123",
+          checkoutUrl: "https://checkout.stripe.test/should-not-leak",
+        }, calls),
+      });
+      try {
+        const result = await request(api);
+        assert.equal(result.status, 200, status);
+        assert.deepEqual(result.body, {
+          attemptKey: NORMALIZED_KEY,
+          orderReference: "ORD-123",
+          status,
+        });
+        assert.equal(Object.hasOwn(result.body, "checkoutUrl"), false);
+      } finally {
+        await api.close();
+      }
+    }
+  });
+
+  for (const [status, httpStatus] of [["conflict", 409], ["unavailable", 503]]) {
+    test(`reports ${status} as ${httpStatus} without revealing a reason`, async () => {
+      const calls = [];
+      const api = await makeApi({ checkout: fakeCheckout({ status }, calls) });
+      try {
+        const result = await request(api);
+        assert.equal(result.status, httpStatus);
+        assert.equal(result.body.status, "error");
+        assert.equal(typeof result.body.message, "string");
+        assert.doesNotMatch(JSON.stringify(result.body), /stripe|secret|price|user-123|internal error/i);
+        assert.equal(calls.length, 1);
+      } finally {
+        await api.close();
+      }
+    });
+  }
+
+  test("replays a recorded attempt even while checkout is switched off", async () => {
+    const calls = [];
+    const checkout = async (args) => {
+      calls.push(args);
+      return calls.length === 1
+        ? { status: "unavailable" }
+        : { status: "ready", isNew: false, attemptKey: NORMALIZED_KEY, orderReference: "ORD-123", checkoutUrl: "https://checkout.stripe.test/replay" };
+    };
+    const api = await makeApi({ checkout });
+    try {
+      const first = await request(api);
+      const replay = await request(api);
+      assert.equal(first.status, 503);
+      assert.equal(replay.status, 200);
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0].checkoutEnabled, false);
+      assert.equal(calls[1].checkoutEnabled, false);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test("refuses a signed-in session that has no usable buyer id", async () => {
+    const calls = [];
+    const api = await makeApi({
+      checkout: fakeCheckout({ status: "ready" }, calls),
+      session: { isAuthenticated: true },
+    });
+    try {
+      const result = await request(api);
+      assert.equal(result.status, 401);
+      assert.deepEqual(result.body, { status: "error", message: "Not authenticated" });
+      assert.equal(calls.length, 0);
+    } finally {
+      await api.close();
+    }
+  });
+});


### PR DESCRIPTION
## Rationale

The shop page will need one thing from the backend: "here is my cart, what do I pay?" This layer is the HTTP answer to that question, and it is deliberately the thinnest part of the stack — the endpoint validates the request, hands the work to the checkout flow, and maps the result onto a response. All the money reasoning lives below it.

The contract is written at the top of the file, because a reviewer (or a future frontend) needs it in one place: which requests are accepted, what each response means, and — importantly — what the endpoint refuses. The body must be exactly `{ items: [{ skuKey, quantity }] }`. Anything else (a buyer, a price, a total) is **rejected rather than ignored**: a silently ignored field is how a client ends up believing it decided the price.

Two boundaries come from the app rather than this file, and remain in force: the endpoint sits behind the signed-in session (identity) and behind the globally mounted trusted-origin gate (so a cookie-authenticated POST cannot be driven from another site), plus the API rate limiter.

## Observable Behavior

`POST /api/v1/shop/checkout-sessions`, for a signed-in buyer:

| Response | Meaning |
|---|---|
| `201 { attemptKey, orderReference, status: "ready", checkoutUrl }` | new attempt, link ready to pay |
| `200 { … status: "ready", checkoutUrl }` | the same attempt, asked again — same link |
| `200 { attemptKey, orderReference, status: "expired" \| "failed" }` | the attempt is over; no link, so a client stops asking |
| `202 { attemptKey, orderReference, status: "pending" }` | recorded, ask again shortly |
| `202 { … status: "reconciliation_required" }` | a human must check Stripe before anything else happens |
| `400` / `401` / `409` / `503` | unusable request · nobody signed in · same retry key with a different cart · checkout switched off, misconfigured, or unavailable |

The buyer comes only from the session, the retry key only from the `Idempotency-Key` header (UUIDv4), and checkout readiness is re-evaluated on every request, so a running process cannot be "already open" when the deployment says otherwise. No response ever contains a Stripe identifier, a price, or an internal field.

## Verification

- `node --test test/shop-checkout-contract.test.js` — 12 passed. Coverage: anonymous callers and sessions without a usable buyer id; missing or malformed retry keys; unknown body fields, missing cart, duplicate variant, and bad quantity; the buyer and seams handed to the flow (with the browser's claims ignored); every status → HTTP mapping including no link leaking for in-progress, terminal, or human-check states; and replay working while checkout is disabled.
- `npm test` — backend and frontend suites passed; production frontend build passed.

## Stack Context

- Position: 8 of 11
- Base PR: #166
- Depends on: #166
