### PR TITLE
fix(shop): match the shop rules to the stored data

### DIFF
--- a/backend/services/checkoutCoordinator.js
+++ b/backend/services/checkoutCoordinator.js
@@ -396,7 +396,18 @@ export async function createCheckout({
     // fails, none is kept — otherwise stock would be held for an order that does not exist, or an
     // order would exist with no stock behind it.
     await transaction(async (session) => {
-      await holdInventory({ models, orderId, items: cart, catalog: catalogRows, now: checkoutNow, session });
+      // Why: the hold lasts exactly as long as the payment link. A shorter hold could give the
+      // stock away while the buyer can still pay for it; a longer one would sit on stock for an
+      // attempt that is already dead.
+      await holdInventory({
+        models,
+        orderId,
+        items: cart,
+        catalog: catalogRows,
+        now: checkoutNow,
+        ttlMs: ATTEMPT_WINDOW_MS,
+        session,
+      });
       await models.Order.create(orderDocument, { session });
       await models.CheckoutAttempt.create(attemptDocument, { session });
     });

--- a/backend/shop/domain.js
+++ b/backend/shop/domain.js
@@ -128,7 +128,10 @@ export function snapshotQuote({ cart, catalog, drop, now = new Date() }) {
 
   const quotedAt = parseDate(now);
   const dropRecord = asRecord(drop);
-  const currency = typeof dropRecord.currency === "string" ? dropRecord.currency.toLowerCase() : "usd";
+  // Why: the shop sells in US dollars. A sale-window row has no currency field of its own, and a
+  // stray value in one must never change what a buyer is charged — the readiness check refuses to
+  // switch checkout on for any currency other than USD.
+  const currency = "usd";
 
   // Why: money is counted in whole cents. Dollars as decimals would quietly lose a cent per line
   //      and the buyer would be charged a total that does not match the prices we displayed.

--- a/backend/shop/domain.js
+++ b/backend/shop/domain.js
@@ -251,8 +251,14 @@ export function applyFulfillmentAction(order, action = {}) {
   const transitions = fulfillmentMethod === "shipping" ? VALID_SHIPPING_TRANSITIONS : VALID_PICKUP_TRANSITIONS;
 
   let nextFulfillmentState = state;
-  let holdReason = current.holdReason ?? null;
-  let stateBeforeHold = current.previousFulfillmentState ?? state;
+  // The order document keeps the hold as one object: why it was placed, when, and where the order
+  // returns to when the hold is lifted.
+  let fulfillmentHold = {
+    reason: null,
+    placedAt: null,
+    returnToState: null,
+    ...asRecord(current.fulfillmentHold),
+  };
 
   switch (action.action) {
     case "prepare":
@@ -275,15 +281,18 @@ export function applyFulfillmentAction(order, action = {}) {
       break;
     case "hold":
       nextFulfillmentState = "on_hold";
-      stateBeforeHold = state;
-      holdReason = action.reason || "unspecified";
+      fulfillmentHold = {
+        reason: action.reason || "unspecified",
+        placedAt: new Date(),
+        returnToState: state,
+      };
       break;
     case "release_hold":
       if (state !== "on_hold") {
         throw new Error("Cannot release hold on an order not on hold");
       }
-      nextFulfillmentState = stateBeforeHold || "pending";
-      holdReason = null;
+      nextFulfillmentState = fulfillmentHold.returnToState || "pending";
+      fulfillmentHold = { reason: null, placedAt: null, returnToState: null };
       break;
     default:
       throw new Error(`Unknown fulfillment action: ${action.action}`);
@@ -299,9 +308,8 @@ export function applyFulfillmentAction(order, action = {}) {
   return {
     ...current,
     fulfillmentState: nextFulfillmentState,
-    holdReason,
-    previousFulfillmentState: stateBeforeHold,
-    trackingNumber: action.trackingNumber || current.trackingNumber,
+    fulfillmentHold,
+    trackingNumber: action.trackingNumber ?? current.trackingNumber ?? null,
   };
 }
 

--- a/backend/shop/domain.js
+++ b/backend/shop/domain.js
@@ -202,11 +202,17 @@ export function applyPaymentEvent(order, event = {}) {
   }
 
   if (event.type === "payment_confirmed" || event.status === "paid") {
+    const settlement = asRecord(current.settlementSnapshot);
     return {
       ...current,
       paymentState: "paid",
       paidAt: event.paidAt ? parseDate(event.paidAt) : new Date(),
-      providerPaymentId: event.providerPaymentId || current.providerPaymentId,
+      // Why: the order document keeps provider facts in its settlement snapshot. A top-level
+      // providerPaymentId would be silently dropped the moment the order is saved.
+      settlementSnapshot: {
+        ...settlement,
+        providerPaymentId: event.providerPaymentId ?? settlement.providerPaymentId ?? null,
+      },
     };
   }
 

--- a/backend/shop/domain.js
+++ b/backend/shop/domain.js
@@ -244,9 +244,11 @@ const VALID_SHIPPING_TRANSITIONS = Object.freeze({
  */
 export function applyFulfillmentAction(order, action = {}) {
   const current = asRecord(order);
-  const mode = current.fulfillmentMode || "pickup";
+  // The order document stores this as fulfillmentMethod; anything that is not "shipping" means
+  // the buyer collects in person, which is the document's own default.
+  const fulfillmentMethod = current.fulfillmentMethod || "pickup";
   const state = current.fulfillmentState || "pending";
-  const transitions = mode === "shipping" ? VALID_SHIPPING_TRANSITIONS : VALID_PICKUP_TRANSITIONS;
+  const transitions = fulfillmentMethod === "shipping" ? VALID_SHIPPING_TRANSITIONS : VALID_PICKUP_TRANSITIONS;
 
   let nextFulfillmentState = state;
   let holdReason = current.holdReason ?? null;

--- a/backend/test/checkout-coordinator.test.js
+++ b/backend/test/checkout-coordinator.test.js
@@ -221,6 +221,18 @@ function pendingAttemptFixture({ id = "attempt-seeded", reference = "ORD-SEEDED"
 }
 
 describe("createCheckout: one attempt, one payment link", () => {
+  it("holds stock for as long as the payment link lives", async () => {
+    const harness = makeHarness();
+    const result = await harness.checkout();
+    const [attempt] = harness.models._state.attempts;
+    const [reservation] = harness.models._state.reservations;
+
+    assert.equal(result.status, "ready");
+    assert.equal(reservation.state, "reserved");
+    assert.equal(reservation.expiresAt.getTime(), attempt.expiresAt.getTime());
+    assert.equal(reservation.expiresAt.getTime(), NOW.getTime() + 60 * 60 * 1000);
+  });
+
   it("rejects a malformed retry key or cart before reading or writing anything", async () => {
     const cases = [
       { attemptKey: "not-a-uuid" },

--- a/backend/test/shop-domain.test.js
+++ b/backend/test/shop-domain.test.js
@@ -152,6 +152,18 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       },
     ]);
 
+    it("prices in US dollars even when a sale-window row carries a stray currency", () => {
+      const quote = snapshotQuote({
+        cart: [{ skuKey: "info-hoodie-purple-l", quantity: 1 }],
+        catalog,
+        drop: { ...activeDrop, currency: "eur" },
+        now: new Date("2026-10-02T10:00:00.000Z"),
+      });
+
+      assert.equal(quote.currency, "usd");
+      assert.equal(quote.totalMinor, 4500);
+    });
+
     it("freezes an immutable quote with exact safe integer cents totals", () => {
       const cart = [
         { skuKey: "info-hoodie-purple-l", quantity: 2 },

--- a/backend/test/shop-domain.test.js
+++ b/backend/test/shop-domain.test.js
@@ -273,7 +273,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
     it("handles pickup fulfillment lifecycle from pending to picked_up", () => {
       let order = {
         orderId: "ord_101",
-        fulfillmentMode: "pickup",
+        fulfillmentMethod: "pickup",
         fulfillmentState: "pending",
       };
 
@@ -287,10 +287,10 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       assert.equal(order.fulfillmentState, "picked_up");
     });
 
-    it("handles shipping fulfillment lifecycle from pending to delivered", () => {
+    it("follows the shipping steps for an order stored as shipping", () => {
       let order = {
         orderId: "ord_102",
-        fulfillmentMode: "shipping",
+        fulfillmentMethod: "shipping",
         fulfillmentState: "pending",
       };
 
@@ -307,10 +307,23 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       assert.equal(order.fulfillmentState, "delivered");
     });
 
+    it("refuses a shipping step on an order the buyer collects", () => {
+      const order = {
+        orderId: "ord_105",
+        fulfillmentMethod: "pickup",
+        fulfillmentState: "preparing",
+      };
+
+      assert.throws(
+        () => applyFulfillmentAction(order, { action: "ship" }),
+        /illegal fulfillment transition/i,
+      );
+    });
+
     it("supports hold and unhold transitions without losing previous progress", () => {
       let order = {
         orderId: "ord_103",
-        fulfillmentMode: "pickup",
+        fulfillmentMethod: "pickup",
         fulfillmentState: "preparing",
         holdReason: null,
       };
@@ -330,7 +343,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
     it("rejects illegal transitions", () => {
       const order = {
         orderId: "ord_104",
-        fulfillmentMode: "pickup",
+        fulfillmentMethod: "pickup",
         fulfillmentState: "picked_up",
       };
 

--- a/backend/test/shop-domain.test.js
+++ b/backend/test/shop-domain.test.js
@@ -234,6 +234,24 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
 
       assert.equal(updated.paymentState, "paid");
       assert.deepEqual(updated.paidAt, paidAt);
+      // The order document keeps provider facts in its settlement snapshot.
+      assert.equal(updated.settlementSnapshot.providerPaymentId, "pi_12345");
+      assert.equal(updated.providerPaymentId, undefined);
+    });
+
+    it("keeps a previously recorded provider payment id", () => {
+      const order = {
+        orderId: "ord_101",
+        paymentState: "paid",
+        totalMinor: 4500,
+        paidAt: new Date("2026-10-02T12:00:00.000Z"),
+        settlementSnapshot: { providerPaymentId: "pi_original", receiptEmail: "buyer@uw.edu" },
+      };
+
+      const updated = applyPaymentEvent(order, { type: "payment_confirmed" });
+
+      assert.equal(updated.settlementSnapshot.providerPaymentId, "pi_original");
+      assert.equal(updated.settlementSnapshot.receiptEmail, "buyer@uw.edu");
     });
 
     it("is idempotent when receiving duplicate payment confirmation", () => {

--- a/backend/test/shop-domain.test.js
+++ b/backend/test/shop-domain.test.js
@@ -302,6 +302,7 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
         trackingNumber: "1Z999",
       });
       assert.equal(order.fulfillmentState, "shipped");
+      assert.equal(order.trackingNumber, "1Z999");
 
       order = applyFulfillmentAction(order, { action: "deliver" });
       assert.equal(order.fulfillmentState, "delivered");
@@ -320,12 +321,12 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
       );
     });
 
-    it("supports hold and unhold transitions without losing previous progress", () => {
+    it("puts an order on hold and returns it to where it was", () => {
       let order = {
         orderId: "ord_103",
         fulfillmentMethod: "pickup",
         fulfillmentState: "preparing",
-        holdReason: null,
+        fulfillmentHold: { reason: null, placedAt: null, returnToState: null },
       };
 
       order = applyFulfillmentAction(order, {
@@ -333,11 +334,14 @@ describe("Shop Domain - Pure Contracts and Reducers", () => {
         reason: "address_verification_needed",
       });
       assert.equal(order.fulfillmentState, "on_hold");
-      assert.equal(order.holdReason, "address_verification_needed");
+      assert.equal(order.fulfillmentHold.reason, "address_verification_needed");
+      assert.equal(order.fulfillmentHold.returnToState, "preparing");
+      assert.ok(order.fulfillmentHold.placedAt instanceof Date);
 
       order = applyFulfillmentAction(order, { action: "release_hold" });
       assert.equal(order.fulfillmentState, "preparing");
-      assert.equal(order.holdReason, null);
+      assert.equal(order.fulfillmentHold.reason, null);
+      assert.equal(order.fulfillmentHold.returnToState, null);
     });
 
     it("rejects illegal transitions", () => {

--- a/backend/test/shop-models.test.js
+++ b/backend/test/shop-models.test.js
@@ -15,6 +15,12 @@ import {
   orderActivitySchema,
 } from "../schemas/schemas.js";
 import { models } from "../models.js";
+import {
+  applyDisputeEvent,
+  applyFulfillmentAction,
+  applyPaymentEvent,
+  applyRefundEvent,
+} from "../shop/domain.js";
 
 describe("Shop Mongoose Schemas and Models", () => {
   describe("Schema exports and model registry", () => {
@@ -149,6 +155,25 @@ describe("Shop Mongoose Schemas and Models", () => {
   });
 
   describe("Order schema and owner cursor index", () => {
+    it("keeps the order rules to fields the order document defines", () => {
+      // A rule that returns a field the document does not store loses that value silently the
+      // moment the order is saved — exactly how the fulfilment and payment rules once drifted.
+      const defined = new Set(Object.keys(orderSchema.paths).map((path) => path.split(".")[0]));
+      const samples = [
+        applyPaymentEvent({ paymentState: "pending", totalMinor: 4500 }, { type: "payment_confirmed", providerPaymentId: "pi_1" }),
+        applyFulfillmentAction({ fulfillmentMethod: "pickup", fulfillmentState: "preparing" }, { action: "hold", reason: "address_verification_needed" }),
+        applyFulfillmentAction({ fulfillmentMethod: "shipping", fulfillmentState: "preparing" }, { action: "ship", trackingNumber: "1Z999" }),
+        applyRefundEvent({ totalMinor: 4500, refundedMinor: 0, pendingRefundMinor: 0 }, { action: "reserve", amountMinor: 500 }),
+        applyDisputeEvent({ dispute: { state: "none" } }, { action: "open", reason: "fraudulent" }),
+      ];
+
+      for (const sample of samples) {
+        for (const key of Object.keys(sample)) {
+          assert.ok(defined.has(key), `order rule returned a field the order document cannot store: ${key}`);
+        }
+      }
+    });
+
     it("stores the fulfilment details the order rules produce", () => {
       for (const path of [
         "fulfillmentHold.reason",

--- a/backend/test/shop-models.test.js
+++ b/backend/test/shop-models.test.js
@@ -149,6 +149,17 @@ describe("Shop Mongoose Schemas and Models", () => {
   });
 
   describe("Order schema and owner cursor index", () => {
+    it("stores the fulfilment details the order rules produce", () => {
+      for (const path of [
+        "fulfillmentHold.reason",
+        "fulfillmentHold.placedAt",
+        "fulfillmentHold.returnToState",
+        "trackingNumber",
+      ]) {
+        assert.ok(orderSchema.paths[path], `Missing order path ${path}`);
+      }
+    });
+
     it("enforces unique orderReference", () => {
       assert.equal(orderSchema.paths.orderReference.options.unique, true);
     });


### PR DESCRIPTION
## Rationale

While documenting the shop, four rules turned out to disagree with the data they act on. None of them can be seen by a passing test suite today, because nothing calls these rules yet — which is exactly why they are worth fixing now: the payment webhook and fulfilment work will call them, and by then the mismatches would look like new bugs in new code.

Each was verified against the schema before being changed:

| Rule | Was | Is | Why it mattered |
|---|---|---|---|
| Stock hold lifetime | written with a hard-coded 15 minutes | exactly as long as the payment link (1 hour) | a hold shorter than the payment window lets a buyer pay for stock we already gave back |
| Fulfilment method | read `current.fulfillmentMode` | reads `fulfillmentMethod` | the order document stores `fulfillmentMethod`, so a **shipping** order was judged against the pickup steps and could never ship |
| Fulfilment hold | returned `holdReason` and `previousFulfillmentState` | returns `fulfillmentHold: { reason, placedAt, returnToState }` | the document has `fulfillmentHold`, so the reason and the state to return to were dropped on save — "take an order off hold" would have lost where it was |
| Provider payment id | returned `providerPaymentId` at the top level | recorded inside `settlementSnapshot` | the document keeps provider facts in its settlement snapshot; the top-level value was dropped on save |
| Currency | read `drop.currency` | states USD, once | the sale-window row has no currency field, so the read was dead and hid where the currency really comes from |

`fulfillmentHold.returnToState` and `trackingNumber` are new fields in the shared schema submodule (`iuga-web-schemas`, its own PR), so the order document can now store what the fulfilment rules produce.

## Observable Behavior

- Stock is held for exactly as long as the payment link can be paid — asserted by comparing the reservation's expiry with the attempt's.
- An order stored as `shipping` follows the shipping steps (`prepare → ship → deliver`) and a pickup order refuses a shipping step; a shipping order stored before this fix would have thrown on `ship`.
- Placing a hold records why, when, and the state to return to, and lifting it puts the order back there (`on_hold` from `preparing` returns to `preparing`).
- A paid order records its provider payment id where the document can keep it, preserving any other settlement facts already stored.
- Prices are always USD in whole cents; a stray currency value on a sale-window row cannot change what a buyer is charged.
- A new contract test fails the build if any payment, fulfilment, refund, or dispute rule returns a field the order document cannot store — the bug class these five fixes belong to.

## Verification

All five fixes were written test-first: each new test was run against the old behavior and failed for the expected reason before the fix (`Illegal fulfillment transition from preparing to shipped`; `Missing order path fulfillmentHold.returnToState`; `Cannot read properties of undefined (reading 'providerPaymentId')`; `expected 'usd', actual 'eur'`; and 15-minute vs 60-minute expiry), then passed after it.

- `npm test` — 177 tests passed across backend and frontend; frontend production build passed.
- Guard proof: re-introducing the top-level payment id makes the new contract test fail with `order rule returned a field the order document cannot store: providerPaymentId`.
- Schema submodule: `feat(schemas): store fulfilment hold state and tracking on orders`, referenced by this PR's gitlink.

## Stack Context

- Position: 11 of 11
- Base PR: #169
- Depends on: #169
