### PR TITLE
refactor(shop): make the shop language plain

### DIFF
--- a/backend/checkoutReadiness.js
+++ b/backend/checkoutReadiness.js
@@ -1,3 +1,15 @@
+/*
+Purpose: The fail-closed answer to "may we sell anything at all?" It checks the Stripe
+         configuration, the infrastructure payments depend on, and the approvals the club must
+         give — and it never contacts Stripe to do it.
+
+Called by: the shop endpoint on every request, and the readiness probe at boot.
+
+Must not: guess. Anything missing, malformed, or unapproved leaves checkout switched off, and the
+          reasons it reports name what is missing without revealing its value.
+*/
+
+// Configuration the deployment must supply before any payment can be taken.
 const REQUIRED_CONFIGURATION = Object.freeze([
   "STRIPE_SECRET_KEY",
   "STRIPE_WEBHOOK_SECRET",
@@ -6,13 +18,17 @@ const REQUIRED_CONFIGURATION = Object.freeze([
   "STRIPE_CATALOG_VERSION",
 ]);
 
-const INFRASTRUCTURE_GATES = Object.freeze([
+// Switched on only when the environment can support payments we can trust.
+const REQUIRED_INFRASTRUCTURE_FLAGS = Object.freeze([
   "databaseTransactions",
   "sessionStore",
   "worker",
 ]);
 
-const POLICY_GATES = Object.freeze([
+// Sign-offs the club must give before selling. The named ones are self-explanatory; gateA and
+// gateB were never recorded anywhere, so they keep their placeholder names until somebody who
+// knows what they stand for renames them. Do not invent meanings for them.
+const REQUIRED_BUSINESS_APPROVALS = Object.freeze([
   "identity",
   "csrf",
   "tax",
@@ -33,7 +49,7 @@ function hasValue(value) {
   return text(value).length > 0;
 }
 
-function explicitlyTrue(value) {
+function isEnabledFlag(value) {
   return value === true || (typeof value === "string" && value.trim().toLowerCase() === "true");
 }
 
@@ -43,7 +59,7 @@ function readPaymentMethods(value) {
   return [];
 }
 
-function readPositiveTotal(value) {
+function readMinimumTotalMinor(value) {
   if (typeof value === "number") {
     return Number.isSafeInteger(value) && value > 0 ? value : null;
   }
@@ -98,10 +114,13 @@ function addReason(reasons, reason) {
   if (!reasons.includes(reason)) reasons.push(reason);
 }
 
-/**
- * @behavior Evaluate explicit checkout prerequisites without contacting Stripe.
- * @param input — configuration plus infrastructure and policy evidence gates
- * @returns a fail-closed capability state with redacted diagnostics
+/*
+ * Purpose:   Decide, without contacting Stripe, whether checkout may run at all — and say
+ *            exactly what is missing when it may not.
+ * @param     input — the deployment's configuration (env), its infrastructure flags, and the
+ *            club's approvals
+ * @returns   whether checkout is enabled, the mode it would run in, why it is disabled, and
+ *            diagnostics safe to show (keys and secrets are redacted)
  */
 export function evaluateCheckoutReadiness(input = {}) {
   const source = asRecord(input);
@@ -126,17 +145,17 @@ export function evaluateCheckoutReadiness(input = {}) {
     addReason(reasons, "card_only_required");
   }
   if (text(env.STRIPE_CURRENCY).toLowerCase() !== "usd") addReason(reasons, "usd_required");
-  if (readPositiveTotal(env.STRIPE_MINIMUM_TOTAL_MINOR) === null) {
+  if (readMinimumTotalMinor(env.STRIPE_MINIMUM_TOTAL_MINOR) === null) {
     addReason(reasons, "positive_total_required");
   }
 
-  if (!INFRASTRUCTURE_GATES.every((gate) => explicitlyTrue(infrastructure[gate]))) {
+  if (!REQUIRED_INFRASTRUCTURE_FLAGS.every((gate) => isEnabledFlag(infrastructure[gate]))) {
     addReason(reasons, "infrastructure_unhealthy");
   }
-  if (!POLICY_GATES.every((gate) => explicitlyTrue(policy[gate]))) {
+  if (!REQUIRED_BUSINESS_APPROVALS.every((gate) => isEnabledFlag(policy[gate]))) {
     addReason(reasons, "policy_unapproved");
   }
-  if (mode === "live" && !explicitlyTrue(policy.livePayments)) {
+  if (mode === "live" && !isEnabledFlag(policy.livePayments)) {
     addReason(reasons, "live_mode_disabled");
   }
 
@@ -149,13 +168,13 @@ export function evaluateCheckoutReadiness(input = {}) {
     catalogVersion: text(env.STRIPE_CATALOG_VERSION) || "[missing]",
     paymentMethods,
     currency: text(env.STRIPE_CURRENCY).toLowerCase() || "[missing]",
-    minimumTotalMinor: readPositiveTotal(env.STRIPE_MINIMUM_TOTAL_MINOR) ?? "[invalid]",
+    minimumTotalMinor: readMinimumTotalMinor(env.STRIPE_MINIMUM_TOTAL_MINOR) ?? "[invalid]",
   };
 
-  const available = reasons.length === 0;
+  // One name for one fact: checkout is enabled exactly when nothing is missing. The probe and the
+  // shop endpoint both read this field.
   return {
-    available,
-    checkoutEnabled: available,
+    checkoutEnabled: reasons.length === 0,
     mode,
     reasons,
     diagnostics,

--- a/backend/services/checkoutCoordinator.js
+++ b/backend/services/checkoutCoordinator.js
@@ -13,7 +13,7 @@ Must not: contact Stripe before the attempt is written down, trust a browser-sup
 import { randomUUID } from "node:crypto";
 
 import mongoose from "mongoose";
-import { normalizeCart, freezeQuote } from "../shop/domain.js";
+import { normalizeCart, snapshotQuote } from "../shop/domain.js";
 import { holdInventory } from "../shop/reservations.js";
 
 // Why: a buyer may take a while to finish paying, but an abandoned attempt must not hold stock
@@ -172,7 +172,7 @@ function variantAsStoredString(value) {
 }
 
 /*
-Purpose: Give the pricing step (freezeQuote) the handful of fields it reads, as plain data.
+Purpose: Give the pricing step (snapshotQuote) the handful of fields it reads, as plain data.
 Why: catalog rows arrive as Mongoose documents, whose fields are not plain properties. Spreading
      such a row yields an empty-looking one, which would make every purchase look unpriced.
 */
@@ -335,9 +335,9 @@ export async function createCheckout({
 
   let quote;
   try {
-    // freezeQuote turns the cart plus the catalog into the prices, quantities, and total the
+    // snapshotQuote turns the cart plus the catalog into the prices, quantities, and total the
     // buyer is agreeing to. Stored below, so a later price change cannot rewrite this order.
-    quote = freezeQuote({ cart, catalog: catalogRows.map(quoteCatalogRow), drop: activeSalesWindow, now: checkoutNow });
+    quote = snapshotQuote({ cart, catalog: catalogRows.map(quoteCatalogRow), drop: activeSalesWindow, now: checkoutNow });
   } catch {
     return unavailable();
   }

--- a/backend/shop/domain.js
+++ b/backend/shop/domain.js
@@ -1,7 +1,18 @@
-/**
- * Pure domain contracts, validations, quote calculations, and state reducers
- * for the IUGA Stripe merchandise store.
- */
+/*
+Purpose: The shop's rules with no database and no network: what a cart must look like, whether
+         a sale window is open, the prices the buyer is agreeing to, and how an order moves
+         through payment, fulfilment, refund, and dispute.
+
+Called by: checkoutCoordinator (cart rules and pricing); the payment and fulfilment work will
+           call the four apply* functions.
+
+Must not: read the database, call Stripe, or invent a price. Every function here is a pure
+          answer computed from what it is given.
+
+Words used here: a "drop" is one sales window, with its own dates and price list; a "variant"
+          (field name skuKey) is one buyable version of a product — the hoodie, purple, size M;
+          money is always whole cents ("minor units"), never dollars with decimals.
+*/
 
 function asRecord(value) {
   return value !== null && typeof value === "object" ? value : {};
@@ -25,10 +36,13 @@ function parseDate(value) {
 }
 
 /*
- * @behavior  Validates and normalizes cart items, sorting deterministically and rejecting duplicate SKUs.
- * @param     items — raw cart items array from client request
- * @returns   frozen array of normalized { skuKey, quantity } records
- * @exceptions throws on non-array, empty cart, duplicate SKUs, invalid SKU strings, or non-positive integer quantities
+ * Purpose:   Turn whatever the shop page sent into the one cart shape the rest of the shop
+ *            trusts — trimmed variants, whole positive quantities, no repeats — and sort it, so
+ *            the same cart always looks identical to the checkout flow.
+ * @param     items — the cart as the browser sent it
+ * @returns   a frozen, sorted list of { skuKey, quantity }
+ * @exceptions throws when the cart is empty, repeats a variant, or asks for zero, half, or a
+ *            nonsensical quantity
  */
 export function normalizeCart(items) {
   if (!Array.isArray(items) || items.length === 0) {
@@ -67,13 +81,14 @@ export function normalizeCart(items) {
 }
 
 /*
- * @behavior  Evaluates whether a drop is currently active within its UTC time boundaries.
- * @param     drop — shop drop record containing opensAt, closesAt, and isEnabled
- * @param     now — current timestamp to compare against
- * @returns   boolean indicating if drop is open for orders
- * @exceptions throws on malformed date fields
+ * Purpose:   Answer whether a sale window is open right now, so a closed or not-yet-started
+ *            window cannot sell anything.
+ * @param     drop — the sale-window row: its start, its end, and whether it is switched on
+ * @param     now — the moment to judge
+ * @returns   true only when the window is switched on and now falls inside its dates
+ * @exceptions throws when the window's dates are missing or malformed
  */
-export function isDropActive(drop, now = new Date()) {
+export function isSalesWindowOpen(drop, now = new Date()) {
   const record = asRecord(drop);
   if (record.isEnabled !== true) {
     return false;
@@ -87,16 +102,19 @@ export function isDropActive(drop, now = new Date()) {
 }
 
 /*
- * @behavior  Computes and freezes an immutable quote snapshot from normalized cart items and active catalog.
- * @param     cart — normalized cart items
- * @param     catalog — collection of active catalog entries for the drop
- * @param     drop — active shop drop
- * @param     now — reference timestamp for drop validity and quote timestamp
- * @returns   frozen quote snapshot with safe integer minor-unit totals
- * @exceptions throws if drop is inactive, SKU is not found, item is unavailable, or integer overflow occurs
+ * Purpose:   Work out what this cart costs and lock it in: which variant, at what unit price,
+ *            how many, and the total — the prices the buyer is agreeing to when they press Pay.
+ * @param     cart — the normalized cart
+ * @param     catalog — the price list rows for the open sale window
+ * @param     drop — the open sale window
+ * @param     now — the moment the prices are being locked at
+ * @returns   a frozen snapshot: the window, its price-list revision, the currency, the priced
+ *            items, and the total, all in whole cents
+ * @exceptions throws when the window is closed, a variant is missing or unavailable, a unit
+ *            price is not a positive whole number of cents, or a total would overflow
  */
-export function freezeQuote({ cart, catalog, drop, now = new Date() }) {
-  if (!isDropActive(drop, now)) {
+export function snapshotQuote({ cart, catalog, drop, now = new Date() }) {
+  if (!isSalesWindowOpen(drop, now)) {
     throw new Error("Cannot freeze quote for an inactive drop");
   }
 
@@ -112,6 +130,8 @@ export function freezeQuote({ cart, catalog, drop, now = new Date() }) {
   const dropRecord = asRecord(drop);
   const currency = typeof dropRecord.currency === "string" ? dropRecord.currency.toLowerCase() : "usd";
 
+  // Why: money is counted in whole cents. Dollars as decimals would quietly lose a cent per line
+  //      and the buyer would be charged a total that does not match the prices we displayed.
   let totalMinor = 0;
   const quotedItems = [];
 
@@ -162,13 +182,14 @@ export function freezeQuote({ cart, catalog, drop, now = new Date() }) {
 }
 
 /*
- * @behavior  Reduces payment state based on verified payment events, enforcing non-regressing paid status.
- * @param     order — existing order state
- * @param     event — incoming payment event
- * @returns   updated order state
- * @exceptions throws on attempts to regress a paid order back to pending
+ * Purpose:   Apply one verified payment event to an order. Payment is the one state we never
+ *            undo: an order that is paid stays paid, and a "back to pending" event is refused.
+ * @param     order — the order as it is now
+ * @param     event — the confirmed payment event (type, or status "paid")
+ * @returns   the order with paymentState "paid" and when it was paid
+ * @exceptions throws when an event tries to move a paid order back to pending
  */
-export function reducePayment(order, event = {}) {
+export function applyPaymentEvent(order, event = {}) {
   const current = asRecord(order);
   const currentPaymentState = current.paymentState || "pending";
 
@@ -192,6 +213,7 @@ export function reducePayment(order, event = {}) {
   return { ...current };
 }
 
+// Which fulfilment steps are legal for an order the buyer collects in person.
 const VALID_PICKUP_TRANSITIONS = Object.freeze({
   pending: ["preparing", "on_hold", "cancelled"],
   preparing: ["ready_for_pickup", "on_hold", "cancelled"],
@@ -201,6 +223,7 @@ const VALID_PICKUP_TRANSITIONS = Object.freeze({
   cancelled: [],
 });
 
+// Which fulfilment steps are legal for an order we post to the buyer.
 const VALID_SHIPPING_TRANSITIONS = Object.freeze({
   pending: ["preparing", "on_hold", "cancelled"],
   preparing: ["shipped", "on_hold", "cancelled"],
@@ -211,81 +234,86 @@ const VALID_SHIPPING_TRANSITIONS = Object.freeze({
 });
 
 /*
- * @behavior  Transitions fulfillment state for pickup or shipping orders while managing holds.
- * @param     order — existing order state
- * @param     action — fulfillment action command
- * @returns   updated order state
- * @exceptions throws on illegal state transitions
+ * Purpose:   Move an order one step through fulfilment — prepare it, mark it ready, hand it
+ *            over, post it, hold it, or cancel it — refusing steps that are not allowed from
+ *            where the order currently is.
+ * @param     order — the order as it is now
+ * @param     action — the step somebody is asking for, and why (for a hold)
+ * @returns   the order with its new fulfilment state, plus the hold and tracking details
+ * @exceptions throws on a step the order cannot take from its current state
  */
-export function reduceFulfillment(order, action = {}) {
+export function applyFulfillmentAction(order, action = {}) {
   const current = asRecord(order);
   const mode = current.fulfillmentMode || "pickup";
   const state = current.fulfillmentState || "pending";
   const transitions = mode === "shipping" ? VALID_SHIPPING_TRANSITIONS : VALID_PICKUP_TRANSITIONS;
 
-  let targetState = state;
+  let nextFulfillmentState = state;
   let holdReason = current.holdReason ?? null;
-  let previousState = current.previousFulfillmentState ?? state;
+  let stateBeforeHold = current.previousFulfillmentState ?? state;
 
   switch (action.action) {
     case "prepare":
-      targetState = "preparing";
+      nextFulfillmentState = "preparing";
       break;
     case "mark_ready":
-      targetState = "ready_for_pickup";
+      nextFulfillmentState = "ready_for_pickup";
       break;
     case "complete_pickup":
-      targetState = "picked_up";
+      nextFulfillmentState = "picked_up";
       break;
     case "ship":
-      targetState = "shipped";
+      nextFulfillmentState = "shipped";
       break;
     case "deliver":
-      targetState = "delivered";
+      nextFulfillmentState = "delivered";
       break;
     case "cancel":
-      targetState = "cancelled";
+      nextFulfillmentState = "cancelled";
       break;
     case "hold":
-      targetState = "on_hold";
-      previousState = state;
+      nextFulfillmentState = "on_hold";
+      stateBeforeHold = state;
       holdReason = action.reason || "unspecified";
       break;
     case "release_hold":
       if (state !== "on_hold") {
         throw new Error("Cannot release hold on an order not on hold");
       }
-      targetState = previousState || "pending";
+      nextFulfillmentState = stateBeforeHold || "pending";
       holdReason = null;
       break;
     default:
       throw new Error(`Unknown fulfillment action: ${action.action}`);
   }
 
-  if (targetState !== state) {
+  if (nextFulfillmentState !== state) {
     const allowed = transitions[state] || [];
-    if (!allowed.includes(targetState) && action.action !== "release_hold") {
-      throw new Error(`Illegal fulfillment transition from ${state} to ${targetState}`);
+    if (!allowed.includes(nextFulfillmentState) && action.action !== "release_hold") {
+      throw new Error(`Illegal fulfillment transition from ${state} to ${nextFulfillmentState}`);
     }
   }
 
   return {
     ...current,
-    fulfillmentState: targetState,
+    fulfillmentState: nextFulfillmentState,
     holdReason,
-    previousFulfillmentState: previousState,
+    previousFulfillmentState: stateBeforeHold,
     trackingNumber: action.trackingNumber || current.trackingNumber,
   };
 }
 
 /*
- * @behavior  Reduces refund state (reserve, settle, fail) within the collected payment budget.
- * @param     order — existing order state
- * @param     refundEvent — refund action and amount
- * @returns   updated order with updated refund totals and refundState
- * @exceptions throws if refund exceeds collected payment budget
+ * Purpose:   Track money going back to the buyer: reserve it, settle it, or drop a reservation —
+ *            never more than we actually collected.
+ * @param     order — the order as it is now, with its total in cents
+ * @param     refundEvent — reserve / settle / fail, and how many cents
+ * @returns   the order with updated refunded and pending-refund totals, and whether it is now
+ *            partly or fully refunded
+ * @exceptions throws when a refund would exceed what was collected, or the amount is not a
+ *            positive whole number of cents
  */
-export function reduceRefund(order, refundEvent = {}) {
+export function applyRefundEvent(order, refundEvent = {}) {
   const current = asRecord(order);
   const totalMinor = Number.isSafeInteger(current.totalMinor) ? current.totalMinor : 0;
   let refundedMinor = Number.isSafeInteger(current.refundedMinor) ? current.refundedMinor : 0;
@@ -341,13 +369,13 @@ export function reduceRefund(order, refundEvent = {}) {
 }
 
 /*
- * @behavior  Reduces dispute state from none to open, and open to won/lost/closed.
- * @param     order — existing order state
- * @param     disputeEvent — dispute event action and outcome
- * @returns   updated order with updated dispute record
- * @exceptions throws when resolving a dispute that is not open
+ * Purpose:   Record a card dispute on an order: when the buyer's bank opens one, and how it ends.
+ * @param     order — the order as it is now
+ * @param     disputeEvent — the bank's action ("open" or "resolve") and its outcome
+ * @returns   the order with its dispute state (none → open → won / lost / closed)
+ * @exceptions throws when resolving a dispute that was never opened, or on an unknown outcome
  */
-export function reduceDispute(order, disputeEvent = {}) {
+export function applyDisputeEvent(order, disputeEvent = {}) {
   const current = asRecord(order);
   const currentDispute = asRecord(current.dispute);
   const state = currentDispute.state || "none";

--- a/backend/shop/reservations.js
+++ b/backend/shop/reservations.js
@@ -1,7 +1,13 @@
-/**
- * Inventory reservation and fencing repository for the IUGA Stripe merchandise store.
- * Manages atomic holds, consumptions, and verified non-payable releases against InventoryCounter.
- */
+/*
+Purpose: How much stock is held, sold, and put back for each physical pile we count. Without
+         this, two students could buy the last hoodie in the same moment and both be charged.
+
+Called by: checkoutCoordinator (takes stock for a new checkout attempt); the payment and expiry
+           work will call the other two.
+
+Must not: move a stock counter without a matching reservation record, put stock back for an
+          order that could still be paid, or let a counter go negative.
+*/
 
 export class InsufficientInventoryError extends Error {
   constructor({ skuKey, fulfillmentSku, requestedQuantity, availableQuantity }) {
@@ -15,16 +21,39 @@ export class InsufficientInventoryError extends Error {
 }
 
 /*
- * @behavior  Holds inventory for finite catalog items in a cart, rolling back on failure.
- * @param     models — Mongoose model registry or injected mock models
- * @param     orderId — internal order identifier
- * @param     items — normalized cart items [{ skuKey, quantity }]
- * @param     catalog — list of catalog entries
- * @param     now — current timestamp for reservation
- * @param     ttlMs — reservation lifetime in milliseconds
- * @param     session — optional Mongoose client session for multi-document transaction
- * @returns   array of created InventoryReservation records
- * @exceptions throws InsufficientInventoryError if any item lacks available stock
+Purpose: Put stock back after an attempt fails halfway through a multi-item order.
+Why: without this, every pile we already took stock from stays taken, and the shop quietly sells
+     less than it owns.
+*/
+async function restoreStockCounters({ models, takenCounters, session }) {
+  for (const taken of takenCounters) {
+    await models.InventoryCounter.findOneAndUpdate(
+      { fulfillmentSku: taken.fulfillmentSku },
+      {
+        $inc: {
+          available: taken.quantity,
+          reserved: -taken.quantity,
+          version: 1,
+        },
+      },
+      { session },
+    );
+  }
+}
+
+/*
+ * Purpose:   Take the ordered quantity off the shelf for each variant in a cart and write a
+ *            time-limited reservation for it, so the order can be paid without overselling.
+ * @param     models — the database models, or fakes in tests
+ * @param     orderId — the order these holds belong to
+ * @param     items — the normalized cart: [{ skuKey, quantity }]
+ * @param     catalog — the price-list rows, which say which pile each variant comes from
+ * @param     now — when the holds start
+ * @param     ttlMs — how long a hold is meant to last before it is released
+ * @param     session — the database transaction the caller is already inside, if any
+ * @returns   the reservation records that were written
+ * @exceptions throws InsufficientInventoryError when a variant does not have enough stock; any
+ *            stock already taken in this attempt is put back first
  */
 export async function holdInventory({
   models,
@@ -43,7 +72,7 @@ export async function holdInventory({
   }
 
   const catalogMap = new Map((catalog || []).map((entry) => [entry.skuKey, entry]));
-  const successfulHolds = [];
+  const countersAlreadyDecremented = [];
   const reservationsToCreate = [];
 
   const expiresAt = new Date(now.getTime() + ttlMs);
@@ -54,7 +83,7 @@ export async function holdInventory({
       throw new Error(`Catalog entry not found for SKU ${item.skuKey}`);
     }
 
-    // Preorder items do not reserve finite inventory
+    // Why: a preorder is sold before we own it, so there is no pile to take stock from.
     if (entry.inventoryPolicy === "preorder") {
       continue;
     }
@@ -62,7 +91,8 @@ export async function holdInventory({
     const fulfillmentSku = entry.fulfillmentSku || item.skuKey;
     const quantity = item.quantity;
 
-    // Atomically decrement available stock and increment reserved stock
+    // The fence: only take stock while the pile still holds this much, so two buyers can never
+    // take the same last hoodie, and the counter can never go negative.
     const updatedCounter = await models.InventoryCounter.findOneAndUpdate(
       {
         fulfillmentSku,
@@ -79,20 +109,8 @@ export async function holdInventory({
     );
 
     if (!updatedCounter) {
-      // Roll back previously successful holds in this batch
-      for (const hold of successfulHolds) {
-        await models.InventoryCounter.findOneAndUpdate(
-          { fulfillmentSku: hold.fulfillmentSku },
-          {
-            $inc: {
-              available: hold.quantity,
-              reserved: -hold.quantity,
-              version: 1,
-            },
-          },
-          { session },
-        );
-      }
+      // Why: this order failed halfway, so every pile we already took stock from is given back.
+      await restoreStockCounters({ models, takenCounters: countersAlreadyDecremented, session });
 
       throw new InsufficientInventoryError({
         skuKey: item.skuKey,
@@ -102,7 +120,7 @@ export async function holdInventory({
       });
     }
 
-    successfulHolds.push({ fulfillmentSku, quantity });
+    countersAlreadyDecremented.push({ fulfillmentSku, quantity });
     reservationsToCreate.push({
       orderId,
       skuKey: item.skuKey,
@@ -119,20 +137,9 @@ export async function holdInventory({
     try {
       await models.InventoryReservation.create(reservationsToCreate, { session });
     } catch (err) {
-      // Compensate all previously held counters if reservation document persistence fails
-      for (const hold of successfulHolds) {
-        await models.InventoryCounter.findOneAndUpdate(
-          { fulfillmentSku: hold.fulfillmentSku },
-          {
-            $inc: {
-              available: hold.quantity,
-              reserved: -hold.quantity,
-              version: 1,
-            },
-          },
-          { session },
-        );
-      }
+      // Why: the holds succeeded but the reservation records did not, so the piles go back to
+      //      exactly how they were before this attempt.
+      await restoreStockCounters({ models, takenCounters: countersAlreadyDecremented, session });
       throw err;
     }
   }
@@ -141,13 +148,15 @@ export async function holdInventory({
 }
 
 /*
- * @behavior  Consumes reserved inventory upon verified payment confirmation.
- * @param     models — Mongoose model registry or injected mock models
- * @param     orderId — internal order identifier
- * @param     session — optional Mongoose client session
- * @param     now — current timestamp
- * @returns   object with consumedCount
- * @exceptions throws on database error or if counter fence is lost
+ * Purpose:   Make a paid order's holds permanent: the stock it reserved is now sold rather than
+ *            held. Runs only after payment is confirmed.
+ * @param     models — the database models, or fakes in tests
+ * @param     orderId — the order whose holds become sales
+ * @param     session — the database transaction the caller is already inside, if any
+ * @param     now — when the change happened
+ * @returns   how many reservations were marked consumed
+ * @exceptions throws when a pile no longer holds what we reserved — that means two workers
+ *            disagreed, so a human must look rather than us guessing
  */
 export async function consumeInventory({
   models,
@@ -203,26 +212,28 @@ export async function consumeInventory({
 }
 
 /*
- * @behavior  Releases reserved inventory back to available stock only when proof of non-payable session is verified.
- * @param     models — Mongoose model registry or injected mock models
- * @param     orderId — internal order identifier
- * @param     proofOfNonPayable — boolean indicating verified non-payable status (expired/canceled)
- * @param     reason — reason for releasing hold
- * @param     session — optional Mongoose client session
- * @param     now — current timestamp
- * @returns   object with releasedCount
- * @exceptions throws if proofOfNonPayable is not explicitly true or if counter fence is lost
+ * Purpose:   Put held stock back on the shelf when — and only when — the payment link can no
+ *            longer be paid: expired, cancelled, or otherwise dead.
+ * @param     models — the database models, or fakes in tests
+ * @param     orderId — the order giving its holds back
+ * @param     sessionCannotBePaidVerified — proof from Stripe, or from our own expiry, that this
+ *            attempt can no longer be paid. Stock must not go back without it: a buyer who pays
+ *            after we released their hold would be charged for a hoodie we already gave away.
+ * @param     session — the database transaction the caller is already inside, if any
+ * @param     now — when the release happened
+ * @returns   how many reservations were released
+ * @exceptions throws when that proof is not explicitly true, or when a pile no longer holds what
+ *            we reserved
  */
 export async function releaseInventory({
   models,
   orderId,
-  proofOfNonPayable,
-  reason = "unspecified",
+  sessionCannotBePaidVerified,
   session = null,
   now = new Date(),
 }) {
-  if (proofOfNonPayable !== true) {
-    throw new Error("Cannot release inventory without verified proof of non-payable session");
+  if (sessionCannotBePaidVerified !== true) {
+    throw new Error("Cannot release inventory until we can verify the payment link can no longer be paid");
   }
 
   const reservations = await models.InventoryReservation.find(

--- a/backend/test/checkout-readiness.test.js
+++ b/backend/test/checkout-readiness.test.js
@@ -1,3 +1,9 @@
+/*
+Purpose: Pin the fail-closed rule: checkout is switched on only when the configuration, the
+         infrastructure, and the club's approvals are all present, and every missing piece is
+         named in the answer.
+*/
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
@@ -40,7 +46,6 @@ function evaluate(overrides = {}) {
 }
 
 function assertUnavailable(result, reason) {
-  assert.equal(result.available, false);
   assert.equal(result.checkoutEnabled, false);
   assert.ok(result.reasons.includes(reason), `expected reason ${reason}`);
 }
@@ -63,7 +68,6 @@ describe("checkout configuration and readiness", () => {
   it("accepts a complete test-mode configuration when every gate is explicitly healthy", () => {
     const result = evaluate();
 
-    assert.equal(result.available, true);
     assert.equal(result.checkoutEnabled, true);
     assert.equal(result.mode, "test");
     assert.deepEqual(result.reasons, []);

--- a/backend/test/shop-domain.test.js
+++ b/backend/test/shop-domain.test.js
@@ -1,14 +1,20 @@
+/*
+Purpose: Pin the shop's rules: what a cart may contain, when a sale window is open, how prices
+         are locked in, and how an order may move through payment, fulfilment, refund, and
+         dispute. These run without a database, because these rules do not need one.
+*/
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
   normalizeCart,
-  isDropActive,
-  freezeQuote,
-  reducePayment,
-  reduceFulfillment,
-  reduceRefund,
-  reduceDispute,
+  isSalesWindowOpen,
+  snapshotQuote,
+  applyPaymentEvent,
+  applyFulfillmentAction,
+  applyRefundEvent,
+  applyDisputeEvent,
 } from "../shop/domain.js";
 
 describe("Shop Domain - Pure Contracts and Reducers", () => {
@@ -77,7 +83,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
     });
   });
 
-  describe("isDropActive", () => {
+  describe("isSalesWindowOpen", () => {
     const drop = Object.freeze({
       dropKey: "drop-fall-2026",
       opensAt: new Date("2026-10-01T00:00:00.000Z"),
@@ -87,22 +93,22 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
 
     it("returns true when current time is strictly within window and drop is enabled", () => {
       const within = new Date("2026-10-05T12:00:00.000Z");
-      assert.equal(isDropActive(drop, within), true);
+      assert.equal(isSalesWindowOpen(drop, within), true);
     });
 
     it("returns true at exact opensAt boundary, false at exact closesAt boundary", () => {
-      assert.equal(isDropActive(drop, drop.opensAt), true);
-      assert.equal(isDropActive(drop, drop.closesAt), false);
+      assert.equal(isSalesWindowOpen(drop, drop.opensAt), true);
+      assert.equal(isSalesWindowOpen(drop, drop.closesAt), false);
     });
 
     it("returns false before opensAt or after closesAt", () => {
-      assert.equal(isDropActive(drop, new Date("2026-09-30T23:59:59.999Z")), false);
-      assert.equal(isDropActive(drop, new Date("2026-10-15T00:00:00.001Z")), false);
+      assert.equal(isSalesWindowOpen(drop, new Date("2026-09-30T23:59:59.999Z")), false);
+      assert.equal(isSalesWindowOpen(drop, new Date("2026-10-15T00:00:00.001Z")), false);
     });
 
     it("returns false when drop is disabled regardless of dates", () => {
       const disabledDrop = { ...drop, isEnabled: false };
-      assert.equal(isDropActive(disabledDrop, new Date("2026-10-05T12:00:00.000Z")), false);
+      assert.equal(isSalesWindowOpen(disabledDrop, new Date("2026-10-05T12:00:00.000Z")), false);
     });
 
     it("parses ISO strings correctly into UTC timestamps", () => {
@@ -112,11 +118,11 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
         closesAt: "2026-10-15T00:00:00.000Z",
         isEnabled: true,
       };
-      assert.equal(isDropActive(stringDrop, new Date("2026-10-05T12:00:00.000Z")), true);
+      assert.equal(isSalesWindowOpen(stringDrop, new Date("2026-10-05T12:00:00.000Z")), true);
     });
   });
 
-  describe("freezeQuote", () => {
+  describe("snapshotQuote", () => {
     const activeDrop = Object.freeze({
       dropKey: "drop-fall-2026",
       catalogVersion: "v1-2026-10",
@@ -153,7 +159,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       ];
       const now = new Date("2026-10-02T10:00:00.000Z");
 
-      const quote = freezeQuote({ cart, catalog, drop: activeDrop, now });
+      const quote = snapshotQuote({ cart, catalog, drop: activeDrop, now });
 
       assert.equal(quote.dropKey, "drop-fall-2026");
       assert.equal(quote.catalogVersion, "v1-2026-10");
@@ -178,7 +184,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       const closedTime = new Date("2026-11-01T00:00:00.000Z");
 
       assert.throws(
-        () => freezeQuote({ cart, catalog, drop: activeDrop, now: closedTime }),
+        () => snapshotQuote({ cart, catalog, drop: activeDrop, now: closedTime }),
         /inactive drop/i,
       );
     });
@@ -188,7 +194,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       const now = new Date("2026-10-02T10:00:00.000Z");
 
       assert.throws(
-        () => freezeQuote({ cart, catalog, drop: activeDrop, now }),
+        () => snapshotQuote({ cart, catalog, drop: activeDrop, now }),
         /catalog/i,
       );
     });
@@ -204,13 +210,13 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       const now = new Date("2026-10-02T10:00:00.000Z");
 
       assert.throws(
-        () => freezeQuote({ cart, catalog: unavailableCatalog, drop: activeDrop, now }),
+        () => snapshotQuote({ cart, catalog: unavailableCatalog, drop: activeDrop, now }),
         /unavailable/i,
       );
     });
   });
 
-  describe("reducePayment", () => {
+  describe("applyPaymentEvent", () => {
     it("transitions pending to paid upon verified provider payment event", () => {
       const order = {
         orderId: "ord_101",
@@ -220,7 +226,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       };
 
       const paidAt = new Date("2026-10-02T12:00:00.000Z");
-      const updated = reducePayment(order, {
+      const updated = applyPaymentEvent(order, {
         type: "payment_confirmed",
         paidAt,
         providerPaymentId: "pi_12345",
@@ -239,7 +245,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
         paidAt,
       };
 
-      const updated = reducePayment(paidOrder, {
+      const updated = applyPaymentEvent(paidOrder, {
         type: "payment_confirmed",
         paidAt: new Date("2026-10-02T12:05:00.000Z"),
       });
@@ -257,13 +263,13 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       };
 
       assert.throws(
-        () => reducePayment(paidOrder, { type: "reset_to_pending" }),
+        () => applyPaymentEvent(paidOrder, { type: "reset_to_pending" }),
         /cannot regress paid state/i,
       );
     });
   });
 
-  describe("reduceFulfillment", () => {
+  describe("applyFulfillmentAction", () => {
     it("handles pickup fulfillment lifecycle from pending to picked_up", () => {
       let order = {
         orderId: "ord_101",
@@ -271,13 +277,13 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
         fulfillmentState: "pending",
       };
 
-      order = reduceFulfillment(order, { action: "prepare" });
+      order = applyFulfillmentAction(order, { action: "prepare" });
       assert.equal(order.fulfillmentState, "preparing");
 
-      order = reduceFulfillment(order, { action: "mark_ready" });
+      order = applyFulfillmentAction(order, { action: "mark_ready" });
       assert.equal(order.fulfillmentState, "ready_for_pickup");
 
-      order = reduceFulfillment(order, { action: "complete_pickup" });
+      order = applyFulfillmentAction(order, { action: "complete_pickup" });
       assert.equal(order.fulfillmentState, "picked_up");
     });
 
@@ -288,16 +294,16 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
         fulfillmentState: "pending",
       };
 
-      order = reduceFulfillment(order, { action: "prepare" });
+      order = applyFulfillmentAction(order, { action: "prepare" });
       assert.equal(order.fulfillmentState, "preparing");
 
-      order = reduceFulfillment(order, {
+      order = applyFulfillmentAction(order, {
         action: "ship",
         trackingNumber: "1Z999",
       });
       assert.equal(order.fulfillmentState, "shipped");
 
-      order = reduceFulfillment(order, { action: "deliver" });
+      order = applyFulfillmentAction(order, { action: "deliver" });
       assert.equal(order.fulfillmentState, "delivered");
     });
 
@@ -309,14 +315,14 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
         holdReason: null,
       };
 
-      order = reduceFulfillment(order, {
+      order = applyFulfillmentAction(order, {
         action: "hold",
         reason: "address_verification_needed",
       });
       assert.equal(order.fulfillmentState, "on_hold");
       assert.equal(order.holdReason, "address_verification_needed");
 
-      order = reduceFulfillment(order, { action: "release_hold" });
+      order = applyFulfillmentAction(order, { action: "release_hold" });
       assert.equal(order.fulfillmentState, "preparing");
       assert.equal(order.holdReason, null);
     });
@@ -329,13 +335,13 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       };
 
       assert.throws(
-        () => reduceFulfillment(order, { action: "prepare" }),
+        () => applyFulfillmentAction(order, { action: "prepare" }),
         /illegal fulfillment transition/i,
       );
     });
   });
 
-  describe("reduceRefund", () => {
+  describe("applyRefundEvent", () => {
     it("reserves and settles refunds within the collected payment budget", () => {
       let order = {
         orderId: "ord_201",
@@ -347,7 +353,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       };
 
       // 1. Reserve partial refund of 3000 cents
-      order = reduceRefund(order, {
+      order = applyRefundEvent(order, {
         action: "reserve",
         amountMinor: 3000,
       });
@@ -357,7 +363,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       assert.equal(order.paymentState, "paid"); // Preserves payment truth
 
       // 2. Settle the 3000 cents refund
-      order = reduceRefund(order, {
+      order = applyRefundEvent(order, {
         action: "settle",
         amountMinor: 3000,
       });
@@ -367,11 +373,11 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       assert.equal(order.paymentState, "paid");
 
       // 3. Reserve and settle remaining 7000 cents
-      order = reduceRefund(order, {
+      order = applyRefundEvent(order, {
         action: "reserve",
         amountMinor: 7000,
       });
-      order = reduceRefund(order, {
+      order = applyRefundEvent(order, {
         action: "settle",
         amountMinor: 7000,
       });
@@ -391,13 +397,13 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
         paymentState: "paid",
       };
 
-      order = reduceRefund(order, {
+      order = applyRefundEvent(order, {
         action: "reserve",
         amountMinor: 2000,
       });
       assert.equal(order.pendingRefundMinor, 2000);
 
-      order = reduceRefund(order, {
+      order = applyRefundEvent(order, {
         action: "fail",
         amountMinor: 2000,
       });
@@ -418,13 +424,13 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
 
       // Only 500 cents remaining available, requesting 1000 must throw
       assert.throws(
-        () => reduceRefund(order, { action: "reserve", amountMinor: 1000 }),
+        () => applyRefundEvent(order, { action: "reserve", amountMinor: 1000 }),
         /refund budget exceeded/i,
       );
     });
   });
 
-  describe("reduceDispute", () => {
+  describe("applyDisputeEvent", () => {
     it("tracks dispute lifecycle from none to open to won or lost", () => {
       let order = {
         orderId: "ord_301",
@@ -439,7 +445,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
 
       // Open dispute
       const dueBy = new Date("2026-11-01T00:00:00.000Z");
-      order = reduceDispute(order, {
+      order = applyDisputeEvent(order, {
         action: "open",
         reason: "fraudulent",
         evidenceDueBy: dueBy,
@@ -450,7 +456,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       assert.equal(order.paymentState, "paid"); // Does not rewrite paymentState
 
       // Resolve dispute
-      order = reduceDispute(order, { action: "resolve", outcome: "won" });
+      order = applyDisputeEvent(order, { action: "resolve", outcome: "won" });
       assert.equal(order.dispute.state, "won");
     });
 
@@ -461,7 +467,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       };
 
       assert.throws(
-        () => reduceDispute(order, { action: "resolve", outcome: "won" }),
+        () => applyDisputeEvent(order, { action: "resolve", outcome: "won" }),
         /dispute not open/i,
       );
     });

--- a/backend/test/shop-reservations.test.js
+++ b/backend/test/shop-reservations.test.js
@@ -1,3 +1,9 @@
+/*
+Purpose: Pin the stock promises: the last hoodie cannot be sold twice, a half-finished order
+         gives its stock back, and stock only returns to the shelf once the payment link can no
+         longer be paid.
+*/
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
@@ -272,7 +278,7 @@ describe("Shop Inventory Reservations and Fencing", () => {
   });
 
   describe("releaseInventory", () => {
-    it("refuses to release stock without verified proof of non-payable session", async () => {
+    it("keeps stock held until we can verify the payment link is dead", async () => {
       const models = makeFakeModels(
         [{ fulfillmentSku: "HOODIE-PURPLE-M", available: 8, reserved: 2, consumed: 0, version: 2 }],
         [{ orderId: "ord_open", skuKey: "info-hoodie-purple-m", fulfillmentSku: "HOODIE-PURPLE-M", quantity: 2, state: "reserved" }],
@@ -283,17 +289,17 @@ describe("Shop Inventory Reservations and Fencing", () => {
           await releaseInventory({
             models,
             orderId: "ord_open",
-            proofOfNonPayable: false, // Session might still be payable!
+            sessionCannotBePaidVerified: false, // Session might still be payable!
           });
         },
-        /proof of non-payable/i,
+        /can no longer be paid/i,
       );
 
       const counter = models.InventoryCounter._getCounters()[0];
       assert.equal(counter.reserved, 2); // Held safely
     });
 
-    it("releases reserved stock back to available when proof of non-payable is provided", async () => {
+    it("puts stock back on the shelf once the payment link is verified dead", async () => {
       const models = makeFakeModels(
         [{ fulfillmentSku: "HOODIE-PURPLE-M", available: 8, reserved: 2, consumed: 0, version: 2 }],
         [{ orderId: "ord_expired", skuKey: "info-hoodie-purple-m", fulfillmentSku: "HOODIE-PURPLE-M", quantity: 2, state: "reserved" }],
@@ -302,8 +308,7 @@ describe("Shop Inventory Reservations and Fencing", () => {
       const result = await releaseInventory({
         models,
         orderId: "ord_expired",
-        proofOfNonPayable: true,
-        reason: "checkout_session_expired",
+        sessionCannotBePaidVerified: true,
       });
 
       assert.equal(result.releasedCount, 1);
@@ -327,7 +332,7 @@ describe("Shop Inventory Reservations and Fencing", () => {
           await releaseInventory({
             models,
             orderId: "ord_lost_fence_rel",
-            proofOfNonPayable: true,
+            sessionCannotBePaidVerified: true,
           });
         },
         /counter fence lost/i,


### PR DESCRIPTION
## Rationale

The shop code works, but it was written for the people who wrote it. Three specific problems made it hard for anyone else — including the person who owns the product — to follow:

1. **One idea, four words.** Availability appears as `isEnabled` (database), `isAvailable` (domain contract), `available` (stock counter), and `available` (readiness result). Nothing said they were related.
2. **Jargon with no key.** `freezeQuote`, `reduceFulfillment`, `proofOfNonPayable`, `targetState`, "drop" — words that require having been in the room, in a repository whose own `docs/COMMENTING.md` bans exactly that.
3. **Reasons missing.** The code said *what* it did and never *why*: why stock and order are written before Stripe, why totals are counted in cents, why a rejected response body is never read, why 23 hours and not 24.

This layer changes no behavior at all — names, comments, and two provable deduplications. It is deliberately its own PR so the rename diff never hides a logic change, and the existing tests are the proof: every assertion still passes, unchanged, except where a name itself was the thing being asserted.

## Observable Behavior

None. Behavior is identical; the reviewable outcome is the code itself:

- `reducePayment` / `reduceFulfillment` / `reduceRefund` / `reduceDispute` → `applyPaymentEvent` / `applyFulfillmentAction` / `applyRefundEvent` / `applyDisputeEvent` (they apply one event and return the next order).
- `freezeQuote` → `snapshotQuote` (it locks in the prices the buyer agreed to; the stored field was already `quoteSnapshot`).
- `isDropActive` → `isSalesWindowOpen`; "drop" survives only as the database row's name, defined in the module header.
- `proofOfNonPayable` → `sessionCannotBePaidVerified`; the guard now reads as the fact that must be verified.
- `successfulHolds` → `countersAlreadyDecremented` (the array holds stock counters, not reservations — as written, the rollback loop looked like it deleted reservation records).
- Every module opens with `Purpose:` · `Called by:` · `Must not:`, every exported function states its purpose in plain words, and `Why:` lines appear only where the reason is invisible in code.
- Two deduplications: the identical 20-line stock-rollback loop in `holdInventory` becomes one `restoreStockCounters(...)` (the riskiest code in the shop no longer has to be reviewed by diffing two copies), and `evaluateCheckoutReadiness` stops returning two names for one fact.

**Deliberately not done:** merging `consumeInventory` and `releaseInventory` (the merge would need a conditional-options flag to tell them apart — the wrong abstraction), and renaming the fulfilment `mode` local (that name sits on a real bug, fixed in the next PR so this one stays behavior-free).

## Verification

- `npm test` — 177 tests passed across backend and frontend, with no assertion changed except the readiness field rename and the removed duplicate.
- Runtime check: `evaluateCheckoutReadiness({ env: {} })` still answers `checkoutEnabled: false` and names all ten missing prerequisites.
- No stale references to any renamed symbol remain anywhere in `backend/` or `docs/`.

## Stack Context

- Position: 9 of 11
- Base PR: #167
- Depends on: #167
