### PR TITLE
docs(shop): explain the shop vocabulary and checkout flow

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,7 +102,11 @@ Internal **architecture plans and agent documentation** live in a private organi
 ```
 
 **SPA routes** (handled by Express sending the same `index.html`):
-`/`, `/events`, `/resources`, `/get-involved`, `/electionfaq`, `/contact`
+`/`, `/events`, `/resources`, `/student-voice`, `/shop`, `/elections`, `/electionfaq`, `/about`,
+`/get-involved`, `/contact`
+
+The list lives in `backend/spaRoutes.js`. `/contact` is served by Express but has no React route
+registered in `frontend/src/App.jsx` yet, so it renders the shell without content.
 
 **API routes** (JSON responses):
 All mounted under `/api/v1` — see [BACKEND.md](./BACKEND.md).

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -84,6 +84,16 @@ Express also serves:
 | `DELETE` | `/withdraw/:eId/:pId` | Yes | Withdraw only the caller's participant from the matching event. Admins may withdraw any participant. |
 | `GET` | `/:pId` | Yes | Return protected participant details only to the participant owner or an admin. |
 
+### Shop (`/api/v1/shop`)
+
+Selling relies on the shop vocabulary and flow described in [SHOP.md](./SHOP.md). Checkout is
+**fail-closed**: until a deployment passes every readiness check, this endpoint answers `503` and
+`GET /readyz` reports `checkoutEnabled: false`.
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `POST` | `/checkout-sessions` | Yes | Price the buyer's cart from the catalog and return a Stripe payment link for it. Requires a UUIDv4 `Idempotency-Key` header and a body of exactly `{ items: [{ skuKey, quantity }] }`; the buyer, prices, and totals come from the server. Returns `201` (new attempt, link), `200` (same attempt again, or a finished attempt with no link), `202` (still in progress, or a human must check Stripe), `400`, `401`, `409` (same retry key, different cart), `503`. |
+
 ### User (`/api/v1/user`)
 
 | Method | Path | Auth | Description |
@@ -250,6 +260,16 @@ Mongoose models are registered at startup:
 | `RoleAssignments` | `roleAssignmentsSchema` | `roleassignments` |
 | `EventRequests` | `eventRequestsSchema` | `eventrequests` |
 | `EventReviews` | `eventReviewsSchema` | `eventreviews` |
+| `CatalogEntry` | `catalogEntrySchema` | `catalogentries` |
+| `ShopDrop` | `shopDropSchema` | `shopdrops` |
+| `InventoryCounter` | `inventoryCounterSchema` | `inventorycounters` |
+| `InventoryReservation` | `inventoryReservationSchema` | `inventoryreservations` |
+| `CheckoutAttempt` | `checkoutAttemptSchema` | `checkoutattempts` |
+| `Order` | `orderSchema` | `orders` |
+| `RefundOperation` | `refundOperationSchema` | `refundoperations` |
+| `Dispute` | `disputeSchema` | `disputes` |
+| `StripeInboxEvent` | `stripeInboxEventSchema` | `stripeinboxevents` |
+| `OrderActivity` | `orderActivitySchema` | `orderactivities` |
 
 The schemas live in a **separate GitHub repository** (`UW-IUGA/iuga-web-schemas`) mounted as a submodule at `backend/schemas/`. If the submodule is not initialized, the backend will fail to start.
 
@@ -314,6 +334,7 @@ ETags are disabled with `app.disable('etag')`, so responses do not use condition
 - [Commenting Guide](COMMENTING.md) — House style for code comments
 - [Development Guide](DEVELOPMENT.md) — Setup, scripts, code conventions
 - [Frontend Documentation](FRONTEND.md) — React app structure, routing, auth flow
+- [Shop and Checkout](SHOP.md) — Shop vocabulary, the checkout flow, and its rules
 - [Deployment Guide](DEPLOYMENT.md) — Environments, CI/CD, Docker
 - [Maintainers Guide](MAINTAINERS.md) — Monitoring and maintenance
 - [Troubleshooting Guide](TROUBLESHOOTING.md) — Common failures and diagnosis

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -89,6 +89,7 @@ Defined in `src/App.jsx`:
 | `/events` | `EventsPage` | Mock data or `GET /api/v1/events` |
 | `/resources` | `ResourcesPage` | Static data from `assets/data/ResourcesData.js` |
 | `/elections` | `ElectionPage` | Static data from `assets/data/CandidateData.js` |
+| `/shop` | `ShopPage` | Static data from `assets/data/ShopData.js` (no prices or cart yet — see [SHOP.md](./SHOP.md)) |
 | `/electionfaq` | `ElectionsFAQPage` | Static data from `assets/data/ElectionFAQData.js` |
 | `/get-involved` | `GetInvolvedPage` | Static data from `frontend/src/assets/data/teams/2026.js` (2026 roster, no API) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory contains the full documentation set for the **Informatics Undergr
 | [Development](DEVELOPMENT.md) | Developers | Setup, scripts, environment configuration, code conventions, common tasks, testing |
 | [Frontend](FRONTEND.md) | Frontend devs | Tech stack, directory layout, routing, data flow, authentication, styling, dependencies |
 | [Backend](BACKEND.md) | Backend devs | Entry points, directory layout, SPA routes, API routes, authentication, database, middleware stack, dependencies |
+| [Shop](SHOP.md) | Backend devs, maintainers | Shop vocabulary, the checkout flow step by step, the rules it enforces, where the code lives, known gaps |
 | [Deployment](DEPLOYMENT.md) | Maintainers | Pipeline overview, Jenkinsfile comparison, credentials, Docker build, runtime architecture, verification, rollback |
 | [Maintainers](MAINTAINERS.md) | Maintainers | Monitoring checks, maintenance procedures, observation points, credential rotation |
 | [Troubleshooting](TROUBLESHOOTING.md) | Developers & maintainers | Pipeline failures, runtime failures, 502 Bad Gateway, stale content, diagnosis sequences |

--- a/docs/SHOP.md
+++ b/docs/SHOP.md
@@ -1,0 +1,110 @@
+# IUGA Website — Shop and Checkout
+
+The shop sells IUGA merchandise online. This document explains the words the code uses, what one
+checkout does from start to finish, and which file owns each step. Read it before changing
+anything under `backend/shop/`, `backend/services/checkout-*`, or the shop routes.
+
+## What exists today
+
+| Piece | State |
+|---|---|
+| Shop page (`/shop`) | Live, advertising only — a name, a photo, and a description per product. No prices, sizes, cart, or buy buttons yet. |
+| Checkout endpoint | Built and tested, but **switched off**. Until a deployment passes every readiness check, it answers `503` and nothing can be bought. |
+| Catalog (prices, sizes, stock) | Not loaded yet. A sale window with real variants, prices, and stock has to exist before a real purchase can happen. |
+| Payment confirmation | Not built. Until the Stripe webhook exists, an order stays `pending` even after the buyer pays. |
+
+## One checkout, step by step
+
+1. **The shop page asks for a payment link.** `POST /api/v1/shop/checkout-sessions`, with the
+   buyer's cart in the body and a retry key in the `Idempotency-Key` header.
+2. **The endpoint decides whether it may sell at all.** `backend/checkoutReadiness.js` answers from
+   configuration, infrastructure flags, and the club's approvals. Off, or misconfigured → `503`.
+3. **The buyer's request is read, or refused.** Only the cart and the retry key are accepted;
+   anything else (a buyer, a price, a total) is rejected outright
+   (`routes/api/v1/controllers/shop.js`).
+4. **An earlier attempt under the same retry key is looked up.** A retry, a refresh, or a double
+   press must find its own attempt — even if checkout has since been switched off
+   (`services/checkoutCoordinator.js`).
+5. **For a new attempt: the sale window is found, the cart is priced, and stock is taken.**
+   Prices come from the catalog, never from the browser (`shop/domain.js`, `shop/reservations.js`).
+6. **The attempt is written down before Stripe is contacted**: the pending order, the stock holds,
+   the agreed prices, and the exact Stripe request — all in one database transaction. If that
+   fails, nothing is written.
+7. **Stripe is asked for a payment link**, using a key derived from our attempt id, so a retry can
+   never become a second charge (`services/stripeProviderClient.js`).
+8. **The link is attached to the attempt** — but only if the attempt is still waiting and the link
+   is still open and unexpired. The buyer gets the link; everyone else who retries gets the same
+   answer instead of a new charge.
+
+## Words used in this code
+
+| Term | In code | In the database | What it means | Example |
+|---|---|---|---|---|
+| Product | `productKey` | `productKey` | A style of merchandise, regardless of size or colour. | The IUGA hoodie. |
+| Variant | `skuKey` | `skuKey` | One buyable version of a product — **this is what the shop page sends**. | The hoodie, purple, size M. |
+| Stock pile | `fulfillmentSku` | `fulfillmentSku` | The physical pile of stock we actually count. Several variants can share one pile. | `HOODIE-PURPLE-M` |
+| Sale window | `activeSalesWindow` | `ShopDrop` row (`dropKey`) | A period during which a set of products can be ordered, with its own price list. | Fall 2026: opens Oct 1, closes Nov 1. |
+| Price list revision | — | `catalogVersion` | Which approved price list the sale window used. Stored on orders so an old order can still be read after prices change. | `catalog-2026-09` |
+| Cart | `cart` | — | The variants and quantities the buyer wants, sorted and de-duplicated. | 1 hoodie, 2 totes. |
+| Price snapshot | `snapshotQuote` | `quoteSnapshot` | The prices, quantities, and total the buyer agreed to, locked at the moment they pressed Pay. | Hoodie ×1 at $65.00 → $65.00. |
+| Checkout attempt | `attempt` | `CheckoutAttempt` | One press of Pay, identified by the buyer's retry key. A retry resumes this attempt instead of starting a second one. | Pressing Pay twice after a timeout. |
+| Retry key | `attemptKey` | `attemptKey` | The browser's `Idempotency-Key` header, lower-cased. Same key + same cart = the same purchase. | `550e8400-e29b-…` |
+| Stripe key | `providerIdempotencyKey` | `providerIdempotencyKey` | The key we hand Stripe, derived from our attempt id — never from the browser. | `iuga:checkout:<attempt id>` |
+| Order | `order` | `Order` | What the buyer is buying, at what price, and how far it has got. | `ORD-9f2c…` |
+| Order reference | `orderReference` | `orderReference` | The id the buyer sees, instead of our internal database id. | `ORD-9f2c…` |
+| Hold / reservation | `holdInventory` | `InventoryReservation` | Stock taken off the shelf at checkout, before payment, and given back if the attempt dies. | 1 hoodie held. |
+| Stock counters | `available` / `reserved` / `consumed` | `InventoryCounter` | Per pile: on the shelf, held for somebody, permanently sold. | 8 available, 2 reserved, 10 sold. |
+| Fence | — | — | A conditional stock update that fails if the numbers changed since we read them, so two workers cannot both take the last item. | `reserved: { $gte: 1 }` |
+| Needs a human check | `needsManualCheckResult` | `reconciliation_required` | We cannot tell whether Stripe created a payment link, so a person must look before we retry. | A timeout mid-dispatch. |
+| Ready | `readyResult` | `status: "ready"` | The attempt has a payment link that is still open and unexpired. | The buyer's link. |
+| Readiness | `evaluateCheckoutReadiness` | — | Whether checkout may run at all, evaluated fresh on every request. | `checkoutEnabled: false`. |
+
+## Rules the code enforces
+
+- **Fail closed.** Checkout is off unless configuration, infrastructure, and approvals all pass —
+  and the answer is re-checked on every request, not just at boot.
+- **One attempt per buyer and retry key.** Two buyers using the same retry key can never share an
+  attempt, an order, or a payment link.
+- **The server owns the money.** Identity comes from the session; prices, quantities, totals, and
+  return URLs come from our catalog and configuration. The browser sends a cart and a retry key.
+- **Written down before money moves.** The order, its stock holds, and the Stripe request are
+  committed first; the payment link is attached afterwards, and only while the attempt is waiting.
+- **Stock is held, then sold, and only given back with proof.** `releaseInventory` refuses unless
+  we can verify the payment link can no longer be paid — otherwise a buyer could pay for stock we
+  already put back on the shelf.
+- **Unclear outcomes stop.** A timeout or an unreadable answer becomes `reconciliation_required`,
+  never an automatic retry with a new key.
+
+## Where the code lives
+
+| File | What it owns |
+|---|---|
+| `backend/routes/api/v1/controllers/shop.js` | The HTTP endpoint, its request rules, and its response contract. |
+| `backend/services/checkoutCoordinator.js` | One checkout attempt from start to finish: retries, pricing, recording, Stripe, attaching the link. |
+| `backend/services/stripeProviderClient.js` | Every call to Stripe, and the only place our Stripe key is used. |
+| `backend/shop/domain.js` | Cart rules, sale-window rules, the price snapshot, and how an order moves through payment, fulfilment, refund, and dispute. No database, no network. |
+| `backend/shop/reservations.js` | Stock: holding it, selling it, putting it back. |
+| `backend/checkoutReadiness.js` | Whether checkout may run at all. |
+| `backend/schemas/schemas.js` (submodule `iuga-web-schemas`) | The database shape: catalog, sale window, stock counters, reservations, attempts, orders, refunds, disputes. |
+
+Models registered for the shop: `CatalogEntry`, `ShopDrop`, `InventoryCounter`,
+`InventoryReservation`, `CheckoutAttempt`, `Order`, `RefundOperation`, `Dispute`,
+`StripeInboxEvent`, `OrderActivity`.
+
+## Known gaps
+
+- **Payment confirmation is missing**, so paying does not yet mark an order paid, sell the held
+  stock, or trigger fulfilment.
+- **Nothing expires a hold yet.** A hold is written with a 15-minute lifetime while the payment
+  link lives for an hour; until the expiry work exists, holds are only released by hand.
+- **Two fulfilment/refund details do not line up** between the order state rules and the stored
+  order shape (`fulfillmentMethod` vs `fulfillmentMode`, and a few fields the rules return that the
+  order document does not store). Both are queued as their own fixes.
+- **The shop page has no cart or buy button**, so the endpoint can only be exercised by tests and
+  by hand until that work lands.
+
+## Related
+
+- [Backend](BACKEND.md) — routes, middleware order, models, and the submodule boundary.
+- [Development](DEVELOPMENT.md) — the Stripe environment variables the readiness check reads.
+- [Deployment](DEPLOYMENT.md) — pipeline and credentials.


### PR DESCRIPTION
## Rationale

The checkout stack is readable to the people who built it and opaque to everyone else, because its vocabulary existed in exactly one place: an unpublished plan file. A reader of `checkoutCoordinator.js` meets `skuKey`, `dropKey`, `quoteSnapshot`, `attemptKey`, and `providerIdempotencyKey` with no way to learn that "the hoodie in purple, size M" is a different thing from "the pile of hoodies we count in the stockroom", or that the browser's retry key and the key we give Stripe are two different keys.

This layer documents the shop where a developer actually looks: the repository's own docs set, following the conventions already established by `docs/BACKEND.md` and `docs/COMMENTING.md`. It also repairs documentation that had drifted — the backend docs had no shop routes or shop models, and the frontend/architecture route tables omitted `/shop` entirely even though the page is live.

## Observable Behavior

None — documentation only. What a reader gets:

- **`docs/SHOP.md`**: what exists today (including an honest "switched off until readiness passes"), the checkout flow step by step with the file that owns each step, a **vocabulary table** mapping each term to its code name, its database field, its plain meaning, and an example (variant vs stock pile, sale window, price snapshot, attempt vs order, retry key, hold, fence, needs-a-human-check), the rules the code enforces, where the code lives, the registered models, and a **known gaps** section that names what is not built (payment confirmation, hold expiry, the rule/schema mismatches being fixed in the next PR, and the missing shop UI).
- **`docs/README.md`**: the shop document appears in the documentation index.
- **`docs/BACKEND.md`**: a shop section listing the endpoint and its response codes, plus the ten shop models in the models table.
- **`docs/FRONTEND.md`** and **`docs/ARCHITECTURE.md`**: `/shop` is now in the route tables (and the architecture route list matches `backend/spaRoutes.js`, with an honest note that `/contact` is served but has no React route yet).

## Verification

- Links checked: `docs/README.md`, `docs/BACKEND.md`, and `docs/FRONTEND.md` all reference `SHOP.md`, which exists.
- Every factual claim was read out of the code it describes: the endpoint's response codes from the controller, the hold lifetime and attempt window from the coordinator, the model list from `backend/models.js`, and the route list from `backend/spaRoutes.js`.

## Stack Context

- Position: 10 of 11
- Base PR: #168
- Depends on: #168
